### PR TITLE
ql-qlf: qlf_k6n0f: TDP BRAM split mode

### DIFF
--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -21,7 +21,8 @@ SOURCES = synth_quicklogic.cc \
           quicklogic_eqn.cc \
           ql-edif.cc \
           ql-dsp-simd.cc \
-          ql-dsp-macc.cc
+          ql-dsp-macc.cc \
+          ql-bram-split.cc
 
 DEPS = pmgen/ql-dsp-pm.h \
        pmgen/ql-dsp-macc.h
@@ -46,6 +47,7 @@ VERILOG_MODULES = $(COMMON)/cells_sim.v         \
                   $(QLF_K6N10_DIR)/lut_map.v   \
                   $(QLF_K6N10F_DIR)/arith_map.v \
                   $(QLF_K6N10F_DIR)/brams_map.v \
+                  $(QLF_K6N10F_DIR)/brams_final_map.v \
                   $(QLF_K6N10F_DIR)/brams.txt   \
                   $(QLF_K6N10F_DIR)/cells_sim.v \
                   $(QLF_K6N10F_DIR)/sram1024x18.v \

--- a/ql-qlf-plugin/ql-bram-split.cc
+++ b/ql-qlf-plugin/ql-bram-split.cc
@@ -1,0 +1,318 @@
+// Copyright (C) 2020-2022  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+#include "kernel/log.h"
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+// ============================================================================
+
+struct QlBramSplitPass : public Pass {
+
+    QlBramSplitPass() : Pass("ql_bram_split", "Infers QuickLogic k6n10f BRAM pairs that can operate independently") {}
+
+    void help() override
+    {
+        log("\n");
+        log("    ql_bram_split [selection]\n");
+        log("\n");
+        log("    This pass identifies k6n10f 18K BRAM cells\n");
+        log("    and packs pairs of them together into final TDP36K cell that can\n");
+        log("    be split into 2x18K BRAMs.\n");
+    }
+
+    // ..........................................
+
+    /// Describes BRAM config unique to a whole BRAM cell
+    struct BramConfig {
+
+        // Port connections
+        dict<RTLIL::IdString, RTLIL::SigSpec> connections;
+
+        // TODO: Possibly include parameters here. For now we have just
+        // connections.
+
+        BramConfig() = default;
+
+        BramConfig(const BramConfig &ref) = default;
+        BramConfig(BramConfig &&ref) = default;
+
+        unsigned int hash() const { return connections.hash(); }
+
+        bool operator==(const BramConfig &ref) const { return connections == ref.connections; }
+    };
+
+    // ..........................................
+
+    // BRAM control and config ports to consider and how to map them to ports
+    // of the target BRAM cell
+    const std::vector<std::pair<std::string, std::string>> m_BramSharedPorts = {};
+
+    // BRAM data ports for subcell #1 and how to map them to ports of the target BRAM cell
+    const std::vector<std::pair<std::string, std::string>> m_BramDataPorts_0 = {
+      std::make_pair("A1ADDR", "A1ADDR"), std::make_pair("A1DATA", "A1DATA"), std::make_pair("A1EN", "A1EN"),     std::make_pair("B1ADDR", "B1ADDR"),
+      std::make_pair("B1DATA", "B1DATA"), std::make_pair("B1EN", "B1EN"),     std::make_pair("C1ADDR", "C1ADDR"), std::make_pair("C1DATA", "C1DATA"),
+      std::make_pair("C1EN", "C1EN"),     std::make_pair("CLK1", "CLK1"),     std::make_pair("CLK2", "CLK2"),     std::make_pair("D1ADDR", "D1ADDR"),
+      std::make_pair("D1DATA", "D1DATA"), std::make_pair("D1EN", "D1EN")};
+    // BRAM data ports for subcell #2 and how to map them to ports of the target BRAM cell
+    const std::vector<std::pair<std::string, std::string>> m_BramDataPorts_1 = {
+      std::make_pair("A1ADDR", "E1ADDR"), std::make_pair("A1DATA", "E1DATA"), std::make_pair("A1EN", "E1EN"),     std::make_pair("B1ADDR", "F1ADDR"),
+      std::make_pair("B1DATA", "F1DATA"), std::make_pair("B1EN", "F1EN"),     std::make_pair("C1ADDR", "G1ADDR"), std::make_pair("C1DATA", "G1DATA"),
+      std::make_pair("C1EN", "G1EN"),     std::make_pair("CLK1", "CLK3"),     std::make_pair("CLK2", "CLK4"),     std::make_pair("D1ADDR", "H1ADDR"),
+      std::make_pair("D1DATA", "H1DATA"), std::make_pair("D1EN", "H1EN")};
+    // BRAM parameters
+    const std::vector<std::string> m_BramParams = {"CFG_ABITS", "CFG_DBITS"};
+    // Source BRAM cell type (1x18K)
+    const std::string m_Bram1x18Type = "$__QLF_FACTOR_BRAM18_TDP";
+    // Target BRAM cell type for the split mode
+    const std::string m_Bram2x18Type = "BRAM2x18_TDP";
+
+    /// Temporary SigBit to SigBit helper map.
+    SigMap m_SigMap;
+
+    // ..........................................
+
+    void execute(std::vector<std::string> a_Args, RTLIL::Design *a_Design) override
+    {
+        log_header(a_Design, "Executing QL_BRAM_Split pass.\n");
+
+        // Parse args
+        extra_args(a_Args, 1, a_Design);
+
+        // Process modules
+        for (auto module : a_Design->selected_modules()) {
+
+            // Setup the SigMap
+            m_SigMap.clear();
+            m_SigMap.set(module);
+
+            // Assemble BRAM cell groups
+            dict<BramConfig, std::vector<RTLIL::Cell *>> groups;
+            for (auto cell : module->selected_cells()) {
+
+                // Check if this is a BRAM cell
+                if (cell->type != RTLIL::escape_id(m_Bram1x18Type)) {
+                    continue;
+                }
+
+                // Skip if it has the (* keep *) attribute set
+                if (cell->has_keep_attr()) {
+                    continue;
+                }
+
+                // Add to a group
+                const auto key = getBramConfig(cell);
+                groups[key].push_back(cell);
+            }
+
+            for (const auto &it : groups) {
+                const auto &group = it.second;
+                const auto &config = it.first;
+            }
+
+            std::vector<const RTLIL::Cell *> cellsToRemove;
+
+            // Map cell pairs to the target BRAM 2x18 cell
+            for (const auto &it : groups) {
+                const auto &group = it.second;
+                const auto &config = it.first;
+
+                // Ensure an even number
+                size_t count = group.size();
+                if (count & 1)
+                    count--;
+
+                // Map SIMD pairs
+                for (size_t i = 0; i < count; i += 2) {
+                    const RTLIL::Cell *bram_0 = group[i];
+                    const RTLIL::Cell *bram_1 = group[i + 1];
+
+                    std::string name = stringf("bram_%s_%s", RTLIL::unescape_id(bram_0->name).c_str(), RTLIL::unescape_id(bram_1->name).c_str());
+
+                    log(" BRAM: %s (%s) + %s (%s) => %s (%s)\n", RTLIL::unescape_id(bram_0->name).c_str(), RTLIL::unescape_id(bram_0->type).c_str(),
+                        RTLIL::unescape_id(bram_1->name).c_str(), RTLIL::unescape_id(bram_1->type).c_str(), RTLIL::unescape_id(name).c_str(),
+                        m_Bram2x18Type.c_str());
+
+                    // Create the new cell
+                    RTLIL::Cell *bram_2x18 = module->addCell(RTLIL::escape_id(name), RTLIL::escape_id(m_Bram2x18Type));
+
+                    // Check if the target cell is known (important to know
+                    // its port widths)
+                    if (!bram_2x18->known()) {
+                        log_error(" The target cell type '%s' is not known!", m_Bram2x18Type.c_str());
+                    }
+
+                    // Connect shared ports
+                    for (const auto &it : m_BramSharedPorts) {
+                        auto src = RTLIL::escape_id(it.first);
+                        auto dst = RTLIL::escape_id(it.second);
+
+                        bram_2x18->setPort(dst, config.connections.at(src));
+                    }
+
+                    // Connect data ports
+                    // Connect first bram
+                    for (const auto &it : m_BramDataPorts_0) {
+                        auto src = RTLIL::escape_id(it.first);
+                        auto dst = RTLIL::escape_id(it.second);
+
+                        size_t width;
+                        bool isOutput;
+
+                        std::tie(width, isOutput) = getPortInfo(bram_2x18, dst);
+
+                        auto getConnection = [&](const RTLIL::Cell *cell) {
+                            RTLIL::SigSpec sigspec;
+                            if (cell->hasPort(src)) {
+                                const auto &sig = cell->getPort(src);
+                                sigspec.append(sig);
+                            }
+                            if (sigspec.bits().size() < width / 2) {
+                                if (isOutput) {
+                                    for (size_t i = 0; i < width / 2 - sigspec.bits().size(); ++i) {
+                                        sigspec.append(RTLIL::SigSpec());
+                                    }
+                                } else {
+                                    sigspec.append(RTLIL::SigSpec(RTLIL::Sx, width / 2 - sigspec.bits().size()));
+                                }
+                            }
+                            return sigspec;
+                        };
+
+                        RTLIL::SigSpec sigspec;
+                        sigspec.append(getConnection(bram_0));
+                        bram_2x18->setPort(dst, sigspec);
+                    }
+
+                    // Connect second bram
+                    for (const auto &it : m_BramDataPorts_1) {
+                        auto src = RTLIL::escape_id(it.first);
+                        auto dst = RTLIL::escape_id(it.second);
+
+                        size_t width;
+                        bool isOutput;
+
+                        std::tie(width, isOutput) = getPortInfo(bram_2x18, dst);
+
+                        auto getConnection = [&](const RTLIL::Cell *cell) {
+                            RTLIL::SigSpec sigspec;
+                            if (cell->hasPort(src)) {
+                                const auto &sig = cell->getPort(src);
+                                sigspec.append(sig);
+                            }
+                            if (sigspec.bits().size() < width / 2) {
+                                if (isOutput) {
+                                    for (size_t i = 0; i < width / 2 - sigspec.bits().size(); ++i) {
+                                        sigspec.append(RTLIL::SigSpec());
+                                    }
+                                } else {
+                                    sigspec.append(RTLIL::SigSpec(RTLIL::Sx, width / 2 - sigspec.bits().size()));
+                                }
+                            }
+                            return sigspec;
+                        };
+
+                        RTLIL::SigSpec sigspec;
+                        sigspec.append(getConnection(bram_1));
+                        bram_2x18->setPort(dst, sigspec);
+                    }
+
+                    // Set bram parameters
+                    for (const auto &it : m_BramParams) {
+                        auto val = bram_0->getParam(RTLIL::escape_id(it));
+                        bram_2x18->setParam(RTLIL::escape_id(it), val);
+                    }
+
+                    // Setting manual parameters
+                    bram_2x18->setParam(RTLIL::escape_id("CFG_ENABLE_B"), bram_0->getParam(RTLIL::escape_id("CFG_ENABLE_B")));
+                    bram_2x18->setParam(RTLIL::escape_id("CFG_ENABLE_F"), bram_1->getParam(RTLIL::escape_id("CFG_ENABLE_B")));
+                    bram_2x18->setParam(RTLIL::escape_id("CFG_ENABLE_D"), bram_0->getParam(RTLIL::escape_id("CFG_ENABLE_D")));
+                    bram_2x18->setParam(RTLIL::escape_id("CFG_ENABLE_H"), bram_1->getParam(RTLIL::escape_id("CFG_ENABLE_D")));
+                    bram_2x18->setParam(RTLIL::escape_id("INIT0"), bram_0->getParam(RTLIL::escape_id("INIT")));
+                    bram_2x18->setParam(RTLIL::escape_id("INIT1"), bram_1->getParam(RTLIL::escape_id("INIT")));
+
+                    // Mark BRAM parts for removal
+                    cellsToRemove.push_back(bram_0);
+                    cellsToRemove.push_back(bram_1);
+                }
+            }
+
+            // Remove old cells
+            for (const auto &cell : cellsToRemove) {
+                module->remove(const_cast<RTLIL::Cell *>(cell));
+            }
+        }
+
+        // Clear
+        m_SigMap.clear();
+    }
+
+    // ..........................................
+
+    /// Looks up port width and direction in the cell definition and returns it.
+    /// Returns (0, false) if it cannot be determined.
+    std::pair<size_t, bool> getPortInfo(RTLIL::Cell *a_Cell, RTLIL::IdString a_Port)
+    {
+        if (!a_Cell->known()) {
+            return std::make_pair(0, false);
+        }
+
+        // Get the module defining the cell (the previous condition ensures
+        // that the pointers are valid)
+        RTLIL::Module *mod = a_Cell->module->design->module(a_Cell->type);
+        if (mod == nullptr) {
+            return std::make_pair(0, false);
+        }
+
+        // Get the wire representing the port
+        RTLIL::Wire *wire = mod->wire(a_Port);
+        if (wire == nullptr) {
+            return std::make_pair(0, false);
+        }
+
+        return std::make_pair(wire->width, wire->port_output);
+    }
+
+    /// Given a BRAM cell populates and returns a BramConfig struct for it.
+    BramConfig getBramConfig(RTLIL::Cell *a_Cell)
+    {
+        BramConfig config;
+
+        for (const auto &it : m_BramSharedPorts) {
+            auto port = RTLIL::escape_id(it.first);
+
+            // Port unconnected
+            if (!a_Cell->hasPort(port)) {
+                config.connections[port] = RTLIL::SigSpec(RTLIL::Sx);
+                continue;
+            }
+
+            // Get the port connection and map it to unique SigBits
+            const auto &orgSigSpec = a_Cell->getPort(port);
+            const auto &orgSigBits = orgSigSpec.bits();
+
+            RTLIL::SigSpec newSigSpec;
+            for (size_t i = 0; i < orgSigBits.size(); ++i) {
+                auto newSigBit = m_SigMap(orgSigBits[i]);
+                newSigSpec.append(newSigBit);
+            }
+
+            // Store
+            config.connections[port] = newSigSpec;
+        }
+
+        return config;
+    }
+
+} QlBramSplitPass;
+
+PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/qlf_k6n10f/brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/brams.txt
@@ -48,25 +48,62 @@ bram $__QLF_FACTOR_BRAM36_SDP
   clkpol 2 3
 endbram
 
