### PR TITLE
Check default UHDM install directory

### DIFF
--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -21,6 +21,9 @@ SOURCES = UhdmAst.cc \
 	  uhdmsurelogastfrontend.cc \
 	  uhdmastreport.cc
 
+# Directory to search for Surelog and UHDM libraries
+UHDM_INSTALL_DIR ?= /usr/local
+
 include ../Makefile_plugin.common
 
 CPPFLAGS += -std=c++17 -Wall -W -Wextra -Werror \


### PR DESCRIPTION
Look for Surelog and UHDM libraries in their default installation location. This can still be overridden for an isolated installation.

Fixes #320.