### PR TITLE
ql-qlf: k6n10f: Add support for new DSP cells

### DIFF
--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -22,7 +22,8 @@ SOURCES = synth_quicklogic.cc \
           ql-edif.cc \
           ql-dsp-simd.cc \
           ql-dsp-macc.cc \
-          ql-bram-split.cc
+          ql-bram-split.cc \
+          ql-dsp-io-regs.cc
 
 DEPS = pmgen/ql-dsp-pm.h \
        pmgen/ql-dsp-macc.h

--- a/ql-qlf-plugin/ql-dsp-io-regs.cc
+++ b/ql-qlf-plugin/ql-dsp-io-regs.cc
@@ -1,0 +1,119 @@
+#include "kernel/sigtools.h"
+#include "kernel/yosys.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+// ============================================================================
+
+const std::vector<std::string> ports2del_mult = {"feedback", "load_acc", "saturate_enable", "shift_right", "round", "subtract", "acc_fir", "dly_b"};
+const std::vector<std::string> ports2del_mult_add_acc = {"saturate_enable", "shift_right", "round", "acc_fir", "dly_b"};
+
+void ql_dsp_io_regs_pass(RTLIL::Module *module)
+{
+
+    for (auto cell : module->cells_) {
+        std::string cell_type = cell.second->type.str();
+        if (cell_type == RTLIL::escape_id("QL_DSP2")) {
+            auto dsp = cell.second;
+            bool del_clk = false;
+
+            // Get DSP configuration
+            const RTLIL::SigSpec *register_inputs;
+            register_inputs = &dsp->getPort(RTLIL::escape_id("register_inputs"));
+            if (!register_inputs)
+                log_error("register_inputs port not found!");
+            auto reg_in_c = register_inputs->as_const();
+            int reg_in_i = reg_in_c.as_int();
+
+            const RTLIL::SigSpec *output_select;
+            output_select = &dsp->getPort(RTLIL::escape_id("output_select"));
+            if (!output_select)
+                log_error("output_select port not found!");
+            auto out_sel_c = output_select->as_const();
+            int out_sel_i = out_sel_c.as_int();
+
+            // Build new type name
+            std::string new_type = cell_type;
+            new_type += "_MULT";
+
+            switch (out_sel_i) {
+            case 1:
+                new_type += "ACC";
+                break;
+            case 2:
+            case 3:
+                new_type += "ADD";
+                break;
+            case 5:
+                new_type += "ACC";
+                break;
+            case 6:
+            case 7:
+                new_type += "ADD";
+                break;
+            default:
+                break;
+            }
+
+            if (reg_in_i)
+                new_type += "_REGIN";
+
+            if (out_sel_i > 3)
+                new_type += "_REGOUT";
+
+            // Set new type name
+            dsp->type = RTLIL::IdString(new_type);
+
+            // Delete ports unused in given type of DSP cell
+            del_clk = (!reg_in_i && out_sel_i <= 3);
+
+            std::vector<std::string> ports2del;
+
+            if (del_clk)
+                ports2del.push_back("clk");
+
+            if (out_sel_i == 0 || out_sel_i == 4) {
+                ports2del.insert(ports2del.end(), ports2del_mult.begin(), ports2del_mult.end());
+            } else {
+                ports2del.insert(ports2del.end(), ports2del_mult_add_acc.begin(), ports2del_mult_add_acc.end());
+            }
+
+            for (auto portname : ports2del) {
+                const RTLIL::SigSpec *port = &dsp->getPort(RTLIL::escape_id(portname));
+                if (!port)
+                    log_error("%s port not found!", portname);
+                dsp->connections_.erase(RTLIL::escape_id(portname));
+            }
+        }
+    }
+}
+
+struct QlDspIORegs : public Pass {
+
+    QlDspIORegs() : Pass("ql_dsp_io_regs", "Does something") {}
+
+    void help() override
+    {
+        log("\n");
+        log("    ql_dsp_io_regs [options] [selection]\n");
+        log("\n");
+    }
+
+    void execute(std::vector<std::string> a_Args, RTLIL::Design *a_Design) override
+    {
+        log_header(a_Design, "Executing QL_DSP_IO_REGS pass.\n");
+
+        size_t argidx;
+        for (argidx = 1; argidx < a_Args.size(); argidx++) {
+            break;
+        }
+        extra_args(a_Args, argidx, a_Design);
+
+        for (auto module : a_Design->selected_modules()) {
+            ql_dsp_io_regs_pass(module);
+        }
+    }
+} QlDspIORegs;
+
+PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/ql-dsp-macc.cc
+++ b/ql-qlf-plugin/ql-dsp-macc.cc
@@ -56,7 +56,7 @@ void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
     }
 
     // Accept only posedge clocked FFs
