### PR TITLE
ql-qlf: k6n10f: Add support for SDP split BRAM

### DIFF
--- a/ql-qlf-plugin/qlf_k6n10f/brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/brams.txt
@@ -86,6 +86,32 @@ bram $__QLF_FACTOR_BRAM18_TDP
   clkpol 1 1 2 2
 endbram
 
+bram $__QLF_FACTOR_BRAM18_SDP
+  init 1
+  abits 10     @a10d18
+  dbits 18     @a10d18
+  abits 10     @a10d16
+  dbits 16     @a10d16
+  abits 11     @a11d9
+  dbits  9     @a11d9
+  abits 11     @a11d8
+  dbits  8     @a11d8
+  abits 12     @a12d4
+  dbits  4     @a12d4
+  abits 13     @a13d2
+  dbits  2     @a13d2
+  abits 14     @a14d1
+  dbits  1     @a14d1
+  groups 2
+  ports  1 1
+  wrmode 0 1
+  enable 1 2  @a10d18 @a10d16
+  enable 1 1  @a11d9 @a11d8 @a12d4 @a13d2 @a14d1
+  transp 0 0
+  clocks 1 1
+  clkpol 1 1
+endbram
+
 match $__QLF_FACTOR_BRAM36_TDP
   min bits 18433
   min wports 1
@@ -115,6 +141,17 @@ match $__QLF_FACTOR_BRAM18_TDP
   max wports 2
   min rports 1
   max rports 2
+  min efficiency 1
+  shuffle_enable B
+  make_transp
+  or_next_if_better
+endmatch
+
+match $__QLF_FACTOR_BRAM18_SDP
+  min bits 128
+  max bits 18432
+  max wports 1
+  max rports 1
   min efficiency 1
   shuffle_enable B
   make_transp

--- a/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
@@ -264,3 +264,219 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
 		.FLUSH2_i(FLUSH2)
 	);
 endmodule