+bram $__QLF_FACTOR_BRAM18_TDP
+  init 1
+  abits 10     @a10d18
+  dbits 18     @a10d18
+  abits 10     @a10d16
+  dbits 16     @a10d16
+  abits 11     @a11d9
+  dbits  9     @a11d9
+  abits 11     @a11d8
+  dbits  8     @a11d8
+  abits 12     @a12d4
+  dbits  4     @a12d4
+  abits 13     @a13d2
+  dbits  2     @a13d2
+  abits 14     @a14d1
+  dbits  1     @a14d1
+  groups 4
+  ports  1 1 1 1
+  wrmode 0 1 0 1
+  enable 1 2 1 2  @a10d18 @a10d16
+  enable 1 1 1 1  @a11d9 @a11d8 @a12d4 @a13d2 @a14d1
+  transp 0 0 0 0
+  clocks 1 1 2 2
+  clkpol 1 1 2 2
+endbram
 
 match $__QLF_FACTOR_BRAM36_TDP
+  min bits 18433
   min wports 1
   max wports 2
   min rports 1
   max rports 2
   min efficiency 1
-  min bits 128
   shuffle_enable B
   make_transp
   or_next_if_better
 endmatch
 
 match $__QLF_FACTOR_BRAM36_SDP
+  min bits 18433
   max wports 1
   max rports 1
   min efficiency 1
+  shuffle_enable B
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_FACTOR_BRAM18_TDP
   min bits 128
+  max bits 18432
+  min wports 1
+  max wports 2
+  min rports 1
+  max rports 2
+  min efficiency 1
   shuffle_enable B
   make_transp
 endmatch
-

--- a/ql-qlf-plugin/qlf_k6n10f/brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/brams.txt
@@ -2,10 +2,16 @@ bram $__QLF_FACTOR_BRAM36_TDP
   init 1
   abits 10     @a10d36
   dbits 36     @a10d36
+  abits 10     @a10d32
+  dbits 32     @a10d32
   abits 11     @a11d18
   dbits 18     @a11d18
+  abits 11     @a11d16
+  dbits 16     @a11d16
   abits 12     @a12d9
   dbits  9     @a12d9
+  abits 12     @a12d8
+  dbits  8     @a12d8
   abits 13     @a13d4
   dbits  4     @a13d4
   abits 14     @a14d2
@@ -15,9 +21,9 @@ bram $__QLF_FACTOR_BRAM36_TDP
   groups 4
   ports  1 1 1 1
   wrmode 0 1 0 1
-  enable 1 4 1 4 @a10d36
-  enable 1 2 1 2 @a11d18
-  enable 1 1 1 1 @a12d9 @a13d4 @a14d2 @a15d1
+  enable 1 4 1 4 @a10d36 @a10d32
+  enable 1 2 1 2 @a11d18 @a11d16
+  enable 1 1 1 1 @a12d9 @a12d8 @a13d4 @a14d2 @a15d1
   transp 0 0 0 0
   clocks 1 1 2 2
   clkpol 1 1 1 1
@@ -27,10 +33,16 @@ bram $__QLF_FACTOR_BRAM36_SDP
   init 1
   abits 10     @a10d36
   dbits 36     @a10d36
+  abits 10     @a10d32
+  dbits 32     @a10d32
   abits 11     @a11d18
   dbits 18     @a11d18
+  abits 11     @a11d16
+  dbits 16     @a11d16
   abits 12     @a12d9
   dbits  9     @a12d9
+  abits 12     @a12d8
+  dbits  8     @a12d8
   abits 13     @a13d4
   dbits  4     @a13d4
   abits 14     @a14d2
@@ -40,9 +52,9 @@ bram $__QLF_FACTOR_BRAM36_SDP
   groups 2
   ports  1 1
   wrmode 0 1
-  enable 1 4   @a10d36
-  enable 1 2   @a11d18
-  enable 1 1   @a12d9 @a13d4 @a14d2 @a15d1
+  enable 1 4   @a10d36 @a10d32
+  enable 1 2   @a11d18 @a11d16
+  enable 1 1   @a12d9 @a12d8 @a13d4 @a14d2 @a15d1
   transp 0 0
   clocks 2 3
   clkpol 2 3

--- a/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
@@ -170,15 +170,41 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
 	assign FLUSH1 = 1'b0;
 	assign FLUSH2 = 1'b0;
 
-	wire [17:0] PORT_A1_RDATA = {A1_RDATA_CMPL, A1DATA};
-	wire [17:0] PORT_B1_RDATA = {C1_RDATA_CMPL, C1DATA};
-	wire [17:0] PORT_A2_RDATA = {E1_RDATA_CMPL, E1DATA};
-	wire [17:0] PORT_B2_RDATA = {G1_RDATA_CMPL, G1DATA};
+	wire [17:0] PORT_A1_RDATA;
+	wire [17:0] PORT_B1_RDATA;
+	wire [17:0] PORT_A2_RDATA;
+	wire [17:0] PORT_B2_RDATA;
 
