### PR TITLE
qlf-k6n10f: DSP ports fix

### DIFF
--- a/ql-qlf-plugin/ql-dsp-io-regs.cc
+++ b/ql-qlf-plugin/ql-dsp-io-regs.cc
@@ -11,7 +11,8 @@ PRIVATE_NAMESPACE_BEGIN
 // ============================================================================
 
 const std::vector<std::string> ports2del_mult = {"load_acc", "subtract", "acc_fir", "dly_b"};
-const std::vector<std::string> ports2del_mult_add_acc = {"acc_fir", "dly_b"};
+const std::vector<std::string> ports2del_mult_acc = {"acc_fir", "dly_b"};
+const std::vector<std::string> ports2del_mult_add = {"dly_b"};
 
 void ql_dsp_io_regs_pass(RTLIL::Module *module)
 {
@@ -72,10 +73,21 @@ void ql_dsp_io_regs_pass(RTLIL::Module *module)
             if (del_clk)
                 ports2del.push_back("clk");
 
-            if (out_sel_i == 0 || out_sel_i == 4) {
+            switch (out_sel_i) {
+            case 0:
+            case 4:
                 ports2del.insert(ports2del.end(), ports2del_mult.begin(), ports2del_mult.end());
-            } else {
-                ports2del.insert(ports2del.end(), ports2del_mult_add_acc.begin(), ports2del_mult_add_acc.end());
+                break;
+            case 1:
+            case 5:
+                ports2del.insert(ports2del.end(), ports2del_mult_acc.begin(), ports2del_mult_acc.end());
+                break;
+            case 2:
+            case 3:
+            case 6:
+            case 7:
+                ports2del.insert(ports2del.end(), ports2del_mult_add.begin(), ports2del_mult_add.end());
+                break;
             }
 
             for (auto portname : ports2del) {

--- a/ql-qlf-plugin/ql-dsp-io-regs.cc
+++ b/ql-qlf-plugin/ql-dsp-io-regs.cc
@@ -10,7 +10,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 // ============================================================================
 
-const std::vector<std::string> ports2del_mult = {"feedback", "load_acc", "subtract", "acc_fir", "dly_b"};
+const std::vector<std::string> ports2del_mult = {"load_acc", "subtract", "acc_fir", "dly_b"};
 const std::vector<std::string> ports2del_mult_add_acc = {"acc_fir", "dly_b"};
 
 void ql_dsp_io_regs_pass(RTLIL::Module *module)

--- a/ql-qlf-plugin/ql-dsp-macc.cc
+++ b/ql-qlf-plugin/ql-dsp-macc.cc
@@ -200,17 +200,17 @@ void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
     cell->setPort(RTLIL::escape_id("unsigned_b_i"), RTLIL::SigSpec(b_signed ? RTLIL::S0 : RTLIL::S1));
 
     // Connect config ports
-    cell->setPort(RTLIL::escape_id("saturate_enable_i"), RTLIL::SigSpec(RTLIL::S0));
-    cell->setPort(RTLIL::escape_id("shift_right_i"), RTLIL::SigSpec(RTLIL::S0, 6));
-    cell->setPort(RTLIL::escape_id("round_i"), RTLIL::SigSpec(RTLIL::S0));
-    cell->setPort(RTLIL::escape_id("register_inputs_i"), RTLIL::SigSpec(RTLIL::S0));
+    cell->setParam(RTLIL::escape_id("SATURATE_ENABLE"), RTLIL::Const(RTLIL::S0));
+    cell->setParam(RTLIL::escape_id("SHIFT_RIGHT"), RTLIL::Const(RTLIL::S0, 6));
+    cell->setParam(RTLIL::escape_id("ROUND"), RTLIL::Const(RTLIL::S0));
+    cell->setParam(RTLIL::escape_id("REGISTER_INPUTS"), RTLIL::Const(RTLIL::S0));
 
     bool subtract = (st.add->type == RTLIL::escape_id("$sub"));
     cell->setPort(RTLIL::escape_id("subtract_i"), RTLIL::SigSpec(subtract ? RTLIL::S1 : RTLIL::S0));
 
     // 3 - output post acc
     // 1 - output pre acc
-    cell->setPort(RTLIL::escape_id("output_select_i"), out_ff ? RTLIL::Const(1, 3) : RTLIL::Const(3, 3));
+    cell->setParam(RTLIL::escape_id("OUTPUT_SELECT"), out_ff ? RTLIL::Const(1, 3) : RTLIL::Const(3, 3));
 
     // Mark the cells for removal
     pm.autoremove(st.mul);

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1658,7 +1658,6 @@ module QL_DSP2_MULT ( // TODO: Name subject to change
     input  wire [17:0] b,
     output wire [37:0] z,
 
-    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1713,7 +1712,6 @@ module QL_DSP2_MULT_REGIN ( // TODO: Name subject to change
 
     (* clkbuf_sink *)
     input  wire       clk,
-    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1770,7 +1768,6 @@ module QL_DSP2_MULT_REGOUT ( // TODO: Name subject to change
 
     (* clkbuf_sink *)
     input  wire       clk,
-    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1826,7 +1823,6 @@ module QL_DSP2_MULT_REGIN_REGOUT ( // TODO: Name subject to change
 
     (* clkbuf_sink *)
     input  wire       clk,
-    // Port not available in architecture file
     input  wire       reset,
 
     input  wire       unsigned_a,
@@ -1880,14 +1876,12 @@ module QL_DSP2_MULTADD (
     input  wire [17:0] b,
     output wire [37:0] z,
 
-    // begin: Ports not available in architecture file
     (* clkbuf_sink *)
     input  wire        clk,
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
     input  wire        load_acc,
-    // end: Ports not available in architecture file
     input  wire        unsigned_a,
     input  wire        unsigned_b,
     input  wire        subtract
@@ -1946,7 +1940,6 @@ module QL_DSP2_MULTADD_REGIN (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2007,7 +2000,6 @@ module QL_DSP2_MULTADD_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2068,7 +2060,6 @@ module QL_DSP2_MULTADD_REGIN_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2129,12 +2120,10 @@ module QL_DSP2_MULTACC (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // begin: Ports not available in architecture file
     input  wire        reset,
 
-    input  wire        load_acc,
-    // end: Ports not available in architecture file
     input  wire [ 2:0] feedback,
+    input  wire        load_acc,
     input  wire        unsigned_a,
     input  wire        unsigned_b,
     input  wire        subtract
@@ -2191,7 +2180,6 @@ module QL_DSP2_MULTACC_REGIN (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2252,7 +2240,6 @@ module QL_DSP2_MULTACC_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -2313,7 +2300,6 @@ module QL_DSP2_MULTACC_REGIN_REGOUT (
 
     (* clkbuf_sink *)
     input  wire        clk,
-    // Port not available in architecture file
     input  wire        reset,
 
     input  wire [ 2:0] feedback,

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1883,8 +1883,6 @@ module QL_DSP2_MULTADD (
     input  wire [17:0] b,
     output wire [37:0] z,
 
-    (* clkbuf_sink *)
-    input  wire        clk,
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
@@ -1927,8 +1925,6 @@ module QL_DSP2_MULTADD (
         .b(b),
         .z(z),
 
-//        .f_mode(f_mode),
-
         .feedback(feedback),
         .acc_fir(acc_fir),
         .load_acc(load_acc),
@@ -1936,7 +1932,6 @@ module QL_DSP2_MULTADD (
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),
 
-        .clk(clk),
         .reset(reset),
         .subtract(subtract)
     );

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1888,6 +1888,7 @@ module QL_DSP2_MULTADD (
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
+    input  wire [ 5:0] acc_fir,
     input  wire        load_acc,
     input  wire        unsigned_a,
     input  wire        unsigned_b,
@@ -1929,6 +1930,7 @@ module QL_DSP2_MULTADD (
 //        .f_mode(f_mode),
 
         .feedback(feedback),
+        .acc_fir(acc_fir),
         .load_acc(load_acc),
 
         .unsigned_a(unsigned_a),
@@ -1950,6 +1952,7 @@ module QL_DSP2_MULTADD_REGIN (
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
+    input  wire [ 5:0] acc_fir,
     input  wire        load_acc,
     input  wire        unsigned_a,
     input  wire        unsigned_b,
@@ -1989,6 +1992,7 @@ module QL_DSP2_MULTADD_REGIN (
         .z(z),
 
         .feedback(feedback),
+        .acc_fir(acc_fir),
         .load_acc(load_acc),
 
         .unsigned_a(unsigned_a),
@@ -2010,6 +2014,7 @@ module QL_DSP2_MULTADD_REGOUT (
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
+    input  wire [ 5:0] acc_fir,
     input  wire        load_acc,
     input  wire        unsigned_a,
     input  wire        unsigned_b,
@@ -2049,6 +2054,7 @@ module QL_DSP2_MULTADD_REGOUT (
         .z(z),
 
         .feedback(feedback),
+        .acc_fir(acc_fir),
         .load_acc(load_acc),
 
         .unsigned_a(unsigned_a),
@@ -2070,6 +2076,7 @@ module QL_DSP2_MULTADD_REGIN_REGOUT (
     input  wire        reset,
 
     input  wire [ 2:0] feedback,
+    input  wire [ 5:0] acc_fir,
     input  wire        load_acc,
     input  wire        unsigned_a,
     input  wire        unsigned_b,
@@ -2109,6 +2116,7 @@ module QL_DSP2_MULTADD_REGIN_REGOUT (
         .z(z),
 
         .feedback(feedback),
+        .acc_fir(acc_fir),
         .load_acc(load_acc),
 
         .unsigned_a(unsigned_a),

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1660,6 +1660,7 @@ module QL_DSP2_MULT ( // TODO: Name subject to change
 
     input  wire       reset,
 
+    input  wire [2:0] feedback,
     input  wire       unsigned_a,
     input  wire       unsigned_b
 );
@@ -1698,7 +1699,7 @@ module QL_DSP2_MULT ( // TODO: Name subject to change
 
         .reset(reset),
 
-        .feedback(3'b0),
+        .feedback(feedback),
 
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b)
@@ -1713,6 +1714,8 @@ module QL_DSP2_MULT_REGIN ( // TODO: Name subject to change
     (* clkbuf_sink *)
     input  wire       clk,
     input  wire       reset,
+
+    input  wire [2:0] feedback,
 
     input  wire       unsigned_a,
     input  wire       unsigned_b
@@ -1751,7 +1754,7 @@ module QL_DSP2_MULT_REGIN ( // TODO: Name subject to change
         .b(b),
         .z(z),
 
-        .feedback(3'b0),
+        .feedback(feedback),
 
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),
@@ -1769,6 +1772,8 @@ module QL_DSP2_MULT_REGOUT ( // TODO: Name subject to change
     (* clkbuf_sink *)
     input  wire       clk,
     input  wire       reset,
+
+    input  wire [2:0] feedback,
 
     input  wire       unsigned_a,
     input  wire       unsigned_b
@@ -1806,7 +1811,7 @@ module QL_DSP2_MULT_REGOUT ( // TODO: Name subject to change
         .b(b),
         .z(z),
 
-        .feedback(3'b0),
+        .feedback(feedback),
 
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),
@@ -1824,6 +1829,8 @@ module QL_DSP2_MULT_REGIN_REGOUT ( // TODO: Name subject to change
     (* clkbuf_sink *)
     input  wire       clk,
     input  wire       reset,
+
+    input  wire [2:0] feedback,
 
     input  wire       unsigned_a,
     input  wire       unsigned_b
@@ -1861,7 +1868,7 @@ module QL_DSP2_MULT_REGIN_REGOUT ( // TODO: Name subject to change
         .b(b),
         .z(z),
 
-        .feedback(3'b0),
+        .feedback(feedback),
 
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
@@ -28,13 +28,7 @@ module dsp_t1_20x18x64 (
     input         load_acc_i,
     input         unsigned_a_i,
     input         unsigned_b_i,
-
-    input  [2:0]  output_select_i,
-    input         saturate_enable_i,
-    input  [5:0]  shift_right_i,
-    input         round_i,
-    input         subtract_i,
-    input         register_inputs_i
+    input         subtract_i
 );
 
     parameter [19:0] COEFF_0 = 20'd0;
@@ -42,8 +36,25 @@ module dsp_t1_20x18x64 (
     parameter [19:0] COEFF_2 = 20'd0;
     parameter [19:0] COEFF_3 = 20'd0;
 
+    parameter [2:0] OUTPUT_SELECT   = 3'd0;
+    parameter [0:0] SATURATE_ENABLE = 1'd0;
+    parameter [5:0] SHIFT_RIGHT     = 6'd0;
+    parameter [0:0] ROUND           = 1'd0;
+    parameter [0:0] REGISTER_INPUTS = 1'd0;
+
     QL_DSP2 # (
-        .MODE_BITS          ({COEFF_3, COEFF_2, COEFF_1, COEFF_0})
+        .MODE_BITS ({
+            REGISTER_INPUTS,
+            ROUND,
+            SHIFT_RIGHT,
+            SATURATE_ENABLE,
+            OUTPUT_SELECT,
+            1'b0, // Not fractured
+            COEFF_3,
+            COEFF_2,
+            COEFF_1,
+            COEFF_0
+        })
     ) _TECHMAP_REPLACE_ (
         .a                  (a_i),
         .b                  (b_i),
@@ -58,14 +69,7 @@ module dsp_t1_20x18x64 (
         .load_acc           (load_acc_i),
         .unsigned_a         (unsigned_a_i),
         .unsigned_b         (unsigned_b_i),
-
-        .f_mode             (1'b0), // No fracturation
-        .output_select      (output_select_i),
-        .saturate_enable    (saturate_enable_i),
-        .shift_right        (shift_right_i),
-        .round              (round_i),
-        .subtract           (subtract_i),
-        .register_inputs    (register_inputs_i)
+        .subtract           (subtract_i)
     );
 
 endmodule
@@ -85,13 +89,7 @@ module dsp_t1_10x9x32 (
     input         load_acc_i,
     input         unsigned_a_i,
     input         unsigned_b_i,
-
-    input  [2:0]  output_select_i,
-    input         saturate_enable_i,
-    input  [5:0]  shift_right_i,
-    input         round_i,
-    input         subtract_i,
-    input         register_inputs_i
+    input         subtract_i
 );
 
     parameter [9:0] COEFF_0 = 10'd0;
@@ -99,14 +97,28 @@ module dsp_t1_10x9x32 (
     parameter [9:0] COEFF_2 = 10'd0;
     parameter [9:0] COEFF_3 = 10'd0;
 
+    parameter [2:0] OUTPUT_SELECT   = 3'd0;
+    parameter [0:0] SATURATE_ENABLE = 1'd0;
+    parameter [5:0] SHIFT_RIGHT     = 6'd0;
+    parameter [0:0] ROUND           = 1'd0;
+    parameter [0:0] REGISTER_INPUTS = 1'd0;
+
     wire [37:0] z;
     wire [17:0] dly_b;
 
     QL_DSP2 # (
-        .MODE_BITS          ({10'd0, COEFF_3,
-                              10'd0, COEFF_2,
-                              10'd0, COEFF_1,
-                              10'd0, COEFF_0})
+        .MODE_BITS  ({
+            REGISTER_INPUTS,
+            ROUND,
+            SHIFT_RIGHT,
+            SATURATE_ENABLE,
+            OUTPUT_SELECT,
+            1'b1, // Fractured
+            10'd0, COEFF_3,
+            10'd0, COEFF_2,
+            10'd0, COEFF_1,
+            10'd0, COEFF_0
+        })
     ) _TECHMAP_REPLACE_ (
         .a                  ({10'd0, a_i}),
         .b                  ({ 9'd0, b_i}),
@@ -121,14 +133,7 @@ module dsp_t1_10x9x32 (
         .load_acc           (load_acc_i),
         .unsigned_a         (unsigned_a_i),
         .unsigned_b         (unsigned_b_i),
-
-        .f_mode             (1'b1), // Enable fractuation, Use the lower half
-        .output_select      (output_select_i),
-        .saturate_enable    (saturate_enable_i),
-        .shift_right        (shift_right_i),
-        .round              (round_i),
-        .subtract           (subtract_i),
-        .register_inputs    (register_inputs_i)
+        .subtract           (subtract_i)
     );
 
     assign z_o = z[18:0];

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
@@ -33,7 +33,13 @@ module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
                (B_SIGNED) ? {{(18 - B_WIDTH){B[B_WIDTH-1]}}, B} :
                             {{(18 - B_WIDTH){1'b0}},         B};
 
-    dsp_t1_20x18x64 _TECHMAP_REPLACE_ (
+    dsp_t1_20x18x64 # (
+        .OUTPUT_SELECT       (3'd0),
+        .SATURATE_ENABLE     (1'd0),
+        .SHIFT_RIGHT         (6'd0),
+        .ROUND               (1'd0),
+        .REGISTER_INPUTS     (1'd0)
+    ) _TECHMAP_REPLACE_ (
         .a_i                (a),
         .b_i                (b),
         .acc_fir_i          (6'd0),
@@ -43,13 +49,7 @@ module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
         .load_acc_i         (1'b0),
         .unsigned_a_i       (!A_SIGNED),
         .unsigned_b_i       (!B_SIGNED),
-
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b0)
+	.subtract_i         (1'b0)
     );
 
     assign Y = z;
@@ -75,7 +75,13 @@ module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
                (B_SIGNED) ? {{( 9 - B_WIDTH){B[B_WIDTH-1]}}, B} :
                             {{( 9 - B_WIDTH){1'b0}},         B};
 
-    dsp_t1_10x9x32 _TECHMAP_REPLACE_ (
+    dsp_t1_10x9x32 # (
+        .OUTPUT_SELECT       (3'd0),
+        .SATURATE_ENABLE     (1'd0),
+        .SHIFT_RIGHT         (6'd0),
+        .ROUND               (1'd0),
+        .REGISTER_INPUTS     (1'd0)
+    ) _TECHMAP_REPLACE_ (
         .a_i                (a),
         .b_i                (b),
         .acc_fir_i          (6'd0),
@@ -85,13 +91,7 @@ module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
         .load_acc_i         (1'b0),
         .unsigned_a_i       (!A_SIGNED),
         .unsigned_b_i       (!B_SIGNED),
-
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b0)
+	.subtract_i         (1'b0)
     );
 
     assign Y = z;

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -16,36 +16,39 @@
 
 # The bram test will be enable in a future PR after it's been fixed.
 
-TESTS = consts \
-	dffs \
-	latches \
-	shreg \
-	iob_no_flatten \
-	full_adder \
-	mac_unit \
-	multiplier \
-	logic \
-	mux \
-	tribuf \
-	fsm \
-	pp3_bram \
-    qlf_k6n10f/dsp_mult \
+TESTS = \
+    consts \
+    dffs \
+    latches \
+    shreg \
+    iob_no_flatten \
+    full_adder \
+    mac_unit \
+    multiplier \
+    logic \
+    mux \
+    tribuf \
+    fsm \
+    pp3_bram \
     qlf_k6n10f/dsp_simd \
+    qlf_k6n10f/dsp_mult \
     qlf_k6n10f/dsp_macc \
-#	qlf_k6n10_bram \
+#   qlf_k6n10_bram \
 
 SIM_TESTS = \
     qlf_k6n10f/sim_dsp_mult \
     qlf_k6n10f/sim_dsp_mult_r \
     qlf_k6n10f/sim_dsp_fir \
-    qlf_k6n10f/sim_tc36fifo
+    qlf_k6n10f/sim_tc36fifo \
+    qlf_k6n10f/sim_dsp_simd_presynth \
 
 # Those tests perform synthesis and simulation of synthesis results
 POST_SYNTH_SIM_TESTS = \
     qlf_k6n10f/bram_tdp \
     qlf_k6n10f/bram_sdp \
     qlf_k6n10f/bram_tdp_split \
-    qlf_k6n10f/bram_sdp_split
+    qlf_k6n10f/bram_sdp_split \
+    qlf_k6n10f/sim_dsp_simd
 
 include $(shell pwd)/../../Makefile_test.common
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
@@ -16,65 +16,67 @@
 
 module simd_mult (
     input  wire         clk,
-                
+
     input  wire [ 7:0]  a0,
     input  wire [ 7:0]  b0,
     output wire [15:0]  z0,
-                
+
     input  wire [ 7:0]  a1,
     input  wire [ 7:0]  b1,
     output wire [15:0]  z1
 );
 
-    dsp_t1_10x9x32 dsp_0 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_0 (
         .a_i    (a0),
         .b_i    (b0),
         .z_o    (z0),
 
         .clock_i            (clk),
 
+	.acc_fir_i          (6'b0),
         .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
+        .subtract_i         (1'b0)
+    );
 
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
-
-    dsp_t1_10x9x32 dsp_1 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_1 (
         .a_i    (a1),
         .b_i    (b1),
         .z_o    (z1),
 
         .clock_i            (clk),
 
+	.acc_fir_i          (6'b0),
         .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
-
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
+        .subtract_i         (1'b0)
+    );
 
 endmodule
 
 module simd_mult_inferred (
     input  wire         clk,
-                
+
     input  wire [ 7:0]  a0,
     input  wire [ 7:0]  b0,
     output reg  [15:0]  z0,
-                
+
     input  wire [ 7:0]  a1,
     input  wire [ 7:0]  b1,
     output reg  [15:0]  z1
@@ -90,11 +92,11 @@ endmodule
 
 module simd_mult_odd (
     input  wire         clk,
-                
+
     input  wire [ 7:0]  a0,
     input  wire [ 7:0]  b0,
     output wire [15:0]  z0,
-                
+
     input  wire [ 7:0]  a1,
     input  wire [ 7:0]  b1,
     output wire [15:0]  z1,
@@ -104,7 +106,13 @@ module simd_mult_odd (
     output wire [15:0]  z2
 );
 
-    dsp_t1_10x9x32 dsp_0 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_0 (
         .a_i    (a0),
         .b_i    (b0),
         .z_o    (z0),
@@ -116,15 +124,16 @@ module simd_mult_odd (
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
 
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
+        .subtract_i         (1'b0)
+    );
 
-    dsp_t1_10x9x32 dsp_1 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_1 (
         .a_i    (a1),
         .b_i    (b1),
         .z_o    (z1),
@@ -136,15 +145,16 @@ module simd_mult_odd (
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
 
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
+        .subtract_i         (1'b0)
+    );
 
-    dsp_t1_10x9x32 dsp_2 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_2 (
         .a_i    (a2),
         .b_i    (b2),
         .z_o    (z2),
@@ -156,30 +166,31 @@ module simd_mult_odd (
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
 
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
+        .subtract_i         (1'b0)
+    );
 
 endmodule
 
 module simd_mult_conflict (
     input  wire         clk0,
     input  wire         clk1,
-                
+
     input  wire [ 7:0]  a0,
     input  wire [ 7:0]  b0,
     output wire [15:0]  z0,
-                
+
     input  wire [ 7:0]  a1,
     input  wire [ 7:0]  b1,
     output wire [15:0]  z1
 );
 
-    dsp_t1_10x9x32 dsp_0 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_0 (
         .a_i    (a0),
         .b_i    (b0),
         .z_o    (z0),
@@ -191,15 +202,16 @@ module simd_mult_conflict (
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
 
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
+        .subtract_i         (1'b0)
+    );
 
-    dsp_t1_10x9x32 dsp_1 (
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_1 (
         .a_i    (a1),
         .b_i    (b1),
         .z_o    (z1),
@@ -211,13 +223,8 @@ module simd_mult_conflict (
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
 
-        .output_select_i    (3'd0),
-        .saturate_enable_i  (1'b0),
-        .shift_right_i      (6'd0),
-        .round_i            (1'b0),
-        .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
-    );    
+        .subtract_i         (1'b0)
+    );
 
 endmodule
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_fir/sim_dsp_fir.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_fir/sim_dsp_fir.v
@@ -90,6 +90,11 @@ module tb();
     wire signed [37:0] Z;
 
     dsp_t1_sim # (
+        .OUTPUT_SELECT      (3'd1),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd10),
+        .ROUND              (1'd1),
+        .REGISTER_INPUTS    (1'd0)
     ) uut (
         .clock_i		(clk),
         .s_reset		(rst),
@@ -100,12 +105,7 @@ module tb();
         .unsigned_b_i		(1'b0),
         .feedback_i		(stb),
         .load_acc_i		(1'b1),
-        .shift_right_i		(6'd10),
-	.register_inputs_i	(1'b0),
-	.output_select_i	(3'h1),
-	.round_i		(1'b1),
-	.saturate_enable_i	(1'b1),
-	.subtract_i		(1'b0),
+        .subtract_i		(1'b0),
         .z_o			(Z)
     );
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_mult/sim_dsp_mult.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_mult/sim_dsp_mult.v
@@ -48,14 +48,14 @@ module tb();
     wire signed [37:0] Z;
 
     dsp_t1_sim # (
+        .OUTPUT_SELECT      (3'd0),
+        .REGISTER_INPUTS    (1'd0)
     ) uut (
         .a_i            	(A),
         .b_i            	(B),
         .unsigned_a_i   	(1'h0),
         .unsigned_b_i   	(1'h0),
         .feedback_i     	(3'h0),
-	.register_inputs_i	(1'h0),
-	.output_select_i	(3'h0),
         .z_o            	(Z)
     );
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_mult_r/sim_dsp_mult_r.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_mult_r/sim_dsp_mult_r.v
@@ -52,14 +52,14 @@ module tb();
     wire signed [37:0] Z;
 
     dsp_t1_sim # (
+        .OUTPUT_SELECT      (3'd0),
+        .REGISTER_INPUTS    (1'd1)
     ) uut (
         .a_i			(A),
         .b_i			(B),
         .unsigned_a_i		(1'h0),
         .unsigned_b_i		(1'h0),
         .feedback_i		(3'h0),
-	.register_inputs_i	(1'h1),
-	.output_select_i	(3'h0),
 	.clock_i		(clk),
         .z_o			(Z)
     );

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = sim_dsp_simd_tb.v
+POST_SYNTH = sim_dsp_simd_post_synth sim_dsp_simd_explicit_post_synth
+TOP = sim_dsp_simd sim_dsp_simd_explicit
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+sim:
+	$(call simulate_post_synth,1)
+	$(call simulate_post_synth,2)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim/sim_dsp_simd_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim/sim_dsp_simd_tb.v
@@ -1,0 +1,122 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module tb();
+
+    // Clock
+    reg clk;
+    initial clk <= 1'b0;
+    always #1 clk <= ~clk;
+
+    // Data Clock
+    reg dclk;
+    initial dclk <= 1'b0;
+    always #2 dclk <= ~dclk;
+
+    // Input data / reference
+    reg [9:0] A0;
+    reg [9:0] A1;
+
+    reg [8:0] B0;
+    reg [8:0] B1;
+
+    reg [18:0] C0;
+    reg [18:0] C1;
+
+    always @(negedge dclk) begin
+        A0 = $random;
+        B0 = $random;
+
+        C0 <= A0 * B0;
+
+        A1 = $random;
+        B1 = $random;
+
+        C1 <= A1 * B1;
+    end
+
+    // UUT
+    wire [18:0] Z0;
+    wire [18:0] Z1;
+
+    case (`STRINGIFY(`TOP))
+        "sim_dsp_simd": begin
+            sim_dsp_simd dsp0 (
+                .clk(clk),
+                .a0(A0),
+                .a1(A1),
+                .b0(B0),
+                .b1(B1),
+                .z0(Z0),
+                .z1(Z1));
+        end
+        "sim_dsp_simd_explicit": begin
+            sim_dsp_simd_explicit dsp1 (
+                .clk(clk),
+                .a0(A0),
+                .a1(A1),
+                .b0(B0),
+                .b1(B1),
+                .z0(Z0),
+                .z1(Z1));
+       end
+    endcase
+
+    reg [18:0] C0_r;
+    reg [18:0] C1_r;
+
+    always @(posedge clk) begin
+        C0_r = C0;
+        C1_r = C1;
+    end
+
+    // Error detection
+    wire error0 = (Z0 !== C0_r) && (C0_r !== 19'bx);
+    wire error1 = (Z1 !== C1_r) && (C0_r !== 19'bx);
+
+    // Error counting
+    integer error_count = 0;
+
+    always @(posedge clk) begin
+        if (error0) begin
+            error_count <= error_count + 1'b1;
+            $display("%d: DSP_0: FAIL: mismatch act=%x exp=%x at A0=%x; B0=%x", $time, Z0, C0_r, A0, B0);
+        end else begin
+            $display("%d: DSP_0: OK: act=%x exp=%x at A0=%x; B0=%x", $time, Z0, C0_r, A0, B0);
+        end
+    end
+
+    always @(posedge clk) begin
+        if (error1) begin
+            error_count <= error_count + 1'b1;
+            $display("%d: DSP_1: FAIL: mismatch act=%x exp=%x at A1=%x; B1=%x", $time, Z1, C1_r, A1, B1);
+        end else begin
+            $display("%d: DSP_1: OK: act=%x exp=%x at A1=%x; B1=%x", $time, Z1, C1_r, A1, B1);
+        end
+    end
+
+    // Simulation control / data dump
+    initial begin
+        $dumpfile(`STRINGIFY(`VCD));
+        $dumpvars;
+        #10000 $finish_and_return( (error_count == 0) ? 0 : -1 );
+    end
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim_dsp_simd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim_dsp_simd.tcl
@@ -1,0 +1,27 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save sim_dsp_simd
+
+select sim_dsp_simd
+select *
+synth_quicklogic -family qlf_k6n10f -top sim_dsp_simd
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/sim_dsp_simd_post_synth.v
+select -assert-count 1 t:QL_DSP2_MULT
+
+select -clear
+design -load sim_dsp_simd
+select sim_dsp_simd_explicit
+select *
+synth_quicklogic -family qlf_k6n10f -top sim_dsp_simd_explicit
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/sim_dsp_simd_explicit_post_synth.v
+select -assert-count 1 t:QL_DSP2_MULT_REGIN

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim_dsp_simd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd/sim_dsp_simd.v
@@ -1,0 +1,91 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module sim_dsp_simd (
+    input  wire         clk,
+
+    input  wire [ 9:0]  a0,
+    input  wire [ 8:0]  b0,
+    output reg  [18:0]  z0,
+
+    input  wire [ 9:0]  a1,
+    input  wire [ 8:0]  b1,
+    output reg  [18:0]  z1
+);
+
+    always @(posedge clk)
+        z0 <= a0 * b0;
+
+    always @(posedge clk)
+        z1 <= a1 * b1;
+
+endmodule
+
+module sim_dsp_simd_explicit (
+    input  wire         clk,
+
+    input  wire [ 9:0]  a0,
+    input  wire [ 8:0]  b0,
+    output reg  [18:0]  z0,
+
+    input  wire [ 9:0]  a1,
+    input  wire [ 8:0]  b1,
+    output reg  [18:0]  z1
+);
+
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_0 (
+        .a_i                (a0),
+        .b_i                (b0),
+        .z_o                (z0),
+
+        .clock_i            (clk),
+
+        .acc_fir_i          (6'b0),
+        .feedback_i         (3'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+        .subtract_i         (1'b0)
+    );
+
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_1 (
+        .a_i                (a1),
+        .b_i                (b1),
+        .z_o                (z1),
+
+        .clock_i            (clk),
+
+        .acc_fir_i          (6'b0),
+        .feedback_i         (3'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+        .subtract_i         (1'b0)
+    );
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd_presynth/sim_dsp_simd_presynth.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/sim_dsp_simd_presynth/sim_dsp_simd_presynth.v
@@ -1,0 +1,167 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`include "qlf_k6n10f/cells_sim.v"
+`timescale 1ns/1ps
+
+module tb();
+
+    // Clock
+    reg clk;
+    initial clk <= 1'b0;
+    always #1 clk <= ~clk;
+
+    // Data Clock
+    reg dclk;
+    initial dclk <= 1'b0;
+    always #2 dclk <= ~dclk;
+
+    // Input data / reference
+    reg [7:0] A0;
+    reg [7:0] A1;
+
+    reg [7:0] B0;
+    reg [7:0] B1;
+
+    reg [15:0] C0;
+    reg [15:0] C1;
+
+    always @(negedge dclk) begin
+        A0 = $random;
+        B0 = $random;
+
+        C0 <= A0 * B0;
+
+        A1 = $random;
+        B1 = $random;
+
+        C1 <= A1 * B1;
+    end
+
+    // UUT
+    wire [15:0] Z0;
+    wire [15:0] Z1;
+
+    sim_dsp_simd_explicit dsp1 (
+    	.clk(clk),
+    	.a0(A0),
+    	.a1(A1),
+    	.b0(B0),
+    	.b1(B1),
+    	.z0(Z0),
+    	.z1(Z1)
+    );
+
+    reg [15:0] C0_r;
+    reg [15:0] C1_r;
+
+    always @(posedge clk) begin
+        C0_r = C0;
+        C1_r = C1;
+    end
+
+    // Error detection
+    wire error0 = (Z0 !== C0_r) && (C0_r !== 16'bx);
+    wire error1 = (Z1 !== C1_r) && (C0_r !== 16'bx);
+
+    // Error counting
+    integer error_count = 0;
+
+    always @(posedge clk) begin
+        if (error0) begin
+            error_count <= error_count + 1'b1;
+            $display("%d: DSP_0: FAIL: mismatch act=%x exp=%x at A0=%x; B0=%x", $time, Z0, C0_r, A0, B0);
+        end else begin
+            $display("%d: DSP_0: OK: act=%x exp=%x at A0=%x; B0=%x", $time, Z0, C0_r, A0, B0);
+        end
+    end
+
+    always @(posedge clk) begin
+        if (error1) begin
+            error_count <= error_count + 1'b1;
+            $display("%d: DSP_1: FAIL: mismatch act=%x exp=%x at A1=%x; B1=%x", $time, Z1, C1_r, A1, B1);
+        end else begin
+            $display("%d: DSP_1: OK: act=%x exp=%x at A1=%x; B1=%x", $time, Z1, C1_r, A1, B1);
+        end
+    end
+
+    // Simulation control / data dump
+    initial begin
+        $dumpfile(`VCD_FILE);
+        $dumpvars;
+        #10000 $finish_and_return( (error_count == 0) ? 0 : -1 );
+    end
+
+endmodule
+
+module sim_dsp_simd_explicit (
+    input  wire         clk,
+
+    input  wire [ 7:0]  a0,
+    input  wire [ 7:0]  b0,
+    output wire [15:0]  z0,
+
+    input  wire [ 7:0]  a1,
+    input  wire [ 7:0]  b1,
+    output wire [15:0]  z1
+);
+
+    wire [2:0] z0_rem;
+    wire [2:0] z1_rem;
+
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_0 (
+        .a_i                ({2'b0, a0}),
+        .b_i                ({1'b0, b0}),
+        .z_o                ({z0_rem, z0}),
+
+        .clock_i            (clk),
+
+        .acc_fir_i          (6'b0),
+        .feedback_i         (3'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+        .subtract_i         (1'b0)
+    );
+
+    dsp_t1_10x9x32 #(
+        .OUTPUT_SELECT      (3'd0),
+        .SATURATE_ENABLE    (1'd0),
+        .SHIFT_RIGHT        (6'd0),
+        .ROUND              (1'd0),
+        .REGISTER_INPUTS    (1'd1)
+    ) dsp_1 (
+        .a_i                ({2'b0, a1}),
+        .b_i                ({1'b0, b1}),
+        .z_o                ({z1_rem, z1}),
+
+        .clock_i            (clk),
+
+        .acc_fir_i          (6'b0),
+        .feedback_i         (3'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+        .subtract_i         (1'b0)
+    );
+
+endmodule


### PR DESCRIPTION
This PR is a follow up to https://github.com/chipsalliance/yosys-f4pga-plugins/pull/318. It rearranges `feedback`, `output_select` and `register_inputs` ports in DSP simulation models, adds `acc_fir` to `QL_DSP2_MULTADD*` cells and removes unnecessary `clk` from `QL_DSP2_MULTADD`. @rakeshm75, @tpagarani - please have a look at this and let me know if everything is ok.