### PR TITLE
Make access to nexus-dsp_rules.txt in tests location indpenedent.

### DIFF
--- a/dsp-ff-plugin/dsp_ff.cc
+++ b/dsp-ff-plugin/dsp_ff.cc
@@ -289,7 +289,7 @@ struct DspFF : public Pass {
 
         log("Loading rules from '%s'...\n", a_FileName.c_str());
         if (!file) {
-            log_error(" Error opening file!\n");
+            log_error(" Error opening file '%s'!\n", a_FileName.c_str());
         }
 
         // Parse each port as if it was associated with its own DSP register.

--- a/dsp-ff-plugin/tests/nexus_conn_conflict/nexus_conn_conflict.tcl
+++ b/dsp-ff-plugin/tests/nexus_conn_conflict/nexus_conn_conflict.tcl
@@ -2,6 +2,8 @@ yosys -import
 if { [info procs dsp_ff] == {} } { plugin -i dsp-ff }
 yosys -import  ;# ingest plugin commands
 
+set DSP_RULES [file dirname $::env(DESIGN_TOP)]/../../nexus-dsp_rules.txt
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -10,7 +12,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -22,7 +24,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 18 t:FD1P3IX
@@ -32,7 +34,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 18 t:FD1P3DX
@@ -42,7 +44,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 18 t:FD1P3IX
@@ -52,7 +54,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 9 t:FD1P3IX

--- a/dsp-ff-plugin/tests/nexus_conn_share/nexus_conn_share.tcl
+++ b/dsp-ff-plugin/tests/nexus_conn_share/nexus_conn_share.tcl
@@ -2,6 +2,8 @@ yosys -import
 if { [info procs dsp_ff] == {} } { plugin -i dsp-ff }
 yosys -import  ;# ingest plugin commands
 
+set DSP_RULES [file dirname $::env(DESIGN_TOP)]/../../nexus-dsp_rules.txt
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -10,7 +12,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 18 t:FD1P3IX
@@ -20,7 +22,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 18 t:FD1P3IX
@@ -30,7 +32,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 9 t:FD1P3IX
@@ -40,9 +42,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 9 t:FD1P3IX
-
-

--- a/dsp-ff-plugin/tests/nexus_fftypes/nexus_fftypes.tcl
+++ b/dsp-ff-plugin/tests/nexus_fftypes/nexus_fftypes.tcl
@@ -2,6 +2,8 @@ yosys -import
 if { [info procs dsp_ff] == {} } { plugin -i dsp-ff }
 yosys -import  ;# ingest plugin commands
 
+set DSP_RULES [file dirname $::env(DESIGN_TOP)]/../../nexus-dsp_rules.txt
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -10,7 +12,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -23,7 +25,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -36,7 +38,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -49,7 +51,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -62,7 +64,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat

--- a/dsp-ff-plugin/tests/nexus_mult/nexus_mult.tcl
+++ b/dsp-ff-plugin/tests/nexus_mult/nexus_mult.tcl
@@ -2,6 +2,8 @@ yosys -import
 if { [info procs dsp_ff] == {} } { plugin -i dsp-ff }
 yosys -import  ;# ingest plugin commands
 
+set DSP_RULES [file dirname $::env(DESIGN_TOP)]/../../nexus-dsp_rules.txt
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -10,7 +12,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -22,7 +24,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -34,7 +36,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -50,7 +52,7 @@ select -assert-count 0 t:FD1P3IX
 #hierarchy -top ${TOP}
 #synth_nexus -flatten
 #techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-#equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+#equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 #design -load postopt
 #yosys cd ${TOP}
 #stat

--- a/dsp-ff-plugin/tests/nexus_mult_wide/nexus_mult_wide.tcl
+++ b/dsp-ff-plugin/tests/nexus_mult_wide/nexus_mult_wide.tcl
@@ -2,6 +2,8 @@ yosys -import
 if { [info procs dsp_ff] == {} } { plugin -i dsp-ff }
 yosys -import  ;# ingest plugin commands
 
+set DSP_RULES [file dirname $::env(DESIGN_TOP)]/../../nexus-dsp_rules.txt
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -10,7 +12,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat

--- a/dsp-ff-plugin/tests/nexus_param_conflict/nexus_param_conflict.tcl
+++ b/dsp-ff-plugin/tests/nexus_param_conflict/nexus_param_conflict.tcl
@@ -2,6 +2,8 @@ yosys -import
 if { [info procs dsp_ff] == {} } { plugin -i dsp-ff }
 yosys -import  ;# ingest plugin commands
 
+set DSP_RULES [file dirname $::env(DESIGN_TOP)]/../../nexus-dsp_rules.txt
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -10,7 +12,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 18 t:FD1P3IX
@@ -20,7 +22,7 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ../../nexus-dsp_rules.txt
+equiv_opt -assert -async2sync -map +/nexus/cells_sim.v debug dsp_ff -rules ${DSP_RULES}
 design -load postopt
 yosys cd ${TOP}
 stat
@@ -32,9 +34,8 @@ design -load read
 hierarchy -top ${TOP}
 synth_nexus -flatten
 techmap -map +/nexus/cells_sim.v t:VLO t:VHI %u ;# Unmap VHI and VLO
-debug dsp_ff -rules ../../nexus-dsp_rules.txt
+debug dsp_ff -rules ${DSP_RULES}
 stat
 select -assert-count 1 t:MULT9X9
 select -assert-count 4 t:FD1P3IX
 select -assert-count 5 t:FD1P3DX
-


### PR DESCRIPTION
Making the access to the dsp rules relative to DESIGN_TOP makes
it easier to invoke the TCL script from any path.

Signed-off-by: Henner Zeller <h.zeller@acm.org>