### PR TITLE
Disable benign warnings.

### DIFF
--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -27,6 +27,8 @@ UHDM_INSTALL_DIR ?= /usr/local
 include ../Makefile_plugin.common
 
 CPPFLAGS += -std=c++17 -Wall -W -Wextra -Werror \
+              -Wno-deprecated-declarations \
+              -Wno-unused-parameter \
               -I${UHDM_INSTALL_DIR}/include \
 	      -I${UHDM_INSTALL_DIR}/include/Surelog
 


### PR DESCRIPTION
In clang++ and g++-12, some warnings are triggered that are benign,
but would stop compilation as we compile with -Werror.

(TODO: mayabe we only enable -Werror in the CI, but are more
lenient otherwise to not have users 'discover' such things).

Signed-off-by: Henner Zeller <h.zeller@acm.org>