### PR TITLE
systemverilog: Add warnings to post inc/dec operations

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2575,7 +2575,11 @@ void UhdmAst::process_operation(const UHDM::BaseClass *object)
         case vpiPowerOp:
             current_node->type = AST::AST_POW;
             break;
-        case vpiPostIncOp: // TODO: Make this an actual post-increment op (currently it's a pre-increment)
+        case vpiPostIncOp: {
+            // TODO: Make this an actual post-increment op (currently it's a pre-increment)
+            log_warning("%s:%d: Post-incrementation operations are handled as pre-incrementation.\n", object->VpiFile().c_str(), object->VpiLineNo());
+        }
+        // fallthrough
         case vpiPreIncOp: {
             current_node->type = AST::AST_ASSIGN_EQ;
             auto id = current_node->children[0]->clone();
@@ -2585,7 +2589,11 @@ void UhdmAst::process_operation(const UHDM::BaseClass *object)
             current_node->children.push_back(add_node);
             break;
         }
-        case vpiPostDecOp: // TODO: Make this an actual post-decrement op (currently it's a pre-decrement)
+        case vpiPostDecOp: {
+            // TODO: Make this an actual post-decrement op (currently it's a pre-decrement)
+            log_warning("%s:%d: Post-decrementation operations are handled as pre-decrementation.\n", object->VpiFile().c_str(), object->VpiLineNo());
+        }
+        // fallthrough
         case vpiPreDecOp: {
             current_node->type = AST::AST_ASSIGN_EQ;
             auto id = current_node->children[0]->clone();


### PR DESCRIPTION
It's okay to do this but we should warn as this may cause bugs in some cases.