### PR TITLE
systemverilog: abort execution when Surelog report error in design

### DIFF
--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -70,10 +70,10 @@ std::vector<vpiHandle> executeCompilation(SURELOG::SymbolTable *symbolTable, SUR
     if (noFErrors == false) {
         noFatalErrors = false;
     }
-    if ((!noFatalErrors) || (!success))
+    if ((!noFatalErrors) || (!success) || (errors->getErrorStats().nbError))
         codedReturn |= 1;
     if (codedReturn) {
-        log_error("Encoraged fatal error when executing Surelog. Aborting!\n");
+        log_error("Error when parsing design. Aborting!\n");
     }
     return the_design;
 }


### PR DESCRIPTION
Abort execution when Surelog report error in design. Up to now, we only aborted when Surelog reported fatal error.

Ref: https://github.com/chipsalliance/f4pga-examples/issues/290
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>