### PR TITLE
systemverilog: add dedicated wildcard operator errors

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2437,6 +2437,13 @@ void UhdmAst::process_operation()
     case vpiAssignmentPatternOp:
         process_assignment_pattern_op();
         break;
+    case vpiWildEqOp:
+    case vpiWildNeqOp: {
+        const uhdm_handle *const handle = (const uhdm_handle *)obj_h;
+        const UHDM::BaseClass *const object = (const UHDM::BaseClass *)handle->object;
+        report_error("%s:%d: Wildcard operators are not supported yet\n", object->VpiFile().c_str(), object->VpiLineNo());
+        break;
+    }
     default: {
         current_node = make_ast_node(AST::AST_NONE);
         visit_one_to_many({vpiOperand}, obj_h, [&](AST::AstNode *node) {

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2417,7 +2417,7 @@ void UhdmAst::process_begin(bool is_named)
     });
 }
 
-void UhdmAst::process_operation()
+void UhdmAst::process_operation(const UHDM::BaseClass *object)
 {
     auto operation = vpi_get(vpiOpType, obj_h);
     switch (operation) {
@@ -2439,8 +2439,6 @@ void UhdmAst::process_operation()
         break;
     case vpiWildEqOp:
     case vpiWildNeqOp: {
-        const uhdm_handle *const handle = (const uhdm_handle *)obj_h;
-        const UHDM::BaseClass *const object = (const UHDM::BaseClass *)handle->object;
         report_error("%s:%d: Wildcard operators are not supported yet\n", object->VpiFile().c_str(), object->VpiLineNo());
         break;
     }
@@ -2635,8 +2633,6 @@ void UhdmAst::process_operation()
         default: {
             delete current_node;
             current_node = nullptr;
-            const uhdm_handle *const handle = (const uhdm_handle *)obj_h;
-            const UHDM::BaseClass *const object = (const UHDM::BaseClass *)handle->object;
             report_error("%s:%d: Encountered unhandled operation type %d\n", object->VpiFile().c_str(), object->VpiLineNo(), operation);
         }
         }
@@ -3902,7 +3898,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         break;
     case vpiCondition:
     case vpiOperation:
-        process_operation();
+        process_operation(object);
         break;
     case vpiTaggedPattern:
         process_tagged_pattern();

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -99,7 +99,7 @@ class UhdmAst
     void process_event_control(const UHDM::BaseClass *object);
     void process_initial();
     void process_begin(bool is_named);
-    void process_operation();
+    void process_operation(const UHDM::BaseClass *object);
     void process_stream_op();
     void process_list_op();
     void process_cast_op();


### PR DESCRIPTION
This should make it easier for users to understand the issues they're getting, for example here: https://github.com/antmicro/yosys-uhdm-plugin-integration/issues/679