### PR TITLE
fix(systemverilog): disable -Werror

### DIFF
--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -26,7 +26,7 @@ UHDM_INSTALL_DIR ?= /usr/local
 
 include ../Makefile_plugin.common
 
-CPPFLAGS += -std=c++17 -Wall -W -Wextra -Werror \
+CPPFLAGS += -std=c++17 -Wall -W -Wextra \
               -Wno-deprecated-declarations \
               -Wno-unused-parameter \
               -I${UHDM_INSTALL_DIR}/include \


### PR DESCRIPTION
The build system has no direct control over the downstream compiler, so it cannot ensure that no stray warnings are produced downstream even if the upstream compilation is warning-free. Setting `-Werror` means that these harmless warnings turn into compilation errors instead, breaking downstream builds.