-	wire [17:0] PORT_A1_WDATA = {B1_WDATA_CMPL, B1DATA};
-	wire [17:0] PORT_B1_WDATA = {D1_WDATA_CMPL, D1DATA};
-	wire [17:0] PORT_A2_WDATA = {F1_WDATA_CMPL, F1DATA};
-	wire [17:0] PORT_B2_WDATA = {H1_WDATA_CMPL, H1DATA};
+	wire [17:0] PORT_A1_WDATA;
+	wire [17:0] PORT_B1_WDATA;
+	wire [17:0] PORT_A2_WDATA;
+	wire [17:0] PORT_B2_WDATA;
+
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
+			assign C1DATA = {PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+			assign E1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
+			assign G1DATA = {PORT_B2_RDATA[16], PORT_B2_RDATA[7:0]};
+			assign PORT_A1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
+			assign PORT_B1_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
+			assign PORT_A2_WDATA = {F1_WDATA_CMPL[17], F1DATA[8], F1_WDATA_CMPL[16:9], F1DATA[7:0]};
+			assign PORT_B2_WDATA = {H1_WDATA_CMPL[17], H1DATA[8], H1_WDATA_CMPL[16:9], H1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
+			assign C1DATA = PORT_B1_RDATA[CFG_DBITS-1:0];
+			assign E1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
+			assign G1DATA = PORT_B2_RDATA[CFG_DBITS-1:0];
+			assign PORT_A1_WDATA = {B1_WDATA_CMPL, B1DATA};
+			assign PORT_B1_WDATA = {D1_WDATA_CMPL, D1DATA};
+			assign PORT_A2_WDATA = {F1_WDATA_CMPL, F1DATA};
+			assign PORT_B2_WDATA = {H1_WDATA_CMPL, H1DATA};
+
+		end
+	endcase
 
 	wire PORT_A1_CLK = CLK1;
 	wire PORT_A2_CLK = CLK3;

--- a/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
@@ -1,0 +1,240 @@
+// Copyright (C) 2020-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+`define MODE_36 3'b011	// 36 or 32-bit
+`define MODE_18 3'b010	// 18 or 16-bit
+`define MODE_9  3'b001	// 9 or 8-bit
+`define MODE_4  3'b100	// 4-bit
+`define MODE_2  3'b110	// 32-bit
+`define MODE_1  3'b101	// 32-bit
+
+module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, CLK3, CLK4, D1ADDR, D1DATA, D1EN, E1ADDR, E1DATA, E1EN, F1ADDR, F1DATA, F1EN, G1ADDR, G1DATA, G1EN, H1ADDR, H1DATA, H1EN);
+	parameter CFG_ABITS = 11;
+	parameter CFG_DBITS = 18;
+	parameter CFG_ENABLE_B = 4;
+	parameter CFG_ENABLE_D = 4;
+	parameter CFG_ENABLE_F = 4;
+	parameter CFG_ENABLE_H = 4;
+
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter [18431:0] INIT0 = 18432'bx;
+	parameter [18431:0] INIT1 = 18432'bx;
+
+	input CLK1;
+	input CLK2;
+	input CLK3;
+	input CLK4;
+
+	input [CFG_ABITS-1:0] A1ADDR;
+	output [CFG_DBITS-1:0] A1DATA;
+	input A1EN;
+
+	input [CFG_ABITS-1:0] B1ADDR;
+	input [CFG_DBITS-1:0] B1DATA;
+	input [CFG_ENABLE_B-1:0] B1EN;
+
+	input [CFG_ABITS-1:0] C1ADDR;
+	output [CFG_DBITS-1:0] C1DATA;
+	input C1EN;
+
+	input [CFG_ABITS-1:0] D1ADDR;
+	input [CFG_DBITS-1:0] D1DATA;
+	input [CFG_ENABLE_D-1:0] D1EN;
+
+	input [CFG_ABITS-1:0] E1ADDR;
+	output [CFG_DBITS-1:0] E1DATA;
+	input E1EN;
+
+	input [CFG_ABITS-1:0] F1ADDR;
+	input [CFG_DBITS-1:0] F1DATA;
+	input [CFG_ENABLE_F-1:0] F1EN;
+
+	input [CFG_ABITS-1:0] G1ADDR;
+	output [CFG_DBITS-1:0] G1DATA;
+	input G1EN;
+
+	input [CFG_ABITS-1:0] H1ADDR;
+	input [CFG_DBITS-1:0] H1DATA;
+	input [CFG_ENABLE_H-1:0] H1EN;
+
+	wire FLUSH1;
+	wire FLUSH2;
+
+	wire [13:CFG_ABITS] A1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] B1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] C1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] D1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] E1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] F1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] G1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] H1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+
+	wire [13:0] A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
+	wire [13:0] B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
+	wire [13:0] C1ADDR_TOTAL = {C1ADDR_CMPL, C1ADDR};
+	wire [13:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
+	wire [13:0] E1ADDR_TOTAL = {E1ADDR_CMPL, E1ADDR};
+	wire [13:0] F1ADDR_TOTAL = {F1ADDR_CMPL, F1ADDR};
+	wire [13:0] G1ADDR_TOTAL = {G1ADDR_CMPL, G1ADDR};
+	wire [13:0] H1ADDR_TOTAL = {H1ADDR_CMPL, H1ADDR};
+
+	wire [17:CFG_DBITS] A1_RDATA_CMPL;
+	wire [17:CFG_DBITS] C1_RDATA_CMPL;
+	wire [17:CFG_DBITS] E1_RDATA_CMPL;
+	wire [17:CFG_DBITS] G1_RDATA_CMPL;
+
+	wire [17:CFG_DBITS] B1_WDATA_CMPL;
+	wire [17:CFG_DBITS] D1_WDATA_CMPL;
+	wire [17:CFG_DBITS] F1_WDATA_CMPL;
+	wire [17:CFG_DBITS] H1_WDATA_CMPL;
+
+	wire [13:0] PORT_A1_ADDR;
+	wire [13:0] PORT_A2_ADDR;
+	wire [13:0] PORT_B1_ADDR;
+	wire [13:0] PORT_B2_ADDR;
+
+	case (CFG_DBITS)
+		1: begin
+			assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+			};
+		end
+
+		2: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 1) : (B1EN ? (B1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 1) : (F1EN ? (F1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 1) : (H1EN ? (H1ADDR_TOTAL << 1) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0
+			};
+		end
+
+		4: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 2) : (B1EN ? (B1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 2) : (D1EN ? (D1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 2) : (F1EN ? (F1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 2) : (H1EN ? (H1ADDR_TOTAL << 2) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0
+			};
+		end
+
+		8, 9: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 3) : (B1EN ? (B1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 3) : (F1EN ? (F1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 3) : (H1EN ? (H1ADDR_TOTAL << 3) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0
+			};
+		end
+
+		16, 18: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 4) : (B1EN ? (B1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 4) : (F1EN ? (F1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 4) : (H1EN ? (H1ADDR_TOTAL << 4) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0
+			};
+		end
+
+		default: begin
+			assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0
+			};
+		end
+	endcase
+
+	assign FLUSH1 = 1'b0;
+	assign FLUSH2 = 1'b0;
+
+	wire [17:0] PORT_A1_RDATA = {A1_RDATA_CMPL, A1DATA};
+	wire [17:0] PORT_B1_RDATA = {C1_RDATA_CMPL, C1DATA};
+	wire [17:0] PORT_A2_RDATA = {E1_RDATA_CMPL, E1DATA};
+	wire [17:0] PORT_B2_RDATA = {G1_RDATA_CMPL, G1DATA};
+
+	wire [17:0] PORT_A1_WDATA = {B1_WDATA_CMPL, B1DATA};
+	wire [17:0] PORT_B1_WDATA = {D1_WDATA_CMPL, D1DATA};
+	wire [17:0] PORT_A2_WDATA = {F1_WDATA_CMPL, F1DATA};
+	wire [17:0] PORT_B2_WDATA = {H1_WDATA_CMPL, H1DATA};
+
+	wire PORT_A1_CLK = CLK1;
+	wire PORT_A2_CLK = CLK3;
+	wire PORT_B1_CLK = CLK2;
+	wire PORT_B2_CLK = CLK4;
+
+	wire PORT_A1_REN = A1EN;
+	wire PORT_A1_WEN = B1EN[0];
+	wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {B1EN[1],B1EN[0]};
+
+	wire PORT_A2_REN = E1EN;
+	wire PORT_A2_WEN = F1EN[0];
+	wire [CFG_ENABLE_F-1:0] PORT_A2_BE = {F1EN[1],F1EN[0]};
+
+	wire PORT_B1_REN = C1EN;
+	wire PORT_B1_WEN = D1EN[0];
+	wire [CFG_ENABLE_D-1:0] PORT_B1_BE = {D1EN[1],D1EN[0]};
+
+	wire PORT_B2_REN = G1EN;
+	wire PORT_B2_WEN = H1EN[0];
+	wire [CFG_ENABLE_H-1:0] PORT_B2_BE = {H1EN[1],H1EN[0]};
+
+	TDP36K  _TECHMAP_REPLACE_ (
+		.WDATA_A1_i(PORT_A1_WDATA),
+		.RDATA_A1_o(PORT_A1_RDATA),
+		.ADDR_A1_i(PORT_A1_ADDR),
+		.CLK_A1_i(PORT_A1_CLK),
+		.REN_A1_i(PORT_A1_REN),
+		.WEN_A1_i(PORT_A1_WEN),
+		.BE_A1_i(PORT_A1_BE),
+
+		.WDATA_A2_i(PORT_A2_WDATA),
+		.RDATA_A2_o(PORT_A2_RDATA),
+		.ADDR_A2_i(PORT_A2_ADDR),
+		.CLK_A2_i(PORT_A2_CLK),
+		.REN_A2_i(PORT_A2_REN),
+		.WEN_A2_i(PORT_A2_WEN),
+		.BE_A2_i(PORT_A2_BE),
+
+		.WDATA_B1_i(PORT_B1_WDATA),
+		.RDATA_B1_o(PORT_B1_RDATA),
+		.ADDR_B1_i(PORT_B1_ADDR),
+		.CLK_B1_i(PORT_B1_CLK),
+		.REN_B1_i(PORT_B1_REN),
+		.WEN_B1_i(PORT_B1_WEN),
+		.BE_B1_i(PORT_B1_BE),
+
+		.WDATA_B2_i(PORT_B2_WDATA),
+		.RDATA_B2_o(PORT_B2_RDATA),
+		.ADDR_B2_i(PORT_B2_ADDR),
+		.CLK_B2_i(PORT_B2_CLK),
+		.REN_B2_i(PORT_B2_REN),
+		.WEN_B2_i(PORT_B2_WEN),
+		.BE_B2_i(PORT_B2_BE),
+
+		.FLUSH1_i(FLUSH1),
+		.FLUSH2_i(FLUSH2)
+	);
+endmodule

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -181,17 +181,20 @@ endmodule
 
 // ------------------------------------------------------------------------
 
-module \$__QLF_FACTOR_BRAM18_TDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
-	parameter CFG_ABITS = 10;
+module \$__QLF_FACTOR_BRAM18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, CLK3, CLK4, D1ADDR, D1DATA, D1EN);
+	parameter CFG_ABITS = 11;
 	parameter CFG_DBITS = 18;
-	parameter CFG_ENABLE_B = 2;
+	parameter CFG_ENABLE_B = 4;
+	parameter CFG_ENABLE_D = 4;
 
 	parameter CLKPOL2 = 1;
 	parameter CLKPOL3 = 1;
 	parameter [18431:0] INIT = 18432'bx;
 
+	input CLK1;
 	input CLK2;
 	input CLK3;
+	input CLK4;
 
 	input [CFG_ABITS-1:0] A1ADDR;
 	output [CFG_DBITS-1:0] A1DATA;
@@ -201,101 +204,55 @@ module \$__QLF_FACTOR_BRAM18_TDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DA
 	input [CFG_DBITS-1:0] B1DATA;
 	input [CFG_ENABLE_B-1:0] B1EN;
 
-	wire [13:0] A1ADDR_14;
-	wire [13:0] B1ADDR_14;
-	//wire [3:0] B1EN_4 = B1EN;
+	input [CFG_ABITS-1:0] C1ADDR;
+	output [CFG_DBITS-1:0] C1DATA;
+	input C1EN;
 
-	wire [1:0] DIP, DOP;
-	wire [15:0] DI, DO;
+	input [CFG_ABITS-1:0] D1ADDR;
+	input [CFG_DBITS-1:0] D1DATA;
+	input [CFG_ENABLE_D-1:0] D1EN;
 
-	wire [15:0] DOBDO;
-	wire [1:0] DOPBDOP;
+	BRAM2x18_TDP #(
+		.CFG_ABITS(CFG_ABITS),
+		.CFG_DBITS(CFG_DBITS),
+		.CFG_ENABLE_B(CFG_ENABLE_B),
+		.CFG_ENABLE_D(CFG_ENABLE_D),
+		.CLKPOL2(CLKPOL2),
+		.CLKPOL3(CLKPOL3),
+		.INIT0(INIT),
+	) _TECHMAP_REPLACE_ (
+		.A1ADDR(A1ADDR),
+		.A1DATA(A1DATA),
+		.A1EN(A1EN),
+		.B1ADDR(B1ADDR),
+		.B1DATA(B1DATA),
+		.B1EN(B1EN),
+		.CLK1(CLK1),
 
-	assign A1DATA = { DOP[1], DO[15: 8], DOP[0], DO[ 7: 0] };
-	assign { DIP[1], DI[15: 8], DIP[0], DI[ 7: 0] } = B1DATA;
-        
-        assign A1ADDR_14[13:CFG_ABITS]  = 0;
-        assign A1ADDR_14[CFG_ABITS-1:0] = A1ADDR;
-        assign B1ADDR_14[13:CFG_ABITS]  = 0;
-        assign B1ADDR_14[CFG_ABITS-1:0] = B1ADDR;
+		.C1ADDR(C1ADDR),
+		.C1DATA(C1DATA),
+		.C1EN(C1EN),
+		.D1ADDR(D1ADDR),
+		.D1DATA(D1DATA),
+		.D1EN(D1EN),
+		.CLK2(CLK2),
 
-	/*if (CFG_DBITS == 1) begin
-	  assign WRITEDATAWIDTHB = 3'b000;
-	  assign READDATAWIDTHA = 3'b000;
-	end else if (CFG_DBITS == 2) begin
-          assign WRITEDATAWIDTHB = 3'b001;
-          assign READDATAWIDTHA = 3'b001;
-        end else if (CFG_DBITS > 2 && CFG_DBITS <= 4) begin
-          assign WRITEDATAWIDTHB = 3'b010;
-          assign READDATAWIDTHA = 3'b010;
-        end else if (CFG_DBITS > 4 && CFG_DBITS <= 9) begin
-          assign WRITEDATAWIDTHB = 3'b011;
-          assign READDATAWIDTHA = 3'b011;
-        end else if (CFG_DBITS > 9 && CFG_DBITS <= 18) begin
-          //assign WRITEDATAWIDTHB = 3'b100;
-          assign READDATAWIDTHA = 3'b100;
-	end*/
-	generate if (CFG_DBITS > 8) begin
-		TDP_BRAM18 #(
-			//`include "brams_init_18.vh"
-                        .READ_WIDTH_A(CFG_DBITS),
-                        .READ_WIDTH_B(CFG_DBITS),
-                        .WRITE_WIDTH_A(CFG_DBITS),
-                        .WRITE_WIDTH_B(CFG_DBITS),
-		) _TECHMAP_REPLACE_ (
-			.WRITEDATAA(16'hFFFF),
-			.WRITEDATAAP(2'b11),
-			.READDATAA(DO[15:0]),
-			.READDATAAP(DOP[2:0]),
-			.ADDRA(A1ADDR_14),
-			.CLOCKA(CLK2),
-			.READENABLEA(A1EN),
-			.WRITEENABLEA(1'b0),
-			.BYTEENABLEA(2'b0),
-			//.WRITEDATAWIDTHA(3'b0),
-			//.READDATAWIDTHA(READDATAWIDTHA),
+		.E1ADDR(),
+		.E1DATA(),
+		.E1EN(),
+		.F1ADDR(),
+		.F1DATA(),
+		.F1EN(),
+		.CLK3(),
 
-			.WRITEDATAB(DI),
-			.WRITEDATABP(DIP),
-			.READDATAB(DOBDO),
-			.READDATABP(DOPBDOP),
-			.ADDRB(B1ADDR_14),
-			.CLOCKB(CLK3),
-			.READENABLEB(1'b0),
-			.WRITEENABLEB(1'b1),
-			.BYTEENABLEB(B1EN)
-			//.WRITEDATAWIDTHB(WRITEDATAWIDTHB),
-			//.READDATAWIDTHB(3'b0)
-		);
-	end else begin
-		TDP_BRAM18 #(
-			//`include "brams_init_16.vh"
-		) _TECHMAP_REPLACE_ (
-			.WRITEDATAA(16'hFFFF),
-			.WRITEDATAAP(2'b11),
-			.READDATAA(DO[15:0]),
-			.READDATAAP(DOP[2:0]),
-			.ADDRA(A1ADDR_14),
-			.CLOCKA(CLK2),
-			.READENABLEA(A1EN),
-			.WRITEENABLEA(1'b0),
-			.BYTEENABLEA(2'b0),
-			//.WRITEDATAWIDTHA(3'b0),
-		//	.READDATAWIDTHA(READDATAWIDTHA),
-
-			.WRITEDATAB(DI),
-			.WRITEDATABP(DIP),
-			.READDATAB(DOBDO),
-			.READDATABP(DOPBDOP),
-			.ADDRB(B1ADDR_14),
-			.CLOCKB(CLK3),
-			.READENABLEB(1'b0),
-			.WRITEENABLEB(1'b1),
-			.BYTEENABLEB(B1EN)
-			//.WRITEDATAWIDTHB(WRITEDATAWIDTHB),
-			//.READDATAWIDTHB(3'b0)
-		);
-	end endgenerate
+		.G1ADDR(),
+		.G1DATA(),
+		.G1EN(),
+		.H1ADDR(),
+		.H1DATA(),
+		.H1EN(),
+		.CLK4()
+	);
 endmodule
 
 module \$__QLF_FACTOR_BRAM36_SDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -65,13 +65,34 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	wire [14:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
 
 	wire [35:CFG_DBITS] A1DATA_CMPL;
+	wire [35:CFG_DBITS] B1DATA_CMPL;
 	wire [35:CFG_DBITS] C1DATA_CMPL;
+	wire [35:CFG_DBITS] D1DATA_CMPL;
 
-	wire [35:0] A1DATA_TOTAL = {A1DATA_CMPL, A1DATA};
-	wire [35:0] C1DATA_TOTAL = {C1DATA_CMPL, C1DATA};
+	wire [35:0] A1DATA_TOTAL;
+	wire [35:0] B1DATA_TOTAL;
+	wire [35:0] C1DATA_TOTAL;
+	wire [35:0] D1DATA_TOTAL;
 
 	wire [14:0] PORT_A_ADDR;
 	wire [14:0] PORT_B_ADDR;
+
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {A1DATA_TOTAL[16], A1DATA_TOTAL[7:0]};
+			assign C1DATA = {C1DATA_TOTAL[16], C1DATA_TOTAL[7:0]};
+			assign B1DATA_TOTAL = {B1DATA_CMPL[35:17], B1DATA[8], B1DATA_CMPL[16:9], B1DATA[7:0]};
+			assign D1DATA_TOTAL = {D1DATA_CMPL[35:17], D1DATA[8], D1DATA_CMPL[16:9], D1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = A1DATA_TOTAL[CFG_DBITS-1:0];
+			assign C1DATA = C1DATA_TOTAL[CFG_DBITS-1:0];
+			assign B1DATA_TOTAL = {B1DATA_CMPL, B1DATA};
+			assign D1DATA_TOTAL = {D1DATA_CMPL, D1DATA};
+		end
+	endcase
 
 	case (CFG_DBITS)
 		1: begin
@@ -144,8 +165,8 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 
 	TDP36K _TECHMAP_REPLACE_ (
 		.RESET_ni(1'b1),
-		.WDATA_A1_i(B1DATA[17:0]),
-		.WDATA_A2_i(B1DATA[35:18]),
+		.WDATA_A1_i(B1DATA_TOTAL[17:0]),
+		.WDATA_A2_i(B1DATA_TOTAL[35:18]),
 		.RDATA_A1_o(A1DATA_TOTAL[17:0]),
 		.RDATA_A2_o(A1DATA_TOTAL[35:18]),
 		.ADDR_A1_i(PORT_A_ADDR),
@@ -159,8 +180,8 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		.BE_A1_i({B1EN[1],B1EN[0]}),
 		.BE_A2_i({B1EN[3],B1EN[2]}),
 
-		.WDATA_B1_i(D1DATA[17:0]),
-		.WDATA_B2_i(D1DATA[35:18]),
+		.WDATA_B1_i(D1DATA_TOTAL[17:0]),
+		.WDATA_B2_i(D1DATA_TOTAL[35:18]),
 		.RDATA_B1_o(C1DATA_TOTAL[17:0]),
 		.RDATA_B2_o(C1DATA_TOTAL[35:18]),
 		.ADDR_B1_i(PORT_B_ADDR),
@@ -306,8 +327,18 @@ module \$__QLF_FACTOR_BRAM36_SDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DA
 	assign A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
 	assign B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
 
-	assign A1DATA_TOTAL = {A1DATA_CMPL, A1DATA};
-	assign B1DATA_TOTAL = {B1DATA_CMPL, B1DATA};
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {A1DATA_TOTAL[16], A1DATA_TOTAL[7:0]};
+			assign B1DATA_TOTAL = {B1DATA_CMPL[35:17], B1DATA[8], B1DATA_CMPL[16:9], B1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = A1DATA_TOTAL[CFG_DBITS-1:0];
+			assign B1DATA_TOTAL = {B1DATA_CMPL, B1DATA};
+		end
+	endcase
 
 	case (CFG_DBITS)
 		1: begin
@@ -392,8 +423,8 @@ module \$__QLF_FACTOR_BRAM36_SDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DA
 		.BE_A1_i({A1EN, A1EN}),
 		.BE_A2_i({A1EN, A1EN}),
 
-		.WDATA_B1_i(B1DATA[17:0]),
-		.WDATA_B2_i(B1DATA[35:18]),
+		.WDATA_B1_i(B1DATA_TOTAL[17:0]),
+		.WDATA_B2_i(B1DATA_TOTAL[35:18]),
 		.RDATA_B1_o(DOBDO[17:0]),
 		.RDATA_B2_o(DOBDO[35:18]),
 		.ADDR_B1_i(B1ADDR_15),

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1155,6 +1155,240 @@ module TDP36K (
     );
 endmodule
 
+module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, CLK3, CLK4, D1ADDR, D1DATA, D1EN, E1ADDR, E1DATA, E1EN, F1ADDR, F1DATA, F1EN, G1ADDR, G1DATA, G1EN, H1ADDR, H1DATA, H1EN);
+    parameter CFG_ABITS = 11;
+    parameter CFG_DBITS = 18;
+    parameter CFG_ENABLE_B = 4;
+    parameter CFG_ENABLE_D = 4;
+    parameter CFG_ENABLE_F = 4;
+    parameter CFG_ENABLE_H = 4;
+
+    parameter CLKPOL2 = 1;
+    parameter CLKPOL3 = 1;
+    parameter [18431:0] INIT0 = 18432'bx;
+    parameter [18431:0] INIT1 = 18432'bx;
+
+    localparam MODE_36 = 3'b011; // 36- or 32-bit
+    localparam MODE_18 = 3'b010; // 18- or 16-bit
+    localparam MODE_9 = 3'b001; // 9- or 8-bit
+    localparam MODE_4 = 3'b100; // 4-bit
+    localparam MODE_2 = 3'b110; // 2-bit
+    localparam MODE_1 = 3'b101; // 1-bit
+
+    input CLK1;
+    input CLK2;
+    input CLK3;
+    input CLK4;
+
+    input [CFG_ABITS-1:0] A1ADDR;
+    output [CFG_DBITS-1:0] A1DATA;
+    input A1EN;
+
+    input [CFG_ABITS-1:0] B1ADDR;
+    input [CFG_DBITS-1:0] B1DATA;
+    input [CFG_ENABLE_B-1:0] B1EN;
+
+    input [CFG_ABITS-1:0] C1ADDR;
+    output [CFG_DBITS-1:0] C1DATA;
+    input C1EN;
+
+    input [CFG_ABITS-1:0] D1ADDR;
+    input [CFG_DBITS-1:0] D1DATA;
+    input [CFG_ENABLE_D-1:0] D1EN;
+
+    input [CFG_ABITS-1:0] E1ADDR;
+    output [CFG_DBITS-1:0] E1DATA;
+    input E1EN;
+
+    input [CFG_ABITS-1:0] F1ADDR;
+    input [CFG_DBITS-1:0] F1DATA;
+    input [CFG_ENABLE_F-1:0] F1EN;
+
+    input [CFG_ABITS-1:0] G1ADDR;
+    output [CFG_DBITS-1:0] G1DATA;
+    input G1EN;
+
+    input [CFG_ABITS-1:0] H1ADDR;
+    input [CFG_DBITS-1:0] H1DATA;
+    input [CFG_ENABLE_H-1:0] H1EN;
+
+    wire FLUSH1;
+    wire FLUSH2;
+    wire SPLIT;
+
+    wire [13:CFG_ABITS] A1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] B1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] C1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] D1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] E1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] F1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] G1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] H1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+
+    wire [13:0] A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
+    wire [13:0] B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
+    wire [13:0] C1ADDR_TOTAL = {C1ADDR_CMPL, C1ADDR};
+    wire [13:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
+    wire [13:0] E1ADDR_TOTAL = {E1ADDR_CMPL, E1ADDR};
+    wire [13:0] F1ADDR_TOTAL = {F1ADDR_CMPL, F1ADDR};
+    wire [13:0] G1ADDR_TOTAL = {G1ADDR_CMPL, G1ADDR};
+    wire [13:0] H1ADDR_TOTAL = {H1ADDR_CMPL, H1ADDR};
+
+    wire [17:CFG_DBITS] A1_RDATA_CMPL;
+    wire [17:CFG_DBITS] C1_RDATA_CMPL;
+    wire [17:CFG_DBITS] E1_RDATA_CMPL;
+    wire [17:CFG_DBITS] G1_RDATA_CMPL;
+
+    wire [17:CFG_DBITS] B1_WDATA_CMPL;
+    wire [17:CFG_DBITS] D1_WDATA_CMPL;
+    wire [17:CFG_DBITS] F1_WDATA_CMPL;
+    wire [17:CFG_DBITS] H1_WDATA_CMPL;
+
+    wire [13:0] PORT_A1_ADDR;
+    wire [13:0] PORT_A2_ADDR;
+    wire [13:0] PORT_B1_ADDR;
+    wire [13:0] PORT_B2_ADDR;
+
+    case (CFG_DBITS)
+        1: begin
+            assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+            assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+            assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+            assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+	    defparam bram_2x18k.MODE_BITS = { 1'b1,
+		11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+		12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+	    };
+        end
+
+        2: begin
+            assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 1) : (B1EN ? (B1ADDR_TOTAL << 1) : 14'd0);
+            assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 14'd0);
+            assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 1) : (F1EN ? (F1ADDR_TOTAL << 1) : 14'd0);
+            assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 1) : (H1EN ? (H1ADDR_TOTAL << 1) : 14'd0);
+	    defparam bram_2x18k.MODE_BITS = { 1'b1,
+		11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+		12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+	    };
+        end
+
+        4: begin
+            assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 2) : (B1EN ? (B1ADDR_TOTAL << 2) : 14'd0);
+            assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 2) : (D1EN ? (D1ADDR_TOTAL << 2) : 14'd0);
+            assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 2) : (F1EN ? (F1ADDR_TOTAL << 2) : 14'd0);
+            assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 2) : (H1EN ? (H1ADDR_TOTAL << 2) : 14'd0);
+	    defparam bram_2x18k.MODE_BITS = { 1'b1,
+		11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+		12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+	    };
+        end
+
+        8, 9: begin
+            assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 3) : (B1EN ? (B1ADDR_TOTAL << 3) : 14'd0);
+            assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 14'd0);
+            assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 3) : (F1EN ? (F1ADDR_TOTAL << 3) : 14'd0);
+            assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 3) : (H1EN ? (H1ADDR_TOTAL << 3) : 14'd0);
+	    defparam bram_2x18k.MODE_BITS = { 1'b1,
+		11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+		12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+	    };
+        end
+
+        16, 18: begin
+            assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 4) : (B1EN ? (B1ADDR_TOTAL << 4) : 14'd0);
+            assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 14'd0);
+            assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 4) : (F1EN ? (F1ADDR_TOTAL << 4) : 14'd0);
+            assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 4) : (H1EN ? (H1ADDR_TOTAL << 4) : 14'd0);
+	    defparam bram_2x18k.MODE_BITS = { 1'b1,
+		11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+		12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+	    };
+        end
+
+        default: begin
+            assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+            assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+            assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+            assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+	    defparam bram_2x18k.MODE_BITS = { 1'b1,
+	        11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+	        12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+	    };
+        end
+    endcase
+
+    assign FLUSH1 = 1'b0;
+    assign FLUSH2 = 1'b0;
+
+    wire [17:0] PORT_A1_RDATA = {A1_RDATA_CMPL, A1DATA};
+    wire [17:0] PORT_B1_RDATA = {C1_RDATA_CMPL, C1DATA};
+    wire [17:0] PORT_A2_RDATA = {E1_RDATA_CMPL, E1DATA};
+    wire [17:0] PORT_B2_RDATA = {G1_RDATA_CMPL, G1DATA};
+
+    wire [17:0] PORT_A1_WDATA = {B1_WDATA_CMPL, B1DATA};
+    wire [17:0] PORT_B1_WDATA = {D1_WDATA_CMPL, D1DATA};
+    wire [17:0] PORT_A2_WDATA = {F1_WDATA_CMPL, F1DATA};
+    wire [17:0] PORT_B2_WDATA = {H1_WDATA_CMPL, H1DATA};
+
+    wire PORT_A1_CLK = CLK1;
+    wire PORT_A2_CLK = CLK3;
+    wire PORT_B1_CLK = CLK2;
+    wire PORT_B2_CLK = CLK4;
+
+    wire PORT_A1_REN = A1EN;
+    wire PORT_A1_WEN = B1EN[0];
+    wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {B1EN[1],B1EN[0]};
+
+    wire PORT_A2_REN = E1EN;
+    wire PORT_A2_WEN = F1EN[0];
+    wire [CFG_ENABLE_F-1:0] PORT_A2_BE = {F1EN[1],F1EN[0]};
+
+    wire PORT_B1_REN = C1EN;
+    wire PORT_B1_WEN = D1EN[0];
+    wire [CFG_ENABLE_D-1:0] PORT_B1_BE = {D1EN[1],D1EN[0]};
+
+    wire PORT_B2_REN = G1EN;
+    wire PORT_B2_WEN = H1EN[0];
+    wire [CFG_ENABLE_H-1:0] PORT_B2_BE = {H1EN[1],H1EN[0]};
+
+    TDP36K bram_2x18k (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+    );
+endmodule
+
 (* blackbox *)
 module QL_DSP1 (
     input wire [19:0] a,

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -309,7 +309,11 @@ struct SynthQuickLogicPass : public ScriptPass {
             if (family == "pp3") {
                 run("pp3_braminit");
             }
+            run("ql_bram_split                   ", "(for qlf_k6n10f if not -no_bram)");
             run("techmap -map +/quicklogic/" + family + "/brams_map.v");
+            if (family == "qlf_k6n10f") {
+                run("techmap -map +/quicklogic/" + family + "/brams_final_map.v");
+            }
         }
 
         if (check_label("map_ffram")) {

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -43,7 +43,8 @@ SIM_TESTS = \
 # Those tests perform synthesis and simulation of synthesis results
 POST_SYNTH_SIM_TESTS = \
     qlf_k6n10f/bram_tdp \
-    qlf_k6n10f/bram_sdp
+    qlf_k6n10f/bram_sdp \
+    qlf_k6n10f/bram_tdp_split
 
 include $(shell pwd)/../../Makefile_test.common
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/bram_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/bram_sdp.tcl
@@ -6,45 +6,100 @@ yosys -import  ;
 read_verilog $::env(DESIGN_TOP).v
 design -save bram_sdp
 
-select BRAM_SDP_32x512
+select BRAM_SDP_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_32x512
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_36x1024
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_sdp_32x512_post_synth.v
+write_verilog sim/bram_sdp_36x1024_post_synth.v
 select -assert-count 1 t:TDP36K
 
 select -clear
 design -load bram_sdp
-select BRAM_SDP_16x1024
+select BRAM_SDP_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_16x1024
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_32x1024
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_sdp_16x1024_post_synth.v
+write_verilog sim/bram_sdp_32x1024_post_synth.v
 select -assert-count 1 t:TDP36K
 
 select -clear
 design -load bram_sdp
-select BRAM_SDP_8x2048
+select BRAM_SDP_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_8x2048
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_18x2048
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_sdp_8x2048_post_synth.v
+write_verilog sim/bram_sdp_18x2048_post_synth.v
 select -assert-count 1 t:TDP36K
 
 select -clear
 design -load bram_sdp
-select BRAM_SDP_4x4096
+select BRAM_SDP_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_4x4096
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_16x2048
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_sdp_4x4096_post_synth.v
+write_verilog sim/bram_sdp_16x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp
+select BRAM_SDP_9x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_9x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_9x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp
+select BRAM_SDP_8x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_8x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_8x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp
+select BRAM_SDP_4x8192
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_4x8192
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_4x8192_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp
+select BRAM_SDP_2x16384
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_2x16384
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_2x16384_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp
+select BRAM_SDP_1x32768
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_1x32768
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_1x32768_post_synth.v
 select -assert-count 1 t:TDP36K
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/bram_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/bram_sdp.v
@@ -54,7 +54,7 @@ parameter DWIDTH = 32)(
 
 endmodule
 
-module BRAM_SDP_32x512(
+module BRAM_SDP_36x1024(
 	clk,
 	rce,
 	ra,
@@ -64,7 +64,39 @@ module BRAM_SDP_32x512(
 	wd
 );
 
-parameter AWIDTH = 9;
+parameter AWIDTH = 10;
+parameter DWIDTH = 36;
+
+	input  			clk;
+	input                   rce;
+	input      [AWIDTH-1:0] ra;
+	output     [DWIDTH-1:0] rq;
+	input                   wce;
+	input      [AWIDTH-1:0] wa;
+	input      [DWIDTH-1:0] wd;
+
+BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_36x1024 (.clk(clk),
+		 .rce(rce),
+		 .ra(ra),
+		 .rq(rq),
+		 .wce(wce),
+		 .wa(wa),
+		 .wd(wd));
+
+endmodule
+
+module BRAM_SDP_32x1024(
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+
+parameter AWIDTH = 10;
 parameter DWIDTH = 32;
 
 	input  			clk;
@@ -76,7 +108,7 @@ parameter DWIDTH = 32;
 	input      [DWIDTH-1:0] wd;
 
 BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_32x512 (.clk(clk),
+	BRAM_32x1024 (.clk(clk),
 		 .rce(rce),
 		 .ra(ra),
 		 .rq(rq),
@@ -86,7 +118,7 @@ BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
 
 endmodule
 
-module BRAM_SDP_16x1024(
+module BRAM_SDP_18x2048(
 	clk,
 	rce,
 	ra,
@@ -96,7 +128,40 @@ module BRAM_SDP_16x1024(
 	wd
 );
 
-parameter AWIDTH = 10;
+parameter AWIDTH = 11;
+parameter DWIDTH = 18;
+
+	input  			clk;
+	input                   rce;
+	input      [AWIDTH-1:0] ra;
+	output     [DWIDTH-1:0] rq;
+	input                   wce;
+	input      [AWIDTH-1:0] wa;
+	input      [DWIDTH-1:0] wd;
+
+BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_18x2048 (.clk(clk),
+		 .rce(rce),
+		 .ra(ra),
+		 .rq(rq),
+		 .wce(wce),
+		 .wa(wa),
+		 .wd(wd));
+
+
+endmodule
+
+module BRAM_SDP_16x2048(
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+
+parameter AWIDTH = 11;
 parameter DWIDTH = 16;
 
 	input  			clk;
@@ -108,7 +173,7 @@ parameter DWIDTH = 16;
 	input      [DWIDTH-1:0] wd;
 
 BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_16x1024 (.clk(clk),
+	BRAM_16x2048 (.clk(clk),
 		 .rce(rce),
 		 .ra(ra),
 		 .rq(rq),
@@ -119,7 +184,7 @@ BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
 
 endmodule
 
-module BRAM_SDP_8x2048(
+module BRAM_SDP_9x4096(
 	clk,
 	rce,
 	ra,
@@ -129,7 +194,40 @@ module BRAM_SDP_8x2048(
 	wd
 );
 
-parameter AWIDTH = 11;
+parameter AWIDTH = 12;
+parameter DWIDTH = 9;
+
+	input  			clk;
+	input                   rce;
+	input      [AWIDTH-1:0] ra;
+	output     [DWIDTH-1:0] rq;
+	input                   wce;
+	input      [AWIDTH-1:0] wa;
+	input      [DWIDTH-1:0] wd;
+
+BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_9x4096 (.clk(clk),
+		 .rce(rce),
+		 .ra(ra),
+		 .rq(rq),
+		 .wce(wce),
+		 .wa(wa),
+		 .wd(wd));
+
+
+endmodule
+
+module BRAM_SDP_8x4096(
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+
+parameter AWIDTH = 12;
 parameter DWIDTH = 8;
 
 	input  			clk;
@@ -141,7 +239,7 @@ parameter DWIDTH = 8;
 	input      [DWIDTH-1:0] wd;
 
 BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_8x2048 (.clk(clk),
+	BRAM_8x4096 (.clk(clk),
 		 .rce(rce),
 		 .ra(ra),
 		 .rq(rq),
@@ -152,7 +250,7 @@ BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
 
 endmodule
 
-module BRAM_SDP_4x4096(
+module BRAM_SDP_4x8192(
 	clk,
 	rce,
 	ra,
@@ -162,7 +260,7 @@ module BRAM_SDP_4x4096(
 	wd
 );
 
-parameter AWIDTH = 12;
+parameter AWIDTH = 13;
 parameter DWIDTH = 4;
 
 	input  			clk;
@@ -174,7 +272,71 @@ parameter DWIDTH = 4;
 	input      [DWIDTH-1:0] wd;
 
 BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_4x4096 (.clk(clk),
+	BRAM_4x8192 (.clk(clk),
+		 .rce(rce),
+		 .ra(ra),
+		 .rq(rq),
+		 .wce(wce),
+		 .wa(wa),
+		 .wd(wd));
+
+endmodule
+
+module BRAM_SDP_2x16384(
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+
+parameter AWIDTH = 14;
+parameter DWIDTH = 2;
+
+	input  			clk;
+	input                   rce;
+	input      [AWIDTH-1:0] ra;
+	output     [DWIDTH-1:0] rq;
+	input                   wce;
+	input      [AWIDTH-1:0] wa;
+	input      [DWIDTH-1:0] wd;
+
+BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_2x16384 (.clk(clk),
+		 .rce(rce),
+		 .ra(ra),
+		 .rq(rq),
+		 .wce(wce),
+		 .wa(wa),
+		 .wd(wd));
+
+endmodule
+
+module BRAM_SDP_1x32768(
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+
+parameter AWIDTH = 15;
+parameter DWIDTH = 1;
+
+	input  			clk;
+	input                   rce;
+	input      [AWIDTH-1:0] ra;
+	output     [DWIDTH-1:0] rq;
+	input                   wce;
+	input      [AWIDTH-1:0] wa;
+	input      [DWIDTH-1:0] wd;
+
+BRAM_SDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_1x32678 (.clk(clk),
 		 .rce(rce),
 		 .ra(ra),
 		 .rq(rq),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/sim/Makefile
@@ -15,11 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = bram_sdp_tb.v
-POST_SYNTH = bram_sdp_32x512_post_synth bram_sdp_16x1024_post_synth bram_sdp_8x2048_post_synth bram_sdp_4x4096_post_synth
-ADDR_WIDTH = 9 10 11 12
-DATA_WIDTH = 32 16 8 4
-TOP = BRAM_SDP_32x512 BRAM_SDP_16x1024 BRAM_SDP_8x2048 BRAM_SDP_4x4096
-TEST_CASES = $(seq 0 3)
+POST_SYNTH = bram_sdp_36x1024_post_synth bram_sdp_32x1024_post_synth bram_sdp_18x2048_post_synth bram_sdp_16x2048_post_synth bram_sdp_9x4096_post_synth bram_sdp_8x4096_post_synth bram_sdp_4x8192_post_synth bram_sdp_2x16384_post_synth bram_sdp_1x32768_post_synth
+ADDR_WIDTH = 10 10 11 11 12 12 13 14 15
+DATA_WIDTH = 36 32 18 16 9 8 4 2 1
+TOP = BRAM_SDP_36x1024 BRAM_SDP_32x1024 BRAM_SDP_18x2048 BRAM_SDP_16x2048 BRAM_SDP_9x4096 BRAM_SDP_8x4096 BRAM_SDP_4x8192 BRAM_SDP_2x16384 BRAM_SDP_1x32768
 ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
 DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
 TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
@@ -36,8 +35,13 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
+# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call simulate_post_synth,2)
 	$(call simulate_post_synth,3)
 	$(call simulate_post_synth,4)
+	$(call simulate_post_synth,6)
+	$(call simulate_post_synth,7)
+	$(call simulate_post_synth,8)
+	$(call simulate_post_synth,9)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/sim/Makefile
@@ -41,6 +41,7 @@ sim:
 	$(call simulate_post_synth,2)
 	$(call simulate_post_synth,3)
 	$(call simulate_post_synth,4)
+	$(call simulate_post_synth,5)
 	$(call simulate_post_synth,6)
 	$(call simulate_post_synth,7)
 	$(call simulate_post_synth,8)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/sim/bram_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/sim/bram_sdp_tb.v
@@ -100,8 +100,8 @@ module TB;
 	end
 
 	case (`STRINGIFY(`TOP))
-		"BRAM_SDP_32x512": begin
-			BRAM_SDP_32x512 #() bram (
+		"BRAM_SDP_36x1024": begin
+			BRAM_SDP_36x1024 #() bram (
 				.clk(clk),
 				.rce(rce),
 				.ra(ra),
@@ -111,8 +111,8 @@ module TB;
 				.wd(wd)
 			);
 		end
-		"BRAM_SDP_16x1024": begin
-			BRAM_SDP_16x1024 #() bram (
+		"BRAM_SDP_32x1024": begin
+			BRAM_SDP_32x1024 #() bram (
 				.clk(clk),
 				.rce(rce),
 				.ra(ra),
@@ -122,8 +122,8 @@ module TB;
 				.wd(wd)
 			);
 		end
-		"BRAM_SDP_8x2048": begin
-			BRAM_SDP_8x2048 #() bram (
+		"BRAM_SDP_18x2048": begin
+			BRAM_SDP_18x2048 #() bram (
 				.clk(clk),
 				.rce(rce),
 				.ra(ra),
@@ -133,8 +133,63 @@ module TB;
 				.wd(wd)
 			);
 		end
-		"BRAM_SDP_4x4096": begin
-			BRAM_SDP_4x4096 #() bram (
+		"BRAM_SDP_16x2048": begin
+			BRAM_SDP_16x2048 #() bram (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"BRAM_SDP_9x4096": begin
+			BRAM_SDP_9x4096 #() bram (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"BRAM_SDP_8x4096": begin
+			BRAM_SDP_8x4096 #() bram (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"BRAM_SDP_4x8192": begin
+			BRAM_SDP_4x8192 #() bram (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"BRAM_SDP_2x16384": begin
+			BRAM_SDP_2x16384 #() bram (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"BRAM_SDP_1x32768": begin
+			BRAM_SDP_1x32768 #() bram (
 				.clk(clk),
 				.rce(rce),
 				.ra(ra),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
@@ -6,45 +6,100 @@ yosys -import  ;
 read_verilog $::env(DESIGN_TOP).v
 design -save bram_tdp
 
-select BRAM_TDP_32x512
+select BRAM_TDP_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_32x512
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_36x1024
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_tdp_32x512_post_synth.v
+write_verilog sim/bram_tdp_36x1024_post_synth.v
 select -assert-count 1 t:TDP36K
 
 select -clear
 design -load bram_tdp
-select BRAM_TDP_16x1024
+select BRAM_TDP_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_16x1024
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_32x1024
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_tdp_16x1024_post_synth.v
+write_verilog sim/bram_tdp_32x1024_post_synth.v
 select -assert-count 1 t:TDP36K
 
 select -clear
 design -load bram_tdp
-select BRAM_TDP_8x2048
+select BRAM_TDP_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_8x2048
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_18x2048
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_tdp_8x2048_post_synth.v
+write_verilog sim/bram_tdp_18x2048_post_synth.v
 select -assert-count 1 t:TDP36K
 
 select -clear
 design -load bram_tdp
-select BRAM_TDP_4x4096
+select BRAM_TDP_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_4x4096
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_16x2048
 opt_expr -undriven
 opt_clean
 stat
-write_verilog sim/bram_tdp_4x4096_post_synth.v
+write_verilog sim/bram_tdp_16x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_9x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_9x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_9x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_8x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_8x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_8x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_4x8192
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_4x8192
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_4x8192_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_2x16384
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_2x16384
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_2x16384_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_1x32768
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_1x32768
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_1x32768_post_synth.v
 select -assert-count 1 t:TDP36K
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.v
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-module BRAM_TDP #(parameter AWIDTH = 9,
-parameter DWIDTH = 32)(
+module BRAM_TDP #(parameter AWIDTH = 10,
+parameter DWIDTH = 36)(
 	clk_a,
 	rce_a,
 	ra_a,
@@ -76,7 +76,7 @@ parameter DWIDTH = 32)(
 
 endmodule
 
-module BRAM_TDP_32x512(
+module BRAM_TDP_36x1024(
 	clk_a,
 	rce_a,
 	ra_a,
@@ -94,7 +94,61 @@ module BRAM_TDP_32x512(
 	wd_b
 );
 
-parameter AWIDTH = 9;
+parameter AWIDTH = 10;
+parameter DWIDTH = 36;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_36x1024 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+
+endmodule
+
+module BRAM_TDP_32x1024(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 10;
 parameter DWIDTH = 32;
 
 	input			clk_a;
@@ -113,7 +167,7 @@ parameter DWIDTH = 32;
 	input      [DWIDTH-1:0] wd_b;
 
 BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_TDP_32x512 (.clk_a(clk_a),
+	BRAM_TDP_32x1024 (.clk_a(clk_a),
 		 .rce_a(rce_a),
 		 .ra_a(ra_a),
 		 .rq_a(rq_a),
@@ -130,7 +184,7 @@ BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
 
 endmodule
 
-module BRAM_TDP_16x1024(
+module BRAM_TDP_18x2048(
 	clk_a,
 	rce_a,
 	ra_a,
@@ -147,7 +201,60 @@ module BRAM_TDP_16x1024(
 	wd_b
 );
 
-parameter AWIDTH = 10;
+parameter AWIDTH = 11;
+parameter DWIDTH = 18;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_18x2048 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule
+
+module BRAM_TDP_16x2048(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 11;
 parameter DWIDTH = 16;
 
 	input			clk_a;
@@ -167,7 +274,7 @@ parameter DWIDTH = 16;
 	input      [DWIDTH-1:0] wd_b;
 
 BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_TDP_16x1024 (.clk_a(clk_a),
+	BRAM_TDP_16x2048 (.clk_a(clk_a),
 		 .rce_a(rce_a),
 		 .ra_a(ra_a),
 		 .rq_a(rq_a),
@@ -183,7 +290,7 @@ BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
 		 .wd_b(wd_b));
 endmodule
 
-module BRAM_TDP_8x2048(
+module BRAM_TDP_9x4096(
 	clk_a,
 	rce_a,
 	ra_a,
@@ -201,7 +308,61 @@ module BRAM_TDP_8x2048(
 	wd_b
 );
 
-parameter AWIDTH = 11;
+parameter AWIDTH = 12;
+parameter DWIDTH = 9;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_9x4096 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule
+
+module BRAM_TDP_8x4096(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 12;
 parameter DWIDTH = 8;
 
 	input			clk_a;
@@ -221,7 +382,7 @@ parameter DWIDTH = 8;
 	input      [DWIDTH-1:0] wd_b;
 
 BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_TDP_8x2048 (.clk_a(clk_a),
+	BRAM_TDP_8x4096 (.clk_a(clk_a),
 		 .rce_a(rce_a),
 		 .ra_a(ra_a),
 		 .rq_a(rq_a),
@@ -237,7 +398,7 @@ BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
 		 .wd_b(wd_b));
 endmodule
 
-module BRAM_TDP_4x4096(
+module BRAM_TDP_4x8192(
 	clk_a,
 	rce_a,
 	ra_a,
@@ -255,7 +416,7 @@ module BRAM_TDP_4x4096(
 	wd_b
 );
 
-parameter AWIDTH = 12;
+parameter AWIDTH = 13;
 parameter DWIDTH = 4;
 
 	input			clk_a;
@@ -275,7 +436,115 @@ parameter DWIDTH = 4;
 	input      [DWIDTH-1:0] wd_b;
 
 BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
-	BRAM_TDP_4x4096 (.clk_a(clk_a),
+	BRAM_TDP_4x8192 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule
+
+module BRAM_TDP_2x16384(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 14;
+parameter DWIDTH = 2;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_2x16384 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule
+
+module BRAM_TDP_1x32768(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 15;
+parameter DWIDTH = 1;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_2x32768 (.clk_a(clk_a),
 		 .rce_a(rce_a),
 		 .ra_a(ra_a),
 		 .rq_a(rq_a),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/Makefile
@@ -15,11 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = bram_tdp_tb.v
-POST_SYNTH = bram_tdp_32x512_post_synth bram_tdp_16x1024_post_synth bram_tdp_8x2048_post_synth bram_tdp_4x4096_post_synth
-ADDR_WIDTH = 9 10 11 12
-DATA_WIDTH = 32 16 8 4
-TOP = BRAM_TDP_32x512 BRAM_TDP_16x1024 BRAM_TDP_8x2048 BRAM_TDP_4x4096
-TEST_CASES = $(seq 0 3)
+POST_SYNTH = bram_tdp_36x1024_post_synth bram_tdp_32x1024_post_synth bram_tdp_18x2048_post_synth bram_tdp_16x2048_post_synth bram_tdp_9x4096_post_synth bram_tdp_8x4096_post_synth bram_tdp_4x8192_post_synth bram_tdp_2x16384_post_synth bram_tdp_1x32768_post_synth
+ADDR_WIDTH = 10 10 11 11 12 12 13 14 15
+DATA_WIDTH = 36 32 18 16 9 8 4 2 1
+TOP = BRAM_TDP_36x1024 BRAM_TDP_32x1024 BRAM_TDP_18x2048 BRAM_TDP_16x2048 BRAM_TDP_9x4096 BRAM_TDP_8x4096 BRAM_TDP_4x8192 BRAM_TDP_2x16384 BRAM_TDP_1x32768
 ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
 DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
 TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
@@ -36,8 +35,13 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
+# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call simulate_post_synth,2)
 	$(call simulate_post_synth,3)
 	$(call simulate_post_synth,4)
+	$(call simulate_post_synth,6)
+	$(call simulate_post_synth,7)
+	$(call simulate_post_synth,8)
+	$(call simulate_post_synth,9)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/Makefile
@@ -41,6 +41,7 @@ sim:
 	$(call simulate_post_synth,2)
 	$(call simulate_post_synth,3)
 	$(call simulate_post_synth,4)
+	$(call simulate_post_synth,5)
 	$(call simulate_post_synth,6)
 	$(call simulate_post_synth,7)
 	$(call simulate_post_synth,8)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/bram_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/bram_tdp_tb.v
@@ -159,8 +159,8 @@ module TB;
 	end
 
 	case (`STRINGIFY(`TOP))
-		"BRAM_TDP_32x512": begin
-			BRAM_TDP_32x512 #() bram (
+		"BRAM_TDP_36x1024": begin
+			BRAM_TDP_36x1024 #() bram (
 				.clk_a(clk_a),
 				.rce_a(rce_a),
 				.ra_a(ra_a),
@@ -177,8 +177,8 @@ module TB;
 				.wd_b(wd_b)
 			);
 		end
-		"BRAM_TDP_16x1024": begin
-			BRAM_TDP_16x1024 #() bram (
+		"BRAM_TDP_32x1024": begin
+			BRAM_TDP_32x1024 #() bram (
 				.clk_a(clk_a),
 				.rce_a(rce_a),
 				.ra_a(ra_a),
@@ -195,8 +195,8 @@ module TB;
 				.wd_b(wd_b)
 			);
 		end
-		"BRAM_TDP_8x2048": begin
-			BRAM_TDP_8x2048 #() bram (
+		"BRAM_TDP_18x2048": begin
+			BRAM_TDP_18x2048 #() bram (
 				.clk_a(clk_a),
 				.rce_a(rce_a),
 				.ra_a(ra_a),
@@ -213,8 +213,98 @@ module TB;
 				.wd_b(wd_b)
 			);
 		end
-		"BRAM_TDP_4x4096": begin
-			BRAM_TDP_4x4096 #() bram (
+		"BRAM_TDP_16x2048": begin
+			BRAM_TDP_16x2048 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_9x4096": begin
+			BRAM_TDP_9x4096 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_8x4096": begin
+			BRAM_TDP_8x4096 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_4x8192": begin
+			BRAM_TDP_4x8192 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_2x16384": begin
+			BRAM_TDP_2x16384 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_1x32768": begin
+			BRAM_TDP_1x32768 #() bram (
 				.clk_a(clk_a),
 				.rce_a(rce_a),
 				.ra_a(ra_a),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/bram_tdp_split.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/bram_tdp_split.tcl
@@ -1,0 +1,83 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram_tdp_split
+
+select BRAM_TDP_SPLIT_2x18x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x18x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x18x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp_split
+select BRAM_TDP_SPLIT_2x16x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x16x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x16x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp_split
+select BRAM_TDP_SPLIT_2x9x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x9x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x9x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp_split
+select BRAM_TDP_SPLIT_2x8x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x8x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x8x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp_split
+select BRAM_TDP_SPLIT_2x4x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x4x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x4x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp_split
+select BRAM_TDP_SPLIT_2x2x8192
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x2x8192
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x2x8192_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp_split
+select BRAM_TDP_SPLIT_2x1x16384
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x1x16384
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_tdp_split_2x1x16384_post_synth.v
+select -assert-count 1 t:TDP36K
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/bram_tdp_split.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/bram_tdp_split.v
@@ -1,0 +1,863 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+module BRAM_TDP_SPLIT #(parameter AWIDTH = 9,
+parameter DWIDTH = 32)(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output reg [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output reg [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+	reg        [DWIDTH-1:0] memory[0:(1<<AWIDTH)-1];
+
+	always @(posedge clk_a) begin
+		if (rce_a)
+			rq_a <= memory[ra_a];
+
+		if (wce_a)
+			memory[wa_a] <= wd_a;
+	end
+
+	always @(posedge clk_b) begin
+		if (rce_b)
+			rq_b <= memory[ra_b];
+
+		if (wce_b)
+			memory[wa_b] <= wd_b;
+	end
+
+	integer i;
+	initial
+	begin
+		for(i = 0; i < (1<<AWIDTH)-1; i = i + 1)
+			memory[i] = 0;
+	end
+
+endmodule
+
+module BRAM_TDP_SPLIT_2x18K #(parameter AWIDTH = 10, parameter DWIDTH = 18)(
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_0 (.clk_a(clk_a_0),
+		 .rce_a(rce_a_0),
+		 .ra_a(ra_a_0),
+		 .rq_a(rq_a_0),
+		 .wce_a(wce_a_0),
+		 .wa_a(wa_a_0),
+		 .wd_a(wd_a_0),
+		 .clk_b(clk_b_0),
+		 .rce_b(rce_b_0),
+		 .ra_b(ra_b_0),
+		 .rq_b(rq_b_0),
+		 .wce_b(wce_b_0),
+		 .wa_b(wa_b_0),
+		 .wd_b(wd_b_0));
+
+BRAM_TDP_SPLIT #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_1 (.clk_a(clk_a_1),
+		 .rce_a(rce_a_1),
+		 .ra_a(ra_a_1),
+		 .rq_a(rq_a_1),
+		 .wce_a(wce_a_1),
+		 .wa_a(wa_a_1),
+		 .wd_a(wd_a_1),
+		 .clk_b(clk_b_1),
+		 .rce_b(rce_b_1),
+		 .ra_b(ra_b_1),
+		 .rq_b(rq_b_1),
+		 .wce_b(wce_b_1),
+		 .wa_b(wa_b_1),
+		 .wd_b(wd_b_1));
+endmodule
+
+
+module BRAM_TDP_SPLIT_2x18x1024 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 10;
+parameter DWIDTH = 18;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x18x1024 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+
+
+module BRAM_TDP_SPLIT_2x16x1024 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 10;
+parameter DWIDTH = 16;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x16x1024 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+
+
+module BRAM_TDP_SPLIT_2x9x2048 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 11;
+parameter DWIDTH = 9;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x9x2048 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+
+module BRAM_TDP_SPLIT_2x8x2048 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 11;
+parameter DWIDTH = 8;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x8x2048 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+
+module BRAM_TDP_SPLIT_2x4x4096 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 12;
+parameter DWIDTH = 4;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x4x4096 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+
+module BRAM_TDP_SPLIT_2x2x8192 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 13;
+parameter DWIDTH = 2;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x2x8192 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+
+module BRAM_TDP_SPLIT_2x1x16384 (
+	clk_a_0,
+	rce_a_0,
+	ra_a_0,
+	rq_a_0,
+	wce_a_0,
+	wa_a_0,
+	wd_a_0,
+
+	clk_a_1,
+	rce_a_1,
+	ra_a_1,
+	rq_a_1,
+	wce_a_1,
+	wa_a_1,
+	wd_a_1,
+
+	clk_b_0,
+	rce_b_0,
+	ra_b_0,
+	rq_b_0,
+	wce_b_0,
+	wa_b_0,
+	wd_b_0,
+
+	clk_b_1,
+	rce_b_1,
+	ra_b_1,
+	rq_b_1,
+	wce_b_1,
+	wa_b_1,
+	wd_b_1
+);
+
+parameter AWIDTH = 14;
+parameter DWIDTH = 1;
+
+	input			clk_a_0;
+	input                   rce_a_0;
+	input      [AWIDTH-1:0] ra_a_0;
+	output     [DWIDTH-1:0] rq_a_0;
+	input                   wce_a_0;
+	input      [AWIDTH-1:0] wa_a_0;
+	input      [DWIDTH-1:0] wd_a_0;
+	input			clk_b_0;
+	input                   rce_b_0;
+	input      [AWIDTH-1:0] ra_b_0;
+	output     [DWIDTH-1:0] rq_b_0;
+	input                   wce_b_0;
+	input      [AWIDTH-1:0] wa_b_0;
+	input      [DWIDTH-1:0] wd_b_0;
+
+	input			clk_a_1;
+	input                   rce_a_1;
+	input      [AWIDTH-1:0] ra_a_1;
+	output     [DWIDTH-1:0] rq_a_1;
+	input                   wce_a_1;
+	input      [AWIDTH-1:0] wa_a_1;
+	input      [DWIDTH-1:0] wd_a_1;
+	input			clk_b_1;
+	input                   rce_b_1;
+	input      [AWIDTH-1:0] ra_b_1;
+	output     [DWIDTH-1:0] rq_b_1;
+	input                   wce_b_1;
+	input      [AWIDTH-1:0] wa_b_1;
+	input      [DWIDTH-1:0] wd_b_1;
+
+BRAM_TDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_SPLIT_2x1x16384 (
+		 .clk_a_0(clk_a_0),
+		 .rce_a_0(rce_a_0),
+		 .ra_a_0(ra_a_0),
+		 .rq_a_0(rq_a_0),
+		 .wce_a_0(wce_a_0),
+		 .wa_a_0(wa_a_0),
+		 .wd_a_0(wd_a_0),
+		 .clk_b_0(clk_b_0),
+		 .rce_b_0(rce_b_0),
+		 .ra_b_0(ra_b_0),
+		 .rq_b_0(rq_b_0),
+		 .wce_b_0(wce_b_0),
+		 .wa_b_0(wa_b_0),
+		 .wd_b_0(wd_b_0),
+		 .clk_a_1(clk_a_1),
+		 .rce_a_1(rce_a_1),
+		 .ra_a_1(ra_a_1),
+		 .rq_a_1(rq_a_1),
+		 .wce_a_1(wce_a_1),
+		 .wa_a_1(wa_a_1),
+		 .wd_a_1(wd_a_1),
+		 .clk_b_1(clk_b_1),
+		 .rce_b_1(rce_b_1),
+		 .ra_b_1(ra_b_1),
+		 .rq_b_1(rq_b_1),
+		 .wce_b_1(wce_b_1),
+		 .wa_b_1(wa_b_1),
+		 .wd_b_1(wd_b_1));
+endmodule
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/sim/Makefile
@@ -31,6 +31,7 @@ endef
 sim:
 	$(call simulate_post_synth,1)
 	$(call simulate_post_synth,2)
+	$(call simulate_post_synth,3)
 	$(call simulate_post_synth,4)
 	$(call simulate_post_synth,5)
 	$(call simulate_post_synth,6)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/sim/Makefile
@@ -1,0 +1,37 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = bram_tdp_split_tb.v
+POST_SYNTH = bram_tdp_split_2x18x1024_post_synth bram_tdp_split_2x16x1024_post_synth bram_tdp_split_2x9x2048_post_synth bram_tdp_split_2x8x2048_post_synth bram_tdp_split_2x4x4096_post_synth bram_tdp_split_2x2x8192_post_synth bram_tdp_split_2x1x16384_post_synth
+ADDR_WIDTH = 10 10 11 11 12 13 14
+DATA_WIDTH = 18 16 9 8 4 2 1
+TOP = BRAM_TDP_SPLIT_2x18x1024 BRAM_TDP_SPLIT_2x16x1024 BRAM_TDP_SPLIT_2x9x2048 BRAM_TDP_SPLIT_2x8x2048 BRAM_TDP_SPLIT_2x4x4096 BRAM_TDP_SPLIT_2x2x8192 BRAM_TDP_SPLIT_2x1x16384
+ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
+DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR_DEFINES)) $(word $(1),$(DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call simulate_post_synth,2)
+	$(call simulate_post_synth,4)
+	$(call simulate_post_synth,5)
+	$(call simulate_post_synth,6)
+	$(call simulate_post_synth,7)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/sim/bram_tdp_split_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/sim/bram_tdp_split_tb.v
@@ -1,0 +1,415 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_a;
+	reg rce_a;
+	reg [`ADDR_WIDTH-1:0] ra_a;
+	wire [`DATA_WIDTH-1:0] rq_a_0;
+	wire [`DATA_WIDTH-1:0] rq_a_1;
+	reg wce_a;
+	reg [`ADDR_WIDTH-1:0] wa_a;
+	reg [`DATA_WIDTH-1:0] wd_a_0;
+	reg [`DATA_WIDTH-1:0] wd_a_1;
+
+	reg clk_b;
+	reg rce_b;
+	reg [`ADDR_WIDTH-1:0] ra_b;
+	wire [`DATA_WIDTH-1:0] rq_b_0;
+	wire [`DATA_WIDTH-1:0] rq_b_1;
+	reg wce_b;
+	reg [`ADDR_WIDTH-1:0] wa_b;
+	reg [`DATA_WIDTH-1:0] wd_b_0;
+	reg [`DATA_WIDTH-1:0] wd_b_1;
+
+
+	initial clk_a = 0;
+	initial clk_b = 0;
+	initial ra_a = 0;
+	initial ra_b = 0;
+	initial rce_a = 0;
+	initial rce_b = 0;
+	initial forever #(PERIOD / 2.0) clk_a = ~clk_a;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_b = ~clk_b;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_a;
+	reg done_b;
+	initial done_a = 1'b0;
+	initial done_b = 1'b0;
+	wire done_sim = done_a & done_b;
+
+	reg [`DATA_WIDTH-1:0] expected_a_0;
+	reg [`DATA_WIDTH-1:0] expected_a_1;
+	reg [`DATA_WIDTH-1:0] expected_b_0;
+	reg [`DATA_WIDTH-1:0] expected_b_1;
+
+	always @(posedge clk_a) begin
+		expected_a_0 <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+		expected_a_1 <= ((a+1) | ((a+1) << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+	always @(posedge clk_b) begin
+		expected_b_0 <= ((b+2) | ((b+2) << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+		expected_b_1 <= ((b+3) | ((b+3) << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+
+	wire error_a_0 = a != 0 ? (rq_a_0 !== expected_a_0) : 0;
+	wire error_a_1 = a != 0 ? (rq_a_1 !== expected_a_1) : 0;
+	wire error_b_0 = b != (1<<`ADDR_WIDTH) / 2 ? (rq_b_0 !== expected_b_0) : 0;
+	wire error_b_1 = b != (1<<`ADDR_WIDTH) / 2 ? (rq_b_1 !== expected_b_1) : 0;
+
+	integer error_a_0_cnt = 0;
+	integer error_a_1_cnt = 0;
+	integer error_b_0_cnt = 0;
+	integer error_b_1_cnt = 0;
+
+	always @ (posedge clk_a)
+	begin
+		if (error_a_0)
+			error_a_0_cnt <= error_a_0_cnt + 1'b1;
+		if (error_a_1)
+			error_a_1_cnt <= error_a_1_cnt + 1'b1;
+	end
+	always @ (posedge clk_b)
+	begin
+		if (error_b_0)
+			error_b_0_cnt <= error_b_0_cnt + 1'b1;
+		if (error_b_1)
+			error_b_1_cnt <= error_b_1_cnt + 1'b1;
+	end
+
+	// PORTs A
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				wa_a = a;
+				wd_a_0 = a | (a << 20) | 20'h55000;
+				wd_a_1 = (a+1) | ((a+1) << 20) | 20'h55000;
+				wce_a = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) wce_a = 0;
+			end
+		end
+		// Read data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				ra_a = a;
+				rce_a = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) rce_a = 0;
+				if ( rq_a_0 !== expected_a_0) begin
+					$display("%d: PORT A0: FAIL: mismatch act=%x exp=%x at %x", $time, rq_a_0, expected_a_0, a);
+				end else begin
+					$display("%d: PORT A0: OK: act=%x exp=%x at %x", $time, rq_a_0, expected_a_0, a);
+				end
+				if ( rq_a_1 !== expected_a_1) begin
+					$display("%d: PORT A1: FAIL: mismatch act=%x exp=%x at %x", $time, rq_a_1, expected_a_1, a);
+				end else begin
+					$display("%d: PORT A1: OK: act=%x exp=%x at %x", $time, rq_a_1, expected_a_1, a);
+				end
+			end
+		end
+		done_a = 1'b1;
+	end
+
+	// PORTs B
+	initial #(1) begin
+		// Write data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				wa_b = b;
+				wd_b_0 = (b+2) | ((b+2) << 20) | 20'h55000;
+				wd_b_1 = (b+3) | ((b+3) << 20) | 20'h55000;
+				wce_b = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) wce_b = 0;
+			end
+		end
+		// Read data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				ra_b = b;
+				rce_b = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) rce_b = 0;
+				if ( rq_b_0 !== expected_b_0) begin
+					$display("%d: PORT B0: FAIL: mismatch act=%x exp=%x at %x", $time, rq_b_0, expected_b_0, b);
+				end else begin
+					$display("%d: PORT B0: OK: act=%x exp=%x at %x", $time, rq_b_0, expected_b_0, b);
+				end
+				if ( rq_b_1 !== expected_b_1) begin
+					$display("%d: PORT B1: FAIL: mismatch act=%x exp=%x at %x", $time, rq_b_1, expected_b_1, b);
+				end else begin
+					$display("%d: PORT B1: OK: act=%x exp=%x at %x", $time, rq_b_1, expected_b_1, b);
+				end
+			end
+		end
+		done_b = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk_a, posedge clk_b) begin
+		if (done_sim)
+			$finish_and_return( (error_a_0_cnt == 0 & error_b_0_cnt == 0 & error_a_1_cnt == 0 & error_b_1_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"BRAM_TDP_SPLIT_2x18x1024": begin
+			BRAM_TDP_SPLIT_2x18x1024 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+		"BRAM_TDP_SPLIT_2x16x1024": begin
+			BRAM_TDP_SPLIT_2x16x1024 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+		"BRAM_TDP_SPLIT_2x9x2048": begin
+			BRAM_TDP_SPLIT_2x9x2048 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+		"BRAM_TDP_SPLIT_2x8x2048": begin
+			BRAM_TDP_SPLIT_2x8x2048 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+		"BRAM_TDP_SPLIT_2x4x4096": begin
+			BRAM_TDP_SPLIT_2x4x4096 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+		"BRAM_TDP_SPLIT_2x2x8192": begin
+			BRAM_TDP_SPLIT_2x2x8192 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+		"BRAM_TDP_SPLIT_2x1x16384": begin
+			BRAM_TDP_SPLIT_2x1x16384 #() bram (
+				.clk_a_0(clk_a),
+				.rce_a_0(rce_a),
+				.ra_a_0(ra_a),
+				.rq_a_0(rq_a_0),
+				.wce_a_0(wce_a),
+				.wa_a_0(wa_a),
+				.wd_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.rce_b_0(rce_b),
+				.ra_b_0(ra_b),
+				.rq_b_0(rq_b_0),
+				.wce_b_0(wce_b),
+				.wa_b_0(wa_b),
+				.wd_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.rce_a_1(rce_a),
+				.ra_a_1(ra_a),
+				.rq_a_1(rq_a_1),
+				.wce_a_1(wce_a),
+				.wa_a_1(wa_a),
+				.wd_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.rce_b_1(rce_b),
+				.ra_b_1(ra_b),
+				.rq_b_1(rq_b_1),
+				.wce_b_1(wce_b),
+				.wa_b_1(wa_b),
+				.wd_b_1(wd_b_1)
+			);
+		end
+	endcase
+endmodule


### PR DESCRIPTION
This PR introduces new BRAM inference possibilities for `qlf_k6n10f` devices. Yosys is now able to use 2 halves of TDP36K modules and merge them into single TDP36K cell in final techmap step. I also added tests cover all 2x18K bram variants and extended the tests for regular TDP36K