+
+module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, D1ADDR, D1DATA, D1EN);
+	parameter CFG_ABITS = 11;
+	parameter CFG_DBITS = 18;
+	parameter CFG_ENABLE_B = 4;
+	parameter CFG_ENABLE_D = 4;
+
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter [18431:0] INIT0 = 18432'bx;
+	parameter [18431:0] INIT1 = 18432'bx;
+
+	input CLK1;
+	input CLK2;
+
+	input [CFG_ABITS-1:0] A1ADDR;
+	output [CFG_DBITS-1:0] A1DATA;
+	input A1EN;
+
+	input [CFG_ABITS-1:0] B1ADDR;
+	input [CFG_DBITS-1:0] B1DATA;
+	input [CFG_ENABLE_B-1:0] B1EN;
+
+	input [CFG_ABITS-1:0] C1ADDR;
+	output [CFG_DBITS-1:0] C1DATA;
+	input C1EN;
+
+	input [CFG_ABITS-1:0] D1ADDR;
+	input [CFG_DBITS-1:0] D1DATA;
+	input [CFG_ENABLE_D-1:0] D1EN;
+
+	wire FLUSH1;
+	wire FLUSH2;
+
+	wire [13:CFG_ABITS] A1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] B1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] C1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] D1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+
+	wire [13:0] A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
+	wire [13:0] B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
+	wire [13:0] C1ADDR_TOTAL = {C1ADDR_CMPL, C1ADDR};
+	wire [13:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
+
+	wire [17:CFG_DBITS] A1_RDATA_CMPL;
+	wire [17:CFG_DBITS] C1_RDATA_CMPL;
+
+	wire [17:CFG_DBITS] B1_WDATA_CMPL;
+	wire [17:CFG_DBITS] D1_WDATA_CMPL;
+
+	wire [13:0] PORT_A1_ADDR;
+	wire [13:0] PORT_A2_ADDR;
+	wire [13:0] PORT_B1_ADDR;
+	wire [13:0] PORT_B2_ADDR;
+
+	case (CFG_DBITS)
+		1: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL;
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+			};
+		end
+
+		2: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 1;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 1;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 1;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 1;
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0
+			};
+		end
+
+		4: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 2;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 2;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 2;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 2;
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0
+			};
+		end
+
+		8, 9: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 3;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 3;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 3;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 3;
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0
+			};
+		end
+
+		16, 18: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 4;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 4;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 4;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 4;
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0
+			};
+		end
+
+		default: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL;
+			assign PORT_A2_ADDR = D1ADDR_TOTAL;
+			assign PORT_B2_ADDR = C1ADDR_TOTAL;
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0
+			};
+		end
+	endcase
+
+	assign FLUSH1 = 1'b0;
+	assign FLUSH2 = 1'b0;
+
+	wire [17:0] PORT_A1_RDATA;
+	wire [17:0] PORT_B1_RDATA;
+	wire [17:0] PORT_A2_RDATA;
+	wire [17:0] PORT_B2_RDATA;
+
+	wire [17:0] PORT_A1_WDATA;
+	wire [17:0] PORT_B1_WDATA;
+	wire [17:0] PORT_A2_WDATA;
+	wire [17:0] PORT_B2_WDATA;
+
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
+			assign C1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
+			assign PORT_A1_WDATA = {18{1'b0}};
+			assign PORT_B1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
+			assign PORT_A2_WDATA = {18{1'b0}};
+			assign PORT_B2_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
+			assign C1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
+			assign PORT_A1_WDATA = {18{1'b1}};
+			assign PORT_B1_WDATA = {B1_WDATA_CMPL, B1DATA};
+			assign PORT_A2_WDATA = {18{1'b1}};
+			assign PORT_B2_WDATA = {D1_WDATA_CMPL, D1DATA};
+
+		end
+	endcase
+
+	wire PORT_A1_CLK = CLK1;
+	wire PORT_A2_CLK = CLK2;
+	wire PORT_B1_CLK = CLK1;
+	wire PORT_B2_CLK = CLK2;
+
+	wire PORT_A1_REN = A1EN;
+	wire PORT_A1_WEN = 1'b0;
+	wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {PORT_A1_WEN,PORT_A1_WEN};
+
+	wire PORT_A2_REN = C1EN;
+	wire PORT_A2_WEN = 1'b0;
+	wire [CFG_ENABLE_D-1:0] PORT_A2_BE = {PORT_A2_WEN,PORT_A2_WEN};
+
+	wire PORT_B1_REN = 1'b0;
+	wire PORT_B1_WEN = B1EN[0];
+	wire [CFG_ENABLE_B-1:0] PORT_B1_BE = {B1EN[1],B1EN[0]};
+
+	wire PORT_B2_REN = 1'b0;
+	wire PORT_B2_WEN = D1EN[0];
+	wire [CFG_ENABLE_D-1:0] PORT_B2_BE = {D1EN[1],D1EN[0]};
+
+	TDP36K  _TECHMAP_REPLACE_ (
+		.WDATA_A1_i(PORT_A1_WDATA),
+		.RDATA_A1_o(PORT_A1_RDATA),
+		.ADDR_A1_i(PORT_A1_ADDR),
+		.CLK_A1_i(PORT_A1_CLK),
+		.REN_A1_i(PORT_A1_REN),
+		.WEN_A1_i(PORT_A1_WEN),
+		.BE_A1_i(PORT_A1_BE),
+
+		.WDATA_A2_i(PORT_A2_WDATA),
+		.RDATA_A2_o(PORT_A2_RDATA),
+		.ADDR_A2_i(PORT_A2_ADDR),
+		.CLK_A2_i(PORT_A2_CLK),
+		.REN_A2_i(PORT_A2_REN),
+		.WEN_A2_i(PORT_A2_WEN),
+		.BE_A2_i(PORT_A2_BE),
+
+		.WDATA_B1_i(PORT_B1_WDATA),
+		.RDATA_B1_o(PORT_B1_RDATA),
+		.ADDR_B1_i(PORT_B1_ADDR),
+		.CLK_B1_i(PORT_B1_CLK),
+		.REN_B1_i(PORT_B1_REN),
+		.WEN_B1_i(PORT_B1_WEN),
+		.BE_B1_i(PORT_B1_BE),
+
+		.WDATA_B2_i(PORT_B2_WDATA),
+		.RDATA_B2_o(PORT_B2_RDATA),
+		.ADDR_B2_i(PORT_B2_ADDR),
+		.CLK_B2_i(PORT_B2_CLK),
+		.REN_B2_i(PORT_B2_REN),
+		.WEN_B2_i(PORT_B2_WEN),
+		.BE_B2_i(PORT_B2_BE),
+
+		.FLUSH1_i(FLUSH1),
+		.FLUSH2_i(FLUSH2)
+	);
+endmodule

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -276,6 +276,46 @@ module \$__QLF_FACTOR_BRAM18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	);
 endmodule
 
+module \$__QLF_FACTOR_BRAM18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, CLK1, CLK2);
+	parameter CFG_ABITS = 11;
+	parameter CFG_DBITS = 18;
+	parameter CFG_ENABLE_B = 4;
+
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter [18431:0] INIT = 18432'bx;
+
+	input CLK1;
+	input CLK2;
+
+	input [CFG_ABITS-1:0] A1ADDR;
+	output [CFG_DBITS-1:0] A1DATA;
+	input A1EN;
+
+	input [CFG_ABITS-1:0] B1ADDR;
+	input [CFG_DBITS-1:0] B1DATA;
+	input [CFG_ENABLE_B-1:0] B1EN;
+
+	BRAM2x18_SDP #(
+		.CFG_ABITS(CFG_ABITS),
+		.CFG_DBITS(CFG_DBITS),
+		.CFG_ENABLE_B(CFG_ENABLE_B),
+		.CLKPOL2(CLKPOL2),
+		.CLKPOL3(CLKPOL3),
+		.INIT0(INIT),
+	) _TECHMAP_REPLACE_ (
+		.A1ADDR(A1ADDR),
+		.A1DATA(A1DATA),
+		.A1EN(A1EN),
+		.CLK1(CLK1),
+
+		.B1ADDR(B1ADDR),
+		.B1DATA(B1DATA),
+		.B1EN(B1EN),
+		.CLK2(CLK2)
+	);
+endmodule
+
 module \$__QLF_FACTOR_BRAM36_SDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
 	parameter CFG_ABITS = 10;
 	parameter CFG_DBITS = 36;

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1389,6 +1389,229 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
     );
 endmodule
 
+module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, D1ADDR, D1DATA, D1EN);
+	parameter CFG_ABITS = 11;
+	parameter CFG_DBITS = 18;
+	parameter CFG_ENABLE_B = 4;
+	parameter CFG_ENABLE_D = 4;
+
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter [18431:0] INIT0 = 18432'bx;
+	parameter [18431:0] INIT1 = 18432'bx;
+
+        localparam MODE_36 = 3'b011; // 36- or 32-bit
+        localparam MODE_18 = 3'b010; // 18- or 16-bit
+        localparam MODE_9 = 3'b001; // 9- or 8-bit
+        localparam MODE_4 = 3'b100; // 4-bit
+        localparam MODE_2 = 3'b110; // 2-bit
+        localparam MODE_1 = 3'b101; // 1-bit
+
+	input CLK1;
+	input CLK2;
+
+	input [CFG_ABITS-1:0] A1ADDR;
+	output [CFG_DBITS-1:0] A1DATA;
+	input A1EN;
+
+	input [CFG_ABITS-1:0] B1ADDR;
+	input [CFG_DBITS-1:0] B1DATA;
+	input [CFG_ENABLE_B-1:0] B1EN;
+
+	input [CFG_ABITS-1:0] C1ADDR;
+	output [CFG_DBITS-1:0] C1DATA;
+	input C1EN;
+
+	input [CFG_ABITS-1:0] D1ADDR;
+	input [CFG_DBITS-1:0] D1DATA;
+	input [CFG_ENABLE_D-1:0] D1EN;
+
+	wire FLUSH1;
+	wire FLUSH2;
+
+	wire [13:CFG_ABITS] A1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] B1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] C1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+	wire [13:CFG_ABITS] D1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+
+	wire [13:0] A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
+	wire [13:0] B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
+	wire [13:0] C1ADDR_TOTAL = {C1ADDR_CMPL, C1ADDR};
+	wire [13:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
+
+	wire [17:CFG_DBITS] A1_RDATA_CMPL;
+	wire [17:CFG_DBITS] C1_RDATA_CMPL;
+
+	wire [17:CFG_DBITS] B1_WDATA_CMPL;
+	wire [17:CFG_DBITS] D1_WDATA_CMPL;
+
+	wire [13:0] PORT_A1_ADDR;
+	wire [13:0] PORT_A2_ADDR;
+	wire [13:0] PORT_B1_ADDR;
+	wire [13:0] PORT_B2_ADDR;
+
+	case (CFG_DBITS)
+		1: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL;
+			defparam bram_2x18k.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+			};
+		end
+
+		2: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 1;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 1;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 1;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 1;
+			defparam bram_2x18k.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+			};
+		end
+
+		4: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 2;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 2;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 2;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 2;
+			defparam bram_2x18k.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+			};
+		end
+
+		8, 9: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 3;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 3;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 3;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 3;
+			defparam bram_2x18k.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+			};
+		end
+
+		16, 18: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL << 4;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL << 4;
+			assign PORT_A2_ADDR = C1ADDR_TOTAL << 4;
+			assign PORT_B2_ADDR = D1ADDR_TOTAL << 4;
+			defparam bram_2x18k.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+			};
+		end
+
+		default: begin
+			assign PORT_A1_ADDR = A1ADDR_TOTAL;
+			assign PORT_B1_ADDR = B1ADDR_TOTAL;
+			assign PORT_A2_ADDR = D1ADDR_TOTAL;
+			assign PORT_B2_ADDR = C1ADDR_TOTAL;
+			defparam bram_2x18k.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+			};
+		end
+	endcase
+
+	assign FLUSH1 = 1'b0;
+	assign FLUSH2 = 1'b0;
+
+	wire [17:0] PORT_A1_RDATA;
+	wire [17:0] PORT_B1_RDATA;
+	wire [17:0] PORT_A2_RDATA;
+	wire [17:0] PORT_B2_RDATA;
+
+	wire [17:0] PORT_A1_WDATA;
+	wire [17:0] PORT_B1_WDATA;
+	wire [17:0] PORT_A2_WDATA;
+	wire [17:0] PORT_B2_WDATA;
+
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
+			assign C1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
+			assign PORT_A1_WDATA = {18{1'b0}};
+			assign PORT_B1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
+			assign PORT_A2_WDATA = {18{1'b0}};
+			assign PORT_B2_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
+			assign C1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
+			assign PORT_A1_WDATA = {18{1'b1}};
+			assign PORT_B1_WDATA = {B1_WDATA_CMPL, B1DATA};
+			assign PORT_A2_WDATA = {18{1'b1}};
+			assign PORT_B2_WDATA = {D1_WDATA_CMPL, D1DATA};
+
+		end
+	endcase
+
+	wire PORT_A1_CLK = CLK1;
+	wire PORT_A2_CLK = CLK2;
+	wire PORT_B1_CLK = CLK1;
+	wire PORT_B2_CLK = CLK2;
+
+	wire PORT_A1_REN = A1EN;
+	wire PORT_A1_WEN = 1'b0;
+	wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {PORT_A1_WEN,PORT_A1_WEN};
+
+	wire PORT_A2_REN = C1EN;
+	wire PORT_A2_WEN = 1'b0;
+	wire [CFG_ENABLE_D-1:0] PORT_A2_BE = {PORT_A2_WEN,PORT_A2_WEN};
+
+	wire PORT_B1_REN = 1'b0;
+	wire PORT_B1_WEN = B1EN[0];
+	wire [CFG_ENABLE_B-1:0] PORT_B1_BE = {B1EN[1],B1EN[0]};
+
+	wire PORT_B2_REN = 1'b0;
+	wire PORT_B2_WEN = D1EN[0];
+	wire [CFG_ENABLE_D-1:0] PORT_B2_BE = {D1EN[1],D1EN[0]};
+
+	TDP36K  bram_2x18k (
+		.WDATA_A1_i(PORT_A1_WDATA),
+		.RDATA_A1_o(PORT_A1_RDATA),
+		.ADDR_A1_i(PORT_A1_ADDR),
+		.CLK_A1_i(PORT_A1_CLK),
+		.REN_A1_i(PORT_A1_REN),
+		.WEN_A1_i(PORT_A1_WEN),
+		.BE_A1_i(PORT_A1_BE),
+
+		.WDATA_A2_i(PORT_A2_WDATA),
+		.RDATA_A2_o(PORT_A2_RDATA),
+		.ADDR_A2_i(PORT_A2_ADDR),
+		.CLK_A2_i(PORT_A2_CLK),
+		.REN_A2_i(PORT_A2_REN),
+		.WEN_A2_i(PORT_A2_WEN),
+		.BE_A2_i(PORT_A2_BE),
+
+		.WDATA_B1_i(PORT_B1_WDATA),
+		.RDATA_B1_o(PORT_B1_RDATA),
+		.ADDR_B1_i(PORT_B1_ADDR),
+		.CLK_B1_i(PORT_B1_CLK),
+		.REN_B1_i(PORT_B1_REN),
+		.WEN_B1_i(PORT_B1_WEN),
+		.BE_B1_i(PORT_B1_BE),
+
+		.WDATA_B2_i(PORT_B2_WDATA),
+		.RDATA_B2_o(PORT_B2_RDATA),
+		.ADDR_B2_i(PORT_B2_ADDR),
+		.CLK_B2_i(PORT_B2_CLK),
+		.REN_B2_i(PORT_B2_REN),
+		.WEN_B2_i(PORT_B2_WEN),
+		.BE_B2_i(PORT_B2_BE),
+
+		.FLUSH1_i(FLUSH1),
+		.FLUSH2_i(FLUSH2)
+	);
+endmodule
+
 (* blackbox *)
 module QL_DSP1 (
     input wire [19:0] a,

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -44,7 +44,8 @@ SIM_TESTS = \
 POST_SYNTH_SIM_TESTS = \
     qlf_k6n10f/bram_tdp \
     qlf_k6n10f/bram_sdp \
-    qlf_k6n10f/bram_tdp_split
+    qlf_k6n10f/bram_tdp_split \
+    qlf_k6n10f/bram_sdp_split
 
 include $(shell pwd)/../../Makefile_test.common
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/bram_sdp_split.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/bram_sdp_split.tcl
@@ -1,0 +1,83 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram_sdp_split
+
+select BRAM_SDP_SPLIT_2x18x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x18x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x18x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp_split
+select BRAM_SDP_SPLIT_2x16x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x16x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x16x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp_split
+select BRAM_SDP_SPLIT_2x9x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x9x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x9x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp_split
+select BRAM_SDP_SPLIT_2x8x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x8x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x8x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp_split
+select BRAM_SDP_SPLIT_2x4x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x4x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x4x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp_split
+select BRAM_SDP_SPLIT_2x2x8192
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x2x8192
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x2x8192_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_sdp_split
+select BRAM_SDP_SPLIT_2x1x16384
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x1x16384
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/bram_sdp_split_2x1x16384_post_synth.v
+select -assert-count 1 t:TDP36K
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/bram_sdp_split.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/bram_sdp_split.v
@@ -1,0 +1,479 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+module BRAM_SDP_SPLIT #(parameter AWIDTH = 9,
+parameter DWIDTH = 32)(
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+
+	input			clk;
+	input                   rce;
+	input      [AWIDTH-1:0] ra;
+	output reg [DWIDTH-1:0] rq;
+	input                   wce;
+	input      [AWIDTH-1:0] wa;
+	input      [DWIDTH-1:0] wd;
+
+	reg        [DWIDTH-1:0] memory[0:(1<<AWIDTH)-1];
+
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra];
+
+		if (wce)
+			memory[wa] <= wd;
+	end
+
+	integer i;
+	initial
+	begin
+		for(i = 0; i < (1<<AWIDTH)-1; i = i + 1)
+			memory[i] = 0;
+	end
+
+endmodule
+
+module BRAM_SDP_SPLIT_2x18K #(parameter AWIDTH = 10, parameter DWIDTH = 18)(
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_0 (.clk(clk_0),
+		 .rce(rce_0),
+		 .ra(ra_0),
+		 .rq(rq_0),
+		 .wce(wce_0),
+		 .wa(wa_0),
+		 .wd(wd_0));
+
+BRAM_SDP_SPLIT #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_1 (.clk(clk_1),
+		 .rce(rce_1),
+		 .ra(ra_1),
+		 .rq(rq_1),
+		 .wce(wce_1),
+		 .wa(wa_1),
+		 .wd(wd_1));
+endmodule
+
+
+module BRAM_SDP_SPLIT_2x18x1024 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 10;
+parameter DWIDTH = 18;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x18x1024 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+
+
+module BRAM_SDP_SPLIT_2x16x1024 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 10;
+parameter DWIDTH = 16;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x16x1024 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+
+
+module BRAM_SDP_SPLIT_2x9x2048 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 11;
+parameter DWIDTH = 9;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x9x2048 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+
+module BRAM_SDP_SPLIT_2x8x2048 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 11;
+parameter DWIDTH = 8;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x8x2048 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+
+module BRAM_SDP_SPLIT_2x4x4096 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 12;
+parameter DWIDTH = 4;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x4x4096 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+
+module BRAM_SDP_SPLIT_2x2x8192 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 13;
+parameter DWIDTH = 2;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x2x8192 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+
+module BRAM_SDP_SPLIT_2x1x16384 (
+	clk_0,
+	rce_0,
+	ra_0,
+	rq_0,
+	wce_0,
+	wa_0,
+	wd_0,
+
+	clk_1,
+	rce_1,
+	ra_1,
+	rq_1,
+	wce_1,
+	wa_1,
+	wd_1
+);
+
+parameter AWIDTH = 14;
+parameter DWIDTH = 1;
+
+	input			clk_0;
+	input                   rce_0;
+	input      [AWIDTH-1:0] ra_0;
+	output     [DWIDTH-1:0] rq_0;
+	input                   wce_0;
+	input      [AWIDTH-1:0] wa_0;
+	input      [DWIDTH-1:0] wd_0;
+	input			clk_1;
+	input                   rce_1;
+	input      [AWIDTH-1:0] ra_1;
+	output     [DWIDTH-1:0] rq_1;
+	input                   wce_1;
+	input      [AWIDTH-1:0] wa_1;
+	input      [DWIDTH-1:0] wd_1;
+
+BRAM_SDP_SPLIT_2x18K #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_SDP_SPLIT_2x1x16384 (
+		 .clk_0(clk_0),
+		 .rce_0(rce_0),
+		 .ra_0(ra_0),
+		 .rq_0(rq_0),
+		 .wce_0(wce_0),
+		 .wa_0(wa_0),
+		 .wd_0(wd_0),
+		 .clk_1(clk_1),
+		 .rce_1(rce_1),
+		 .ra_1(ra_1),
+		 .rq_1(rq_1),
+		 .wce_1(wce_1),
+		 .wa_1(wa_1),
+		 .wd_1(wd_1));
+endmodule
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/sim/Makefile
@@ -1,0 +1,38 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = bram_sdp_split_tb.v
+POST_SYNTH = bram_sdp_split_2x18x1024_post_synth bram_sdp_split_2x16x1024_post_synth bram_sdp_split_2x9x2048_post_synth bram_sdp_split_2x8x2048_post_synth bram_sdp_split_2x4x4096_post_synth bram_sdp_split_2x2x8192_post_synth bram_sdp_split_2x1x16384_post_synth
+ADDR_WIDTH = 10 10 11 11 12 13 14
+DATA_WIDTH = 18 16 9 8 4 2 1
+TOP = BRAM_SDP_SPLIT_2x18x1024 BRAM_SDP_SPLIT_2x16x1024 BRAM_SDP_SPLIT_2x9x2048 BRAM_SDP_SPLIT_2x8x2048 BRAM_SDP_SPLIT_2x4x4096 BRAM_SDP_SPLIT_2x2x8192 BRAM_SDP_SPLIT_2x1x16384
+ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
+DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR_DEFINES)) $(word $(1),$(DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call simulate_post_synth,2)
+	$(call simulate_post_synth,3)
+	$(call simulate_post_synth,4)
+	$(call simulate_post_synth,5)
+	$(call simulate_post_synth,6)
+	$(call simulate_post_synth,7)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/sim/bram_sdp_split_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/sim/bram_sdp_split_tb.v
@@ -1,0 +1,296 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_0;
+	reg rce_0;
+	reg [`ADDR_WIDTH-1:0] ra_0;
+	wire [`DATA_WIDTH-1:0] rq_0;
+	reg wce_0;
+	reg [`ADDR_WIDTH-1:0] wa_0;
+	reg [`DATA_WIDTH-1:0] wd_0;
+
+	reg clk_1;
+	reg rce_1;
+	reg [`ADDR_WIDTH-1:0] ra_1;
+	wire [`DATA_WIDTH-1:0] rq_1;
+	reg wce_1;
+	reg [`ADDR_WIDTH-1:0] wa_1;
+	reg [`DATA_WIDTH-1:0] wd_1;
+
+
+	initial clk_0 = 0;
+	initial clk_1 = 0;
+	initial ra_0 = 0;
+	initial ra_1 = 0;
+	initial rce_0 = 0;
+	initial rce_1 = 0;
+	initial forever #(PERIOD / 2.0) clk_0 = ~clk_0;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_1 = ~clk_1;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_0;
+	reg done_1;
+	initial done_0 = 1'b0;
+	initial done_1 = 1'b0;
+	wire done_sim = done_0 & done_1;
+
+	reg [`DATA_WIDTH-1:0] expected_0;
+	reg [`DATA_WIDTH-1:0] expected_1;
+
+	reg read_test_0;
+	reg read_test_1;
+	initial read_test_0 = 0;
+	initial read_test_1 = 0;
+
+	always @(posedge clk_0) begin
+		expected_0 <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+	always @(posedge clk_1) begin
+		expected_1 <= ((b+1) | ((b+1) << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+
+	wire error_0 = ((a != 0) && read_test_0) ? (rq_0 !== expected_0) : 0;
+	wire error_1 = ((b != (1<<`ADDR_WIDTH) / 2) && read_test_1) ? (rq_1 !== expected_1) : 0;
+
+	integer error_0_cnt = 0;
+	integer error_1_cnt = 0;
+
+	always @ (posedge clk_0)
+	begin
+		if (error_0)
+			error_0_cnt <= error_0_cnt + 1'b1;
+	end
+	always @ (posedge clk_1)
+	begin
+		if (error_1)
+			error_1_cnt <= error_1_cnt + 1'b1;
+	end
+
+	// PART 0
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa_0 = a;
+				wd_0 = a | (a << 20) | 20'h55000;
+				wce_0 = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce_0 = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				ra_0 = a;
+				rce_0 = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) rce_0 = 0;
+				if ( rq_0 !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq_0, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq_0, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+	end
+
+	// PART 1
+	initial #(1) begin
+		// Write data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				wa_1 = b;
+				wd_1 = (b+1) | ((b+1) << 20) | 20'h55000;
+				wce_1 = 1;
+			end
+			@(posedge clk_1) begin
+				#(PERIOD/10) wce_1 = 0;
+			end
+		end
+		// Read data
+		read_test_1 = 1;
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra_1 = b;
+				rce_1 = 1;
+			end
+			@(posedge clk_1) begin
+				#(PERIOD/10) rce_1 = 0;
+				if ( rq_1 !== expected_1) begin
+					$display("%d: PORT 1: FAIL: mismatch act=%x exp=%x at %x", $time, rq_1, expected_1, b);
+				end else begin
+					$display("%d: PORT 1: OK: act=%x exp=%x at %x", $time, rq_1, expected_1, b);
+				end
+			end
+		end
+		done_1 = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk_0, posedge clk_1) begin
+		if (done_sim)
+			$finish_and_return( (error_0_cnt == 0 & error_1_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"BRAM_SDP_SPLIT_2x18x1024": begin
+			BRAM_SDP_SPLIT_2x18x1024 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+		"BRAM_SDP_SPLIT_2x16x1024": begin
+			BRAM_SDP_SPLIT_2x16x1024 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+		"BRAM_SDP_SPLIT_2x9x2048": begin
+			BRAM_SDP_SPLIT_2x9x2048 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+		"BRAM_SDP_SPLIT_2x8x2048": begin
+			BRAM_SDP_SPLIT_2x8x2048 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+		"BRAM_SDP_SPLIT_2x4x4096": begin
+			BRAM_SDP_SPLIT_2x4x4096 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+		"BRAM_SDP_SPLIT_2x2x8192": begin
+			BRAM_SDP_SPLIT_2x2x8192 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+		"BRAM_SDP_SPLIT_2x1x16384": begin
+			BRAM_SDP_SPLIT_2x1x16384 #() bram (
+				.clk_0(clk_0),
+				.rce_0(rce_0),
+				.ra_0(ra_0),
+				.rq_0(rq_0),
+				.wce_0(wce_0),
+				.wa_0(wa_0),
+				.wd_0(wd_0),
+
+				.clk_1(clk_1),
+				.rce_1(rce_1),
+				.ra_1(ra_1),
+				.rq_1(rq_1),
+				.wce_1(wce_1),
+				.wa_1(wa_1),
+				.wd_1(wd_1)
+			);
+		end
+	endcase
+endmodule


### PR DESCRIPTION
This is a follow up PR to https://github.com/chipsalliance/yosys-f4pga-plugins/pull/286. It adds missing support for SDP BRAMs in split mode. @rakeshm75, @tpagarani please have a look at this.