### PR TITLE
Systemverilog: adapt to current Surelog

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3363,6 +3363,32 @@ void UhdmAst::process_int_typespec()
     current_node->is_signed = true;
 }
 
+void UhdmAst::process_shortint_typespec()
+{
+    std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
+    std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
+    current_node = make_ast_node(AST::AST_WIRE);
+    auto left_const = AST::AstNode::mkconst_int(16, true);
+    auto right_const = AST::AstNode::mkconst_int(0, true);
+    auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
+    packed_ranges.push_back(range);
+    add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
+    current_node->is_signed = true;
+}
+
+void UhdmAst::process_time_typespec()
+{
+    std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
+    std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
+    current_node = make_ast_node(AST::AST_WIRE);
+    auto left_const = AST::AstNode::mkconst_int(64, true);
+    auto right_const = AST::AstNode::mkconst_int(0, true);
+    auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
+    packed_ranges.push_back(range);
+    add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
+    current_node->is_signed = false;
+}
+
 void UhdmAst::process_string_var()
 {
     current_node = make_ast_node(AST::AST_WIRE);
@@ -3992,6 +4018,12 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case vpiIntTypespec:
     case vpiIntegerTypespec:
         process_int_typespec();
+        break;
+    case vpiShortIntTypespec:
+        process_shortint_typespec();
+        break;
+    case vpiTimeTypespec:
+        process_time_typespec();
         break;
     case vpiBitTypespec:
         process_bit_typespec();

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2177,11 +2177,15 @@ void UhdmAst::process_array_net(const UHDM::BaseClass *object)
         if (net_type == vpiLogicNet) {
             current_node->is_logic = true;
             current_node->is_signed = vpi_get(vpiSigned, net_h);
-            if (vpiHandle typespec_h = vpi_handle(vpiTypespec, net_h)) {
+            vpiHandle typespec_h = vpi_handle(vpiTypespec, net_h);
+            if (!typespec_h) {
+                typespec_h = vpi_handle(vpiTypespec, obj_h);
+            }
+            if (typespec_h) {
                 visit_one_to_many({vpiRange}, typespec_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
                 vpi_release_handle(typespec_h);
             } else {
-                log_error("%s:%d: No typespec found for array net %s\n", object->VpiFile().c_str(), object->VpiLineNo(), current_node->str.c_str());
+                visit_one_to_many({vpiRange}, net_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
             }
             shared.report.mark_handled(net_h);
         } else if (net_type == vpiStructNet) {

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3622,7 +3622,10 @@ void UhdmAst::process_net()
             current_node->is_custom_type = true;
         }
     });
-    visit_one_to_many({vpiRange}, obj_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
+    if(vpiHandle typespec_h = vpi_handle(vpiTypespec, obj_h)) {
+        visit_one_to_many({vpiRange}, typespec_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
+        vpi_release_handle(typespec_h);
+    }
     add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
 }
 

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3981,7 +3981,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case vpiHierPath:
         process_hier_path();
         break;
-    case UHDM::uhdmimport:
+    case UHDM::uhdmimport_typespec:
         break;
     case vpiDelayControl:
         process_nonsynthesizable(object);

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3360,10 +3360,7 @@ void UhdmAst::process_int_typespec()
     std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
     std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
     current_node = make_ast_node(AST::AST_WIRE);
-    auto left_const = AST::AstNode::mkconst_int(31, true);
-    auto right_const = AST::AstNode::mkconst_int(0, true);
-    auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
-    packed_ranges.push_back(range);
+    packed_ranges.push_back(make_range(31, 0));
     add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
     current_node->is_signed = true;
 }
@@ -3373,10 +3370,7 @@ void UhdmAst::process_shortint_typespec()
     std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
     std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
     current_node = make_ast_node(AST::AST_WIRE);
-    auto left_const = AST::AstNode::mkconst_int(16, true);
-    auto right_const = AST::AstNode::mkconst_int(0, true);
-    auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
-    packed_ranges.push_back(range);
+    packed_ranges.push_back(make_range(16, 0));
     add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
     current_node->is_signed = true;
 }
@@ -3386,10 +3380,7 @@ void UhdmAst::process_time_typespec()
     std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
     std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
     current_node = make_ast_node(AST::AST_WIRE);
-    auto left_const = AST::AstNode::mkconst_int(64, true);
-    auto right_const = AST::AstNode::mkconst_int(0, true);
-    auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
-    packed_ranges.push_back(range);
+    packed_ranges.push_back(make_range(64, 0));
     add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
     current_node->is_signed = false;
 }

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3588,7 +3588,7 @@ void UhdmAst::process_net()
     current_node->is_logic = !current_node->is_reg;
     current_node->is_signed = vpi_get(vpiSigned, obj_h);
     visit_one_to_one({vpiTypespec}, obj_h, [&](AST::AstNode *node) {
-        if (node) {
+        if (node && !node->str.empty()) {
             auto wiretype_node = new AST::AstNode(AST::AST_WIRETYPE);
             wiretype_node->str = node->str;
             // wiretype needs to be 1st node
@@ -3636,9 +3636,11 @@ void UhdmAst::process_parameter()
         }
         case vpiStructTypespec: {
             visit_one_to_one({vpiTypespec}, obj_h, [&](AST::AstNode *node) {
-                auto wiretype_node = make_ast_node(AST::AST_WIRETYPE);
-                wiretype_node->str = node->str;
-                current_node->children.push_back(wiretype_node);
+                if (node && !node->str.empty()) {
+                    auto wiretype_node = make_ast_node(AST::AST_WIRETYPE);
+                    wiretype_node->str = node->str;
+                    current_node->children.push_back(wiretype_node);
+                }
                 current_node->is_custom_type = true;
                 auto it = shared.param_types.find(current_node->str);
                 if (it == shared.param_types.end())

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -90,7 +90,7 @@ class UhdmAst
     void process_assignment();
     void process_net();
     void process_packed_array_net();
-    void process_array_net();
+    void process_array_net(const UHDM::BaseClass *object);
     void process_package();
     void process_interface();
     void process_modport();

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -126,6 +126,8 @@ class UhdmAst
     void process_hier_path();
     void process_logic_typespec();
     void process_int_typespec();
+    void process_shortint_typespec();
+    void process_time_typespec();
     void process_bit_typespec();
     void process_string_var();
     void process_string_typespec();


### PR DESCRIPTION
* Update `import_typespec` case
* Handle shortint and time typespecs
* Fix packed ranges access in nets