### PR TITLE
IWYU - the sdc plugin was only including a fraction of the headers it…

### DIFF
--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -17,7 +17,14 @@
  */
 #include <algorithm>
 #include <array>
+#include <istream>
 #include <iterator>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "clocks.h"
 #include "kernel/log.h"


### PR DESCRIPTION
… needs.

This is mostly in the context of #326. The PR #324 was fixing the immediate
issue but was leaving out other missing headers.