### PR TITLE
systemverilog: add -parse-only flag

### DIFF
--- a/systemverilog-plugin/uhdmastshared.h
+++ b/systemverilog-plugin/uhdmastshared.h
@@ -38,6 +38,10 @@ class UhdmAstShared
     // Flag that determines whether errors should be fatal
     bool stop_on_error = true;
 
+    // Flag that determines whether we should only parse the design
+    // applies only to read_systemverilog command
+    bool parse_only = false;
+
     // Top nodes of the design (modules, interfaces)
     std::unordered_map<std::string, AST::AstNode *> top_nodes;
 

--- a/systemverilog-plugin/uhdmcommonfrontend.cc
+++ b/systemverilog-plugin/uhdmcommonfrontend.cc
@@ -63,6 +63,10 @@ void UhdmCommonFrontend::print_read_options()
     log("        only read the abstract syntax tree and defer actual compilation\n");
     log("        to a later 'hierarchy' command. Useful in cases where the default\n");
     log("        parameters of modules yield invalid or not synthesizable code.\n");
+    log("    -parse-only\n");
+    log("        this parameter only applies to read_systemverilog command,\n");
+    log("        it runs only Surelog to parse design, but doesn't load generated\n");
+    log("        tree into Yosys.\n");
     log("\n");
 }
 
@@ -108,6 +112,8 @@ void UhdmCommonFrontend::execute(std::istream *&f, std::string filename, std::ve
             dump_rtlil = true;
         } else if (args[i] == "-yydebug") {
             this->shared.debug_flag = true;
+        } else if (args[i] == "-parse-only") {
+            this->shared.parse_only = true;
         } else {
             unhandled_args.push_back(args[i]);
         }
@@ -128,9 +134,11 @@ void UhdmCommonFrontend::execute(std::istream *&f, std::string filename, std::ve
 
     AST::AstNode *current_ast = parse(filename);
 
-    AST::process(design, current_ast, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil, false, false, false, false, false, false,
-                 false, false, false, false, dont_redefine, false, defer, default_nettype_wire);
-    delete current_ast;
+    if (current_ast) {
+        AST::process(design, current_ast, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil, false, false, false, false, false,
+                     false, false, false, false, false, dont_redefine, false, defer, default_nettype_wire);
+        delete current_ast;
+    }
 }
 
 YOSYS_NAMESPACE_END

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -124,6 +124,10 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         delete clp;
         delete symbolTable;
         delete errors;
+        // on parse_only mode, don't try to load design
+        // into yosys
+        if (this->shared.parse_only)
+            return nullptr;
 
         UhdmAst uhdm_ast(this->shared);
         AST::AstNode *current_ast = uhdm_ast.visit_designs(uhdm_design);


### PR DESCRIPTION
This flag can be used to only check designs, but don't load them into yosys

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>