-    if (st.ff->getParam(ID(CLK_POLARITY)) != RTLIL::S1) {
+    if (st.ff->getParam(ID(CLK_POLARITY)).as_int() != 1) {
         return;
     }
 
@@ -151,7 +151,7 @@ void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
     RTLIL::SigSpec ena;
 
     if (st.ff->hasPort(ID(ARST))) {
-        if (st.ff->getParam(ID(ARST_POLARITY)) != RTLIL::S1) {
+        if (st.ff->getParam(ID(ARST_POLARITY)).as_int() != 1) {
             rst = pm.module->Not(NEW_ID, st.ff->getPort(ID(ARST)));
         } else {
             rst = st.ff->getPort(ID(ARST));
@@ -161,7 +161,7 @@ void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
     }
 
     if (st.ff->hasPort(ID(EN))) {
-        if (st.ff->getParam(ID(EN_POLARITY)) != RTLIL::S1) {
+        if (st.ff->getParam(ID(EN_POLARITY)).as_int() != 1) {
             ena = pm.module->Not(NEW_ID, st.ff->getPort(ID(EN)));
         } else {
             ena = st.ff->getPort(ID(EN));

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1559,6 +1559,593 @@ module QL_DSP2 ( // TODO: Name subject to change
         );
 endmodule
 
+module QL_DSP2_MULT ( // TODO: Name subject to change
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    input  wire       reset,
+
+    input  wire       unsigned_a,
+    input  wire       unsigned_b,
+
+    input  wire       f_mode,
+    input  wire [2:0] output_select,
+    input  wire       register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+	.reset(reset),
+
+        .f_mode(f_mode),
+
+        .feedback(3'b0),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .output_select(3'b0),	// unregistered output: a * b (0)
+        .register_inputs(1'b0)  // unregistered inputs
+    );
+endmodule
+
+module QL_DSP2_MULT_REGIN ( // TODO: Name subject to change
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire       clk,
+    input  wire       reset,
+
+    input  wire       unsigned_a,
+    input  wire       unsigned_b,
+
+    input  wire       f_mode,
+    input  wire [2:0] output_select,
+    input  wire       register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(3'b0),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(3'b0),	// unregistered output: a * b (0)
+        .register_inputs(1'b1)  // registered inputs
+    );
+endmodule
+
+module QL_DSP2_MULT_REGOUT ( // TODO: Name subject to change
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire       clk,
+    input  wire       reset,
+
+    input  wire       unsigned_a,
+    input  wire       unsigned_b,
+    input  wire       f_mode,
+    input  wire [2:0] output_select,
+    input  wire       register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(3'b0),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(3'b100),	// registered output: a * b (4)
+        .register_inputs(1'b0)  // unregistered inputs
+    );
+endmodule
+
+module QL_DSP2_MULT_REGIN_REGOUT ( // TODO: Name subject to change
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire       clk,
+    input  wire       reset,
+
+    input  wire       unsigned_a,
+    input  wire       unsigned_b,
+    input  wire       f_mode,
+    input  wire [2:0] output_select,
+    input  wire       register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(3'b0),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(3'b100),	// registered output: a * b (4)
+        .register_inputs(1'b1)  // registered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTADD (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+        .load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(output_select),	// unregistered output: ACCin (2, 3)
+        .subtract(subtract),
+        .register_inputs(1'b0)  // unregistered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTADD_REGIN (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+        .load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(output_select),	// unregistered output: ACCin (2, 3)
+        .subtract(subtract),
+        .register_inputs(1'b1)  // registered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTADD_REGOUT (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+        .load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(output_select),	// registered output: ACCin (6, 7)
+        .subtract(subtract),
+        .register_inputs(1'b0)  // unregistered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTADD_REGIN_REGOUT (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+        .load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(output_select),	// registered output: ACCin (6, 7)
+        .subtract(subtract),
+        .register_inputs(1'b1)  // registered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTACC (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+	.feedback(feedback),
+	.load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+        .reset(reset),
+
+        .output_select(1'b1),	// unregistered output: ACCout (1)
+        .subtract(subtract),
+        .register_inputs(1'b0)  // unregistered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTACC_REGIN (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+        .load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(1'b1),	// unregistered output: ACCout (1)
+        .subtract(subtract),
+        .register_inputs(1'b1)  // registered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTACC_REGOUT (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+	.load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(3'b101),	// registered output: ACCout (5)
+        .subtract(subtract),
+        .register_inputs(1'b0)  // unregistered inputs
+    );
+endmodule
+
+module QL_DSP2_MULTACC_REGIN_REGOUT (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+
+    (* clkbuf_sink *)
+    input  wire        clk,
+    input  wire        reset,
+
+    input  wire [ 2:0] feedback,
+    input  wire        load_acc,
+    input  wire        unsigned_a,
+    input  wire        unsigned_b,
+
+    input  wire        f_mode,
+    input  wire [ 2:0] output_select,
+    input  wire        subtract,
+    input  wire        register_inputs
+);
+
+    parameter [79:0] MODE_BITS = 80'd0;
+
+    localparam [19:0] COEFF_0 = MODE_BITS[19:0];
+    localparam [19:0] COEFF_1 = MODE_BITS[39:20];
+    localparam [19:0] COEFF_2 = MODE_BITS[59:40];
+    localparam [19:0] COEFF_3 = MODE_BITS[79:60];
+
+    QL_DSP2 #(
+        .MODE_BITS({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+    ) dsp (
+        .a(a),
+        .b(b),
+        .z(z),
+
+        .f_mode(f_mode),
+
+        .feedback(feedback),
+        .load_acc(load_acc),
+
+        .unsigned_a(unsigned_a),
+        .unsigned_b(unsigned_b),
+
+        .clk(clk),
+	.reset(reset),
+
+        .output_select(3'b101),	// registered output: ACCout (5)
+        .subtract(subtract),
+        .register_inputs(1'b1)  // registered inputs
+    );
+endmodule
+
 module dsp_t1_sim # (
     parameter NBITS_ACC  = 64,
     parameter NBITS_A    = 20,

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1564,6 +1564,7 @@ module QL_DSP2_MULT ( // TODO: Name subject to change
     input  wire [17:0] b,
     output wire [37:0] z,
 
+    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1609,6 +1610,7 @@ module QL_DSP2_MULT_REGIN ( // TODO: Name subject to change
 
     (* clkbuf_sink *)
     input  wire       clk,
+    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1655,6 +1657,7 @@ module QL_DSP2_MULT_REGOUT ( // TODO: Name subject to change
 
     (* clkbuf_sink *)
     input  wire       clk,
+    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1700,6 +1703,7 @@ module QL_DSP2_MULT_REGIN_REGOUT ( // TODO: Name subject to change
 
     (* clkbuf_sink *)
     input  wire       clk,
+    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1743,12 +1747,14 @@ module QL_DSP2_MULTADD (
     input  wire [17:0] b,
     output wire [37:0] z,
 
+    // begin: Ports not available in architecture file
     (* clkbuf_sink *)
     input  wire        clk,
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
     input  wire        load_acc,
+    // end: Ports not available in architecture file
     input  wire        unsigned_a,
     input  wire        unsigned_b,
 
@@ -1796,6 +1802,7 @@ module QL_DSP2_MULTADD_REGIN (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -1847,6 +1854,7 @@ module QL_DSP2_MULTADD_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -1898,6 +1906,7 @@ module QL_DSP2_MULTADD_REGIN_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -1949,10 +1958,12 @@ module QL_DSP2_MULTACC (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // begin: Ports not available in architecture file
     input  wire        reset,
 
-    input  wire [ 2:0] feedback,
     input  wire        load_acc,
+    // end: Ports not available in architecture file
+    input  wire [ 2:0] feedback,
     input  wire        unsigned_a,
     input  wire        unsigned_b,
 
@@ -2000,6 +2011,7 @@ module QL_DSP2_MULTACC_REGIN (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2051,6 +2063,7 @@ module QL_DSP2_MULTACC_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2102,6 +2115,7 @@ module QL_DSP2_MULTACC_REGIN_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
+    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -275,6 +275,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                     run("techmap -map +/quicklogic/" + family + "/dsp_map.v", "(for qlf_k6n10f if not -no_dsp)");
                     run("ql_dsp_simd                   ", "(for qlf_k6n10f if not -no_dsp)");
                     run("techmap -map +/quicklogic/" + family + "/dsp_final_map.v", "(for qlf_k6n10f if not -no_dsp)");
+                    run("ql_dsp_io_regs");
                 } else if (!nodsp) {
 
                     run("wreduce t:$mul");
@@ -291,6 +292,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                     run("techmap -map +/quicklogic/" + family + "/dsp_map.v");
                     run("ql_dsp_simd");
                     run("techmap -map +/quicklogic/" + family + "/dsp_final_map.v");
+                    run("ql_dsp_io_regs");
                 }
             }
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_macc/dsp_macc.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_macc/dsp_macc.tcl
@@ -37,7 +37,7 @@ hierarchy -top $TOP
 check_equiv $TOP
 design -load postopt
 yosys cd $TOP
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULTACC
 select -assert-count 1 t:*
 
 set TOP "macc_simple_clr"
@@ -46,7 +46,7 @@ hierarchy -top $TOP
 check_equiv $TOP
 design -load postopt
 yosys cd $TOP
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULTACC
 select -assert-count 1 t:*
 
 set TOP "macc_simple_arst"
@@ -55,29 +55,26 @@ hierarchy -top $TOP
 check_equiv $TOP
 design -load postopt
 yosys cd $TOP
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULTACC
 select -assert-count 1 t:*
 
-#FIXME: DSP not inferred (got $mux instead of $dffe)
-#set TOP "macc_simple_ena"
-#design -load read
-#hierarchy -top $TOP
-#check_equiv $TOP
-#design -load postopt
-#yosys cd $TOP
-#select -assert-count 1 t:QL_DSP2
-#select -assert-count 1 t:*
+set TOP "macc_simple_ena"
+design -load read
+hierarchy -top $TOP
+check_equiv $TOP
+design -load postopt
+yosys cd $TOP
+select -assert-count 1 t:QL_DSP2_MULTACC
+select -assert-count 1 t:*
 
-#FIXME: DSP not inferred (got $mux instead of $dffe)
-#set TOP "macc_simple_arst_clr_ena"
-#design -load read
-#hierarchy -top $TOP
-#check_equiv $TOP
-#design -load postopt
-#yosys cd $TOP
-#select -assert-count 1 t:QL_DSP2
-#select -assert-count 1 t:\$lut
-#select -assert-count 2 t:*
+set TOP "macc_simple_arst_clr_ena"
+design -load read
+hierarchy -top $TOP
+check_equiv $TOP
+design -load postopt
+yosys cd $TOP
+select -assert-count 1 t:QL_DSP2_MULTACC
+select -assert-count 1 t:*
 
 set TOP "macc_simple_preacc"
 design -load read
@@ -85,7 +82,7 @@ hierarchy -top $TOP
 check_equiv $TOP
 design -load postopt
 yosys cd $TOP
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULTADD
 select -assert-count 1 t:*
 
 set TOP "macc_simple_preacc_clr"
@@ -94,6 +91,6 @@ hierarchy -top $TOP
 check_equiv $TOP
 design -load postopt
 yosys cd $TOP
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULTADD
 select -assert-count 1 t:*
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
@@ -36,33 +36,33 @@ design -load read
 check_equiv ${TOP}
 design -load postopt
 yosys cd ${TOP}
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT
 
 set TOP "mult_20x18"
 design -load read
 check_equiv ${TOP}
 design -load postopt
 yosys cd ${TOP}
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT
 
 set TOP "mult_8x8"
 design -load read
 check_equiv ${TOP}
 design -load postopt
 yosys cd ${TOP}
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT
 
 set TOP "mult_10x9"
 design -load read
 check_equiv ${TOP}
 design -load postopt
 yosys cd ${TOP}
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT
 
 set TOP "mult_8x8_s"
 design -load read
 check_equiv ${TOP}
 design -load postopt
 yosys cd ${TOP}
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
@@ -38,7 +38,7 @@ check_equiv ${TOP}
 design -load postopt
 select -assert-count 0 t:dsp_t1_20x18x64
 select -assert-count 0 t:dsp_t1_10x9x32
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT_REGIN
 
 set TOP "simd_mult_inferred"
 design -load read
@@ -48,7 +48,7 @@ design -load postopt
 yosys cd $TOP
 select -assert-count 0 t:dsp_t1_20x18x64
 select -assert-count 0 t:dsp_t1_10x9x32
-select -assert-count 1 t:QL_DSP2
+select -assert-count 1 t:QL_DSP2_MULT
 
 set TOP "simd_mult_odd"
 design -load read
@@ -58,7 +58,8 @@ design -load postopt
 yosys cd $TOP
 select -assert-count 0 t:dsp_t1_20x18x64
 select -assert-count 0 t:dsp_t1_10x9x32
-select -assert-count 2 t:QL_DSP2
+select -assert-count 0 t:QL_DSP2
+select -assert-count 2 t:QL_DSP2_MULT_REGIN
 
 set TOP "simd_mult_conflict"
 design -load read
@@ -68,5 +69,5 @@ design -load postopt
 yosys cd $TOP
 select -assert-count 0 t:dsp_t1_20x18x64
 select -assert-count 0 t:dsp_t1_10x9x32
-select -assert-count 2 t:QL_DSP2
+select -assert-count 2 t:QL_DSP2_MULT_REGIN
 


### PR DESCRIPTION
This PR adds support for DSP cells:
* QL_DSP2_MULT,
* QL_DSP2_MULT_REGIN,
* QL_DSP2_MULT_REGOUT,
* QL_DSP2_MULT_REGIN_REGOUT

This was done with new custom pass that changes the cell type to intermediate type which is then mapped onto new cells in final techmap step.
@rakeshm75, @tpagarani please take a look at this and let me know if there is anything to change here.