### PR TITLE
SystemVerilog: fix read_uhdm frontend

### DIFF
--- a/systemverilog-plugin/uhdmcommonfrontend.cc
+++ b/systemverilog-plugin/uhdmcommonfrontend.cc
@@ -112,6 +112,7 @@ void UhdmCommonFrontend::execute(std::istream *&f, std::string filename, std::ve
             unhandled_args.push_back(args[i]);
         }
     }
+    extra_args(f, filename, args, args.size() - 1);
     // pass only unhandled args to Surelog
     // unhandled args starts with command name,
     // but Surelog expects args[0] to be program name


### PR DESCRIPTION
Related to: https://github.com/chipsalliance/yosys-f4pga-plugins/pull/291

``extra_args`` is necessary for ``read_uhdm`` frontend as it sets filename.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>