### PR TITLE
Makefile: fix DESTDIR handling

### DIFF
--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -53,11 +53,7 @@ LDFLAGS = $(shell $(YOSYS_CONFIG) --ldflags)
 LDLIBS = $(shell $(YOSYS_CONFIG) --ldlibs)
 EXTRA_FLAGS ?=
 
-ifdef DESTDIR
-  DATA_DIR = $(DESTDIR)
-else
-  DATA_DIR = $(shell $(YOSYS_CONFIG) --datdir)
-endif
+DATA_DIR = $(DESTDIR)$(shell $(YOSYS_CONFIG) --datdir)
 PLUGINS_DIR = $(DATA_DIR)/plugins
 
 OBJS := $(patsubst %.cc,%.o,$(SOURCES))


### PR DESCRIPTION
DESTDIR is an *additional* prefix to the installation path, not an *alternative*: https://www.gnu.org/prep/standards/html_node/DESTDIR.html