### PR TITLE
Fix variable creation in unnamed scope

### DIFF
--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -167,6 +167,10 @@ class UhdmAst
     static const IdString &is_imported();
 };
 
+namespace VERILOG_FRONTEND
+{
+extern bool sv_mode;
+}
 YOSYS_NAMESPACE_END
 
 #endif


### PR DESCRIPTION
This allows i.e. declaring loop variables outside of the loop statement itself.