### PR TITLE
add ability to pass YOSYS_CONFIG while build

### DIFF
--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -42,7 +42,7 @@
 YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
 
 # Find yosys-config, throw an error if not found
-YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config
+YOSYS_CONFIG ?= $(YOSYS_PATH)/bin/yosys-config
 ifeq (,$(wildcard $(YOSYS_CONFIG)))
 $(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
 endif


### PR DESCRIPTION
This will add the ability to specify the path for the yosys-config binary, instead of always having it necessary to exist in a `bin/` directory, while not removing any functionality from before.

This would be similar to the addition of the ability to specify the YOSYS_PATH while building plugins introduced in this commit : https://github.com/SymbiFlow/yosys-symbiflow-plugins/commit/37a31ef9d9ede643e5a2af967f7eaf1fb4e53988

This would be useful, for context, while integrating the yosys-symbiflow-plugins into the [OpenFPGA](https://github.com/lnis-uofu/OpenFPGA/pull/371) repo.

The OpenFPGA build system invokes a plain `make` rather than a `make install` to keep yosys in tree - this means there is no `bin/` directory where yosys-config (or yosys) is built.

With this PR, we can specify to the Makefile where to find the yosys-config binary and proceed to build the plugins in cases like the above, using `make install YOSYS_PATH=/path/to/yosys YOSYS_CONFIG=/path/to/yosys-config`