### PR TITLE
Synchronous S/R flip-flop inference for QuickLogic k6n10f

### DIFF
--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -23,11 +23,11 @@ module sh_dff(
     (* clkbuf_sink *)
     input wire C
 );
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
 
+    initial Q <= 1'b0;
     always @(posedge C)
-            Q <= D;
+        Q <= D;
+
 endmodule
 
 (* abc9_box, lib_blackbox *)

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -75,8 +75,6 @@ module adder_lut5(
 
 endmodule
 
-
-
 (* abc9_lut=1, lib_whitebox *)
 module frac_lut6(
     input wire [0:5] in,
@@ -126,171 +124,36 @@ module frac_lut6(
 
 endmodule
 
+
 (* abc9_flop, lib_whitebox *)
 module dff(
     output reg Q,
     input wire D,
     (* clkbuf_sink *)
-    (* invertible_pin = "IS_C_INVERTED" *)
     input wire C
 );
-    parameter [0:0] INIT = 1'b0;
-    parameter [0:0] IS_C_INVERTED = 1'b0;
-    initial Q = INIT;
-    case(|IS_C_INVERTED)
-          1'b0:
-            always @(posedge C)
-                Q <= D;
-          1'b1:
-            always @(negedge C)
-                Q <= D;
-    endcase
+    initial Q <= 1'b0;
+
+    always @(posedge C)
+      Q <= D;
+
 endmodule
 
 (* abc9_flop, lib_whitebox *)
-module dffr(
+module dffn(
     output reg Q,
     input wire D,
-    input wire R,
     (* clkbuf_sink *)
-    (* invertible_pin = "IS_C_INVERTED" *)
     input wire C
 );
-    parameter [0:0] INIT = 1'b0;
-    parameter [0:0] IS_C_INVERTED = 1'b0;
-    initial Q = INIT;
-    case(|IS_C_INVERTED)
-          1'b0:
-            always @(posedge C or posedge R)
-                if (R)
-                        Q <= 1'b0;
-                else
-                        Q <= D;
-          1'b1:
-            always @(negedge C or posedge R)
-                if (R)
-                        Q <= 1'b0;
-                else
-                        Q <= D;
-    endcase
+    initial Q <= 1'b0;
+
+    always @(negedge C)
+      Q <= D;
+
 endmodule
 
 (* abc9_flop, lib_whitebox *)
-module dffre(
-    output reg Q,
-    input wire D,
-    input wire R,
-    input wire E,
-    (* clkbuf_sink *)
-    (* invertible_pin = "IS_C_INVERTED" *)
-    input wire C
-);
-    parameter [0:0] INIT = 1'b0;
-    parameter [0:0] IS_C_INVERTED = 1'b0;
-    initial Q = INIT;
-    case(|IS_C_INVERTED)
-          1'b0:
-            always @(posedge C or posedge R)
-              if (R)
-                Q <= 1'b0;
-              else if(E)
-                Q <= D;
-          1'b1:
-            always @(negedge C or posedge R)
-              if (R)
-                Q <= 1'b0;
-              else if(E)
-                Q <= D;
-        endcase
-endmodule
-
-module dffs(
-    output reg Q,
-    input wire D,
-    (* clkbuf_sink *)
-    (* invertible_pin = "IS_C_INVERTED" *)
-    input wire C,
-    input wire S
-);
-    parameter [0:0] INIT = 1'b0;
-    parameter [0:0] IS_C_INVERTED = 1'b0;
-    initial Q = INIT;
-    case(|IS_C_INVERTED)
-          1'b0:
-            always @(posedge C or negedge S)
-              if (S)
-                Q <= 1'b1;
-              else
-                Q <= D;
-          1'b1:
-            always @(negedge C or negedge S)
-              if (S)
-                Q <= 1'b1;
-              else
-                Q <= D;
-        endcase
-endmodule
-
-module dffse(
-    output reg Q,
-    input wire D,
-    (* clkbuf_sink *)
-    (* invertible_pin = "IS_C_INVERTED" *)
-    input wire C,
-    input wire S,
-    input wire E
-);
-    parameter [0:0] INIT = 1'b0;
-    parameter [0:0] IS_C_INVERTED = 1'b0;
-    initial Q = INIT;
-    case(|IS_C_INVERTED)
-          1'b0:
-            always @(posedge C or negedge S)
-              if (S)
-                Q <= 1'b1;
-              else if(E)
-                Q <= D;
-          1'b1:
-            always @(negedge C or negedge S)
-              if (S)
-                Q <= 1'b1;
-              else if(E)
-                Q <= D;
-        endcase
-endmodule
-
-module dffsr(
-    output reg Q,
-    input wire D,
-    (* clkbuf_sink *)
-    (* invertible_pin = "IS_C_INVERTED" *)
-    input wire C,
-    input wire R,
-    input wire S
-);
-    parameter [0:0] INIT = 1'b0;
-    parameter [0:0] IS_C_INVERTED = 1'b0;
-    initial Q = INIT;
-    case(|IS_C_INVERTED)
-          1'b0:
-            always @(posedge C or negedge S or negedge R)
-              if (S)
-                Q <= 1'b1;
-              else if (R)
-                Q <= 1'b0;
-              else
-                Q <= D;
-          1'b1:
-            always @(negedge C or negedge S or negedge R)
-              if (S)
-                Q <= 1'b1;
-              else if (R)
-                Q <= 1'b0;
-              else
-                Q <= D;
-        endcase
-endmodule
-
 module dffsre(
     output reg Q,
     input wire D,
@@ -300,19 +163,19 @@ module dffsre(
     input wire R,
     input wire S
 );
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
+    initial Q <= 1'b0;
 
-        always @(posedge C or negedge S or negedge R)
-          if (!R)
-            Q <= 1'b0;
-          else if (!S)
-            Q <= 1'b1;
-          else if (E)
-            Q <= D;
-        
+    always @(posedge C or negedge S or negedge R)
+      if (!R)
+        Q <= 1'b0;
+      else if (!S)
+        Q <= 1'b1;
+      else if (E)
+        Q <= D;
+
 endmodule
 
+(* abc9_flop, lib_whitebox *)
 module dffnsre(
     output reg Q,
     input wire D,
@@ -322,17 +185,86 @@ module dffnsre(
     input wire R,
     input wire S
 );
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
+    initial Q <= 1'b0;
 
-        always @(negedge C or negedge S or negedge R)
-          if (!R)
-            Q <= 1'b0;
-          else if (!S)
-            Q <= 1'b1;
-          else if (E)
-            Q <= D;
-        
+    always @(negedge C or negedge S or negedge R)
+      if (!R)
+        Q <= 1'b0;
+      else if (!S)
+        Q <= 1'b1;
+      else if (E)
+        Q <= D;
+
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module sdffsre(
+    output reg Q,
+    input wire D,
+    (* clkbuf_sink *)
+    input wire C,
+    input wire E,
+    input wire R,
+    input wire S
+);
+    initial Q <= 1'b0;
+
+    always @(posedge C)
+      if (!R)
+        Q <= 1'b0;
+      else if (!S)
+        Q <= 1'b1;
+      else if (E)
+        Q <= D;
+
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module sdffnsre(
+    output reg Q,
+    input wire D,
+    (* clkbuf_sink *)
+    input wire C,
+    input wire E,
+    input wire R,
+    input wire S
+);
+    initial Q <= 1'b0;
+
+    always @(negedge C)
+      if (!R)
+        Q <= 1'b0;
+      else if (!S)
+        Q <= 1'b1;
+      else if (E)
+        Q <= D;
+
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module latch (
+    output reg Q,
+    input wire D,
+    input wire G
+);
+    initial Q <= 1'b0;
+
+    always @(G)
+      if (G) Q <= D;
+
+endmodule
+
+(* abc9_flop, lib_whitebox *)
+module latchn (
+    output reg Q,
+    input wire D,
+    input wire G
+);
+    initial Q <= 1'b0;
+
+    always @(G)
+      if (!G) Q <= D;
+
 endmodule
 
 (* abc9_flop, lib_whitebox *)
@@ -344,17 +276,18 @@ module latchsre (
     input wire G,
     input wire E
 );
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
+    initial Q <= 1'b0;
+
     always @*
       begin
-        if (!R) 
+        if (!R)
           Q <= 1'b0;
-        else if (!S) 
+        else if (!S)
           Q <= 1'b1;
-        else if (E && G) 
+        else if (E && G)
           Q <= D;
       end
+
 endmodule
 
 (* abc9_flop, lib_whitebox *)
@@ -366,31 +299,20 @@ module latchnsre (
     input wire G,
     input wire E
 );
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
+    initial Q <= 1'b0;
+
     always @*
       begin
-        if (!R) 
+        if (!R)
           Q <= 1'b0;
-        else if (!S) 
+        else if (!S)
           Q <= 1'b1;
-        else if (E && !G) 
+        else if (E && !G)
           Q <= D;
       end
+
 endmodule
 
-(* abc9_flop, lib_whitebox *)
-module scff(
-    output reg Q,
-    input wire D,
-    input wire clk
-);
-    parameter [0:0] INIT = 1'b0;
-    initial Q = INIT;
-
-    always @(posedge clk)
-            Q <= D;
-endmodule
 
 module TDP_BRAM18 (
     (* clkbuf_sink *)
@@ -1255,10 +1177,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
             assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
             assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
-	    defparam bram_2x18k.MODE_BITS = { 1'b1,
-		11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
-		12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
-	    };
+        defparam bram_2x18k.MODE_BITS = { 1'b1,
+        11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+        12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+        };
         end
 
         2: begin
@@ -1266,10 +1188,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 1) : (F1EN ? (F1ADDR_TOTAL << 1) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 1) : (H1EN ? (H1ADDR_TOTAL << 1) : 14'd0);
-	    defparam bram_2x18k.MODE_BITS = { 1'b1,
-		11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
-		12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
-	    };
+        defparam bram_2x18k.MODE_BITS = { 1'b1,
+        11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+        12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+        };
         end
 
         4: begin
@@ -1277,10 +1199,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 2) : (D1EN ? (D1ADDR_TOTAL << 2) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 2) : (F1EN ? (F1ADDR_TOTAL << 2) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 2) : (H1EN ? (H1ADDR_TOTAL << 2) : 14'd0);
-	    defparam bram_2x18k.MODE_BITS = { 1'b1,
-		11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
-		12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
-	    };
+        defparam bram_2x18k.MODE_BITS = { 1'b1,
+        11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+        12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+        };
         end
 
         8, 9: begin
@@ -1288,10 +1210,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 3) : (F1EN ? (F1ADDR_TOTAL << 3) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 3) : (H1EN ? (H1ADDR_TOTAL << 3) : 14'd0);
-	    defparam bram_2x18k.MODE_BITS = { 1'b1,
-		11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
-		12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
-	    };
+        defparam bram_2x18k.MODE_BITS = { 1'b1,
+        11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+        12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+        };
         end
 
         16, 18: begin
@@ -1299,10 +1221,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 4) : (F1EN ? (F1ADDR_TOTAL << 4) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 4) : (H1EN ? (H1ADDR_TOTAL << 4) : 14'd0);
-	    defparam bram_2x18k.MODE_BITS = { 1'b1,
-		11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
-		12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
-	    };
+        defparam bram_2x18k.MODE_BITS = { 1'b1,
+        11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+        12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+        };
         end
 
         default: begin
@@ -1310,10 +1232,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
             assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
             assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
-	    defparam bram_2x18k.MODE_BITS = { 1'b1,
-	        11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
-	        12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
-	    };
+        defparam bram_2x18k.MODE_BITS = { 1'b1,
+            11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+            12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+        };
         end
     endcase
 
@@ -1390,15 +1312,15 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
 endmodule
 
 module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, D1ADDR, D1DATA, D1EN);
-	parameter CFG_ABITS = 11;
-	parameter CFG_DBITS = 18;
-	parameter CFG_ENABLE_B = 4;
-	parameter CFG_ENABLE_D = 4;
+    parameter CFG_ABITS = 11;
+    parameter CFG_DBITS = 18;
+    parameter CFG_ENABLE_B = 4;
+    parameter CFG_ENABLE_D = 4;
 
-	parameter CLKPOL2 = 1;
-	parameter CLKPOL3 = 1;
-	parameter [18431:0] INIT0 = 18432'bx;
-	parameter [18431:0] INIT1 = 18432'bx;
+    parameter CLKPOL2 = 1;
+    parameter CLKPOL3 = 1;
+    parameter [18431:0] INIT0 = 18432'bx;
+    parameter [18431:0] INIT1 = 18432'bx;
 
         localparam MODE_36 = 3'b011; // 36- or 32-bit
         localparam MODE_18 = 3'b010; // 18- or 16-bit
@@ -1407,209 +1329,209 @@ module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
         localparam MODE_2 = 3'b110; // 2-bit
         localparam MODE_1 = 3'b101; // 1-bit
 
-	input CLK1;
-	input CLK2;
+    input CLK1;
+    input CLK2;
 
-	input [CFG_ABITS-1:0] A1ADDR;
-	output [CFG_DBITS-1:0] A1DATA;
-	input A1EN;
+    input [CFG_ABITS-1:0] A1ADDR;
+    output [CFG_DBITS-1:0] A1DATA;
+    input A1EN;
 
-	input [CFG_ABITS-1:0] B1ADDR;
-	input [CFG_DBITS-1:0] B1DATA;
-	input [CFG_ENABLE_B-1:0] B1EN;
+    input [CFG_ABITS-1:0] B1ADDR;
+    input [CFG_DBITS-1:0] B1DATA;
+    input [CFG_ENABLE_B-1:0] B1EN;
 
-	input [CFG_ABITS-1:0] C1ADDR;
-	output [CFG_DBITS-1:0] C1DATA;
-	input C1EN;
+    input [CFG_ABITS-1:0] C1ADDR;
+    output [CFG_DBITS-1:0] C1DATA;
+    input C1EN;
 
-	input [CFG_ABITS-1:0] D1ADDR;
-	input [CFG_DBITS-1:0] D1DATA;
-	input [CFG_ENABLE_D-1:0] D1EN;
+    input [CFG_ABITS-1:0] D1ADDR;
+    input [CFG_DBITS-1:0] D1DATA;
+    input [CFG_ENABLE_D-1:0] D1EN;
 
-	wire FLUSH1;
-	wire FLUSH2;
+    wire FLUSH1;
+    wire FLUSH2;
 
-	wire [13:CFG_ABITS] A1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
-	wire [13:CFG_ABITS] B1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
-	wire [13:CFG_ABITS] C1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
-	wire [13:CFG_ABITS] D1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] A1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] B1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] C1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
+    wire [13:CFG_ABITS] D1ADDR_CMPL = {14-CFG_ABITS{1'b0}};
 
-	wire [13:0] A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
-	wire [13:0] B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
-	wire [13:0] C1ADDR_TOTAL = {C1ADDR_CMPL, C1ADDR};
-	wire [13:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
+    wire [13:0] A1ADDR_TOTAL = {A1ADDR_CMPL, A1ADDR};
+    wire [13:0] B1ADDR_TOTAL = {B1ADDR_CMPL, B1ADDR};
+    wire [13:0] C1ADDR_TOTAL = {C1ADDR_CMPL, C1ADDR};
+    wire [13:0] D1ADDR_TOTAL = {D1ADDR_CMPL, D1ADDR};
 
-	wire [17:CFG_DBITS] A1_RDATA_CMPL;
-	wire [17:CFG_DBITS] C1_RDATA_CMPL;
+    wire [17:CFG_DBITS] A1_RDATA_CMPL;
+    wire [17:CFG_DBITS] C1_RDATA_CMPL;
 
-	wire [17:CFG_DBITS] B1_WDATA_CMPL;
-	wire [17:CFG_DBITS] D1_WDATA_CMPL;
+    wire [17:CFG_DBITS] B1_WDATA_CMPL;
+    wire [17:CFG_DBITS] D1_WDATA_CMPL;
 
-	wire [13:0] PORT_A1_ADDR;
-	wire [13:0] PORT_A2_ADDR;
-	wire [13:0] PORT_B1_ADDR;
-	wire [13:0] PORT_B2_ADDR;
+    wire [13:0] PORT_A1_ADDR;
+    wire [13:0] PORT_A2_ADDR;
+    wire [13:0] PORT_B1_ADDR;
+    wire [13:0] PORT_B2_ADDR;
 
-	case (CFG_DBITS)
-		1: begin
-			assign PORT_A1_ADDR = A1ADDR_TOTAL;
-			assign PORT_B1_ADDR = B1ADDR_TOTAL;
-			assign PORT_A2_ADDR = C1ADDR_TOTAL;
-			assign PORT_B2_ADDR = D1ADDR_TOTAL;
-			defparam bram_2x18k.MODE_BITS = { 1'b1,
-				11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
-				12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
-			};
-		end
+    case (CFG_DBITS)
+        1: begin
+            assign PORT_A1_ADDR = A1ADDR_TOTAL;
+            assign PORT_B1_ADDR = B1ADDR_TOTAL;
+            assign PORT_A2_ADDR = C1ADDR_TOTAL;
+            assign PORT_B2_ADDR = D1ADDR_TOTAL;
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+            };
+        end
 
-		2: begin
-			assign PORT_A1_ADDR = A1ADDR_TOTAL << 1;
-			assign PORT_B1_ADDR = B1ADDR_TOTAL << 1;
-			assign PORT_A2_ADDR = C1ADDR_TOTAL << 1;
-			assign PORT_B2_ADDR = D1ADDR_TOTAL << 1;
-			defparam bram_2x18k.MODE_BITS = { 1'b1,
-				11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
-				12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
-			};
-		end
+        2: begin
+            assign PORT_A1_ADDR = A1ADDR_TOTAL << 1;
+            assign PORT_B1_ADDR = B1ADDR_TOTAL << 1;
+            assign PORT_A2_ADDR = C1ADDR_TOTAL << 1;
+            assign PORT_B2_ADDR = D1ADDR_TOTAL << 1;
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+            };
+        end
 
-		4: begin
-			assign PORT_A1_ADDR = A1ADDR_TOTAL << 2;
-			assign PORT_B1_ADDR = B1ADDR_TOTAL << 2;
-			assign PORT_A2_ADDR = C1ADDR_TOTAL << 2;
-			assign PORT_B2_ADDR = D1ADDR_TOTAL << 2;
-			defparam bram_2x18k.MODE_BITS = { 1'b1,
-				11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
-				12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
-			};
-		end
+        4: begin
+            assign PORT_A1_ADDR = A1ADDR_TOTAL << 2;
+            assign PORT_B1_ADDR = B1ADDR_TOTAL << 2;
+            assign PORT_A2_ADDR = C1ADDR_TOTAL << 2;
+            assign PORT_B2_ADDR = D1ADDR_TOTAL << 2;
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+            };
+        end
 
-		8, 9: begin
-			assign PORT_A1_ADDR = A1ADDR_TOTAL << 3;
-			assign PORT_B1_ADDR = B1ADDR_TOTAL << 3;
-			assign PORT_A2_ADDR = C1ADDR_TOTAL << 3;
-			assign PORT_B2_ADDR = D1ADDR_TOTAL << 3;
-			defparam bram_2x18k.MODE_BITS = { 1'b1,
-				11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
-				12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
-			};
-		end
+        8, 9: begin
+            assign PORT_A1_ADDR = A1ADDR_TOTAL << 3;
+            assign PORT_B1_ADDR = B1ADDR_TOTAL << 3;
+            assign PORT_A2_ADDR = C1ADDR_TOTAL << 3;
+            assign PORT_B2_ADDR = D1ADDR_TOTAL << 3;
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+            };
+        end
 
-		16, 18: begin
-			assign PORT_A1_ADDR = A1ADDR_TOTAL << 4;
-			assign PORT_B1_ADDR = B1ADDR_TOTAL << 4;
-			assign PORT_A2_ADDR = C1ADDR_TOTAL << 4;
-			assign PORT_B2_ADDR = D1ADDR_TOTAL << 4;
-			defparam bram_2x18k.MODE_BITS = { 1'b1,
-				11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
-				12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
-			};
-		end
+        16, 18: begin
+            assign PORT_A1_ADDR = A1ADDR_TOTAL << 4;
+            assign PORT_B1_ADDR = B1ADDR_TOTAL << 4;
+            assign PORT_A2_ADDR = C1ADDR_TOTAL << 4;
+            assign PORT_B2_ADDR = D1ADDR_TOTAL << 4;
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+            };
+        end
 
-		default: begin
-			assign PORT_A1_ADDR = A1ADDR_TOTAL;
-			assign PORT_B1_ADDR = B1ADDR_TOTAL;
-			assign PORT_A2_ADDR = D1ADDR_TOTAL;
-			assign PORT_B2_ADDR = C1ADDR_TOTAL;
-			defparam bram_2x18k.MODE_BITS = { 1'b1,
-				11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
-				12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
-			};
-		end
-	endcase
+        default: begin
+            assign PORT_A1_ADDR = A1ADDR_TOTAL;
+            assign PORT_B1_ADDR = B1ADDR_TOTAL;
+            assign PORT_A2_ADDR = D1ADDR_TOTAL;
+            assign PORT_B2_ADDR = C1ADDR_TOTAL;
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+            };
+        end
+    endcase
 
-	assign FLUSH1 = 1'b0;
-	assign FLUSH2 = 1'b0;
+    assign FLUSH1 = 1'b0;
+    assign FLUSH2 = 1'b0;
 
-	wire [17:0] PORT_A1_RDATA;
-	wire [17:0] PORT_B1_RDATA;
-	wire [17:0] PORT_A2_RDATA;
-	wire [17:0] PORT_B2_RDATA;
+    wire [17:0] PORT_A1_RDATA;
+    wire [17:0] PORT_B1_RDATA;
+    wire [17:0] PORT_A2_RDATA;
+    wire [17:0] PORT_B2_RDATA;
 
-	wire [17:0] PORT_A1_WDATA;
-	wire [17:0] PORT_B1_WDATA;
-	wire [17:0] PORT_A2_WDATA;
-	wire [17:0] PORT_B2_WDATA;
+    wire [17:0] PORT_A1_WDATA;
+    wire [17:0] PORT_B1_WDATA;
+    wire [17:0] PORT_A2_WDATA;
+    wire [17:0] PORT_B2_WDATA;
 
-	// Assign read/write data - handle special case for 9bit mode
-	// parity bit for 9bit mode is placed in R/W port on bit #16
-	case (CFG_DBITS)
-		9: begin
-			assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
-			assign C1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
-			assign PORT_A1_WDATA = {18{1'b0}};
-			assign PORT_B1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
-			assign PORT_A2_WDATA = {18{1'b0}};
-			assign PORT_B2_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
-		end
-		default: begin
-			assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
-			assign C1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
-			assign PORT_A1_WDATA = {18{1'b1}};
-			assign PORT_B1_WDATA = {B1_WDATA_CMPL, B1DATA};
-			assign PORT_A2_WDATA = {18{1'b1}};
-			assign PORT_B2_WDATA = {D1_WDATA_CMPL, D1DATA};
+    // Assign read/write data - handle special case for 9bit mode
+    // parity bit for 9bit mode is placed in R/W port on bit #16
+    case (CFG_DBITS)
+        9: begin
+            assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
+            assign C1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
+            assign PORT_A1_WDATA = {18{1'b0}};
+            assign PORT_B1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
+            assign PORT_A2_WDATA = {18{1'b0}};
+            assign PORT_B2_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
+        end
+        default: begin
+            assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
+            assign C1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
+            assign PORT_A1_WDATA = {18{1'b1}};
+            assign PORT_B1_WDATA = {B1_WDATA_CMPL, B1DATA};
+            assign PORT_A2_WDATA = {18{1'b1}};
+            assign PORT_B2_WDATA = {D1_WDATA_CMPL, D1DATA};
 
-		end
-	endcase
+        end
+    endcase
 
-	wire PORT_A1_CLK = CLK1;
-	wire PORT_A2_CLK = CLK2;
-	wire PORT_B1_CLK = CLK1;
-	wire PORT_B2_CLK = CLK2;
+    wire PORT_A1_CLK = CLK1;
+    wire PORT_A2_CLK = CLK2;
+    wire PORT_B1_CLK = CLK1;
+    wire PORT_B2_CLK = CLK2;
 
-	wire PORT_A1_REN = A1EN;
-	wire PORT_A1_WEN = 1'b0;
-	wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {PORT_A1_WEN,PORT_A1_WEN};
+    wire PORT_A1_REN = A1EN;
+    wire PORT_A1_WEN = 1'b0;
+    wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {PORT_A1_WEN,PORT_A1_WEN};
 
-	wire PORT_A2_REN = C1EN;
-	wire PORT_A2_WEN = 1'b0;
-	wire [CFG_ENABLE_D-1:0] PORT_A2_BE = {PORT_A2_WEN,PORT_A2_WEN};
+    wire PORT_A2_REN = C1EN;
+    wire PORT_A2_WEN = 1'b0;
+    wire [CFG_ENABLE_D-1:0] PORT_A2_BE = {PORT_A2_WEN,PORT_A2_WEN};
 
-	wire PORT_B1_REN = 1'b0;
-	wire PORT_B1_WEN = B1EN[0];
-	wire [CFG_ENABLE_B-1:0] PORT_B1_BE = {B1EN[1],B1EN[0]};
+    wire PORT_B1_REN = 1'b0;
+    wire PORT_B1_WEN = B1EN[0];
+    wire [CFG_ENABLE_B-1:0] PORT_B1_BE = {B1EN[1],B1EN[0]};
 
-	wire PORT_B2_REN = 1'b0;
-	wire PORT_B2_WEN = D1EN[0];
-	wire [CFG_ENABLE_D-1:0] PORT_B2_BE = {D1EN[1],D1EN[0]};
+    wire PORT_B2_REN = 1'b0;
+    wire PORT_B2_WEN = D1EN[0];
+    wire [CFG_ENABLE_D-1:0] PORT_B2_BE = {D1EN[1],D1EN[0]};
 
-	TDP36K  bram_2x18k (
-		.WDATA_A1_i(PORT_A1_WDATA),
-		.RDATA_A1_o(PORT_A1_RDATA),
-		.ADDR_A1_i(PORT_A1_ADDR),
-		.CLK_A1_i(PORT_A1_CLK),
-		.REN_A1_i(PORT_A1_REN),
-		.WEN_A1_i(PORT_A1_WEN),
-		.BE_A1_i(PORT_A1_BE),
+    TDP36K  bram_2x18k (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
 
-		.WDATA_A2_i(PORT_A2_WDATA),
-		.RDATA_A2_o(PORT_A2_RDATA),
-		.ADDR_A2_i(PORT_A2_ADDR),
-		.CLK_A2_i(PORT_A2_CLK),
-		.REN_A2_i(PORT_A2_REN),
-		.WEN_A2_i(PORT_A2_WEN),
-		.BE_A2_i(PORT_A2_BE),
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
 
-		.WDATA_B1_i(PORT_B1_WDATA),
-		.RDATA_B1_o(PORT_B1_RDATA),
-		.ADDR_B1_i(PORT_B1_ADDR),
-		.CLK_B1_i(PORT_B1_CLK),
-		.REN_B1_i(PORT_B1_REN),
-		.WEN_B1_i(PORT_B1_WEN),
-		.BE_B1_i(PORT_B1_BE),
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
 
-		.WDATA_B2_i(PORT_B2_WDATA),
-		.RDATA_B2_o(PORT_B2_RDATA),
-		.ADDR_B2_i(PORT_B2_ADDR),
-		.CLK_B2_i(PORT_B2_CLK),
-		.REN_B2_i(PORT_B2_REN),
-		.WEN_B2_i(PORT_B2_WEN),
-		.BE_B2_i(PORT_B2_BE),
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
 
-		.FLUSH1_i(FLUSH1),
-		.FLUSH2_i(FLUSH2)
-	);
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+    );
 endmodule
 
 (* blackbox *)
@@ -1812,7 +1734,7 @@ module QL_DSP2_MULT ( // TODO: Name subject to change
         .b(b),
         .z(z),
 
-	.reset(reset),
+    .reset(reset),
 
         .f_mode(f_mode),
 
@@ -1821,7 +1743,7 @@ module QL_DSP2_MULT ( // TODO: Name subject to change
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),
 
-        .output_select(3'b0),	// unregistered output: a * b (0)
+        .output_select(3'b0),   // unregistered output: a * b (0)
         .register_inputs(1'b0)  // unregistered inputs
     );
 endmodule
@@ -1866,9 +1788,9 @@ module QL_DSP2_MULT_REGIN ( // TODO: Name subject to change
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(3'b0),	// unregistered output: a * b (0)
+        .output_select(3'b0),   // unregistered output: a * b (0)
         .register_inputs(1'b1)  // registered inputs
     );
 endmodule
@@ -1912,9 +1834,9 @@ module QL_DSP2_MULT_REGOUT ( // TODO: Name subject to change
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(3'b100),	// registered output: a * b (4)
+        .output_select(3'b100), // registered output: a * b (4)
         .register_inputs(1'b0)  // unregistered inputs
     );
 endmodule
@@ -1958,9 +1880,9 @@ module QL_DSP2_MULT_REGIN_REGOUT ( // TODO: Name subject to change
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(3'b100),	// registered output: a * b (4)
+        .output_select(3'b100), // registered output: a * b (4)
         .register_inputs(1'b1)  // registered inputs
     );
 endmodule
@@ -2010,9 +1932,9 @@ module QL_DSP2_MULTADD (
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(output_select),	// unregistered output: ACCin (2, 3)
+        .output_select(output_select),  // unregistered output: ACCin (2, 3)
         .subtract(subtract),
         .register_inputs(1'b0)  // unregistered inputs
     );
@@ -2062,9 +1984,9 @@ module QL_DSP2_MULTADD_REGIN (
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(output_select),	// unregistered output: ACCin (2, 3)
+        .output_select(output_select),  // unregistered output: ACCin (2, 3)
         .subtract(subtract),
         .register_inputs(1'b1)  // registered inputs
     );
@@ -2114,9 +2036,9 @@ module QL_DSP2_MULTADD_REGOUT (
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(output_select),	// registered output: ACCin (6, 7)
+        .output_select(output_select),  // registered output: ACCin (6, 7)
         .subtract(subtract),
         .register_inputs(1'b0)  // unregistered inputs
     );
@@ -2166,9 +2088,9 @@ module QL_DSP2_MULTADD_REGIN_REGOUT (
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(output_select),	// registered output: ACCin (6, 7)
+        .output_select(output_select),  // registered output: ACCin (6, 7)
         .subtract(subtract),
         .register_inputs(1'b1)  // registered inputs
     );
@@ -2212,8 +2134,8 @@ module QL_DSP2_MULTACC (
 
         .f_mode(f_mode),
 
-	.feedback(feedback),
-	.load_acc(load_acc),
+    .feedback(feedback),
+    .load_acc(load_acc),
 
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),
@@ -2221,7 +2143,7 @@ module QL_DSP2_MULTACC (
         .clk(clk),
         .reset(reset),
 
-        .output_select(1'b1),	// unregistered output: ACCout (1)
+        .output_select(1'b1),   // unregistered output: ACCout (1)
         .subtract(subtract),
         .register_inputs(1'b0)  // unregistered inputs
     );
@@ -2271,9 +2193,9 @@ module QL_DSP2_MULTACC_REGIN (
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(1'b1),	// unregistered output: ACCout (1)
+        .output_select(1'b1),   // unregistered output: ACCout (1)
         .subtract(subtract),
         .register_inputs(1'b1)  // registered inputs
     );
@@ -2317,15 +2239,15 @@ module QL_DSP2_MULTACC_REGOUT (
         .f_mode(f_mode),
 
         .feedback(feedback),
-	.load_acc(load_acc),
+    .load_acc(load_acc),
 
         .unsigned_a(unsigned_a),
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(3'b101),	// registered output: ACCout (5)
+        .output_select(3'b101), // registered output: ACCout (5)
         .subtract(subtract),
         .register_inputs(1'b0)  // unregistered inputs
     );
@@ -2375,9 +2297,9 @@ module QL_DSP2_MULTACC_REGIN_REGOUT (
         .unsigned_b(unsigned_b),
 
         .clk(clk),
-	.reset(reset),
+    .reset(reset),
 
-        .output_select(3'b101),	// registered output: ACCout (5)
+        .output_select(3'b101), // registered output: ACCout (5)
         .subtract(subtract),
         .register_inputs(1'b1)  // registered inputs
     );

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -126,34 +126,6 @@ endmodule
 
 
 (* abc9_flop, lib_whitebox *)
-module dff(
-    output reg Q,
-    input wire D,
-    (* clkbuf_sink *)
-    input wire C
-);
-    initial Q <= 1'b0;
-
-    always @(posedge C)
-      Q <= D;
-
-endmodule
-
-(* abc9_flop, lib_whitebox *)
-module dffn(
-    output reg Q,
-    input wire D,
-    (* clkbuf_sink *)
-    input wire C
-);
-    initial Q <= 1'b0;
-
-    always @(negedge C)
-      Q <= D;
-
-endmodule
-
-(* abc9_flop, lib_whitebox *)
 module dffsre(
     output reg Q,
     input wire D,
@@ -238,32 +210,6 @@ module sdffnsre(
         Q <= 1'b1;
       else if (E)
         Q <= D;
-
-endmodule
-
-(* abc9_flop, lib_whitebox *)
-module latch (
-    output reg Q,
-    input wire D,
-    input wire G
-);
-    initial Q <= 1'b0;
-
-    always @(G)
-      if (G) Q <= D;
-
-endmodule
-
-(* abc9_flop, lib_whitebox *)
-module latchn (
-    output reg Q,
-    input wire D,
-    input wire G
-);
-    initial Q <= 1'b0;
-
-    always @(G)
-      if (!G) Q <= D;
 
 endmodule
 

--- a/ql-qlf-plugin/qlf_k6n10f/ffs_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/ffs_map.v
@@ -14,566 +14,94 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Basic DFF
-
+// DFF, no set/reset, no enable
 module \$_DFF_P_ (D, C, Q);
-    input D;
-    input C;
+    input  D;
+    input  C;
     output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(1'b1), .S(1'b1));
+    dff _TECHMAP_REPLACE_ (.C(C), .D(D), .Q(Q));
 endmodule
 
-// Async reset
-module \$_DFF_PP0_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
+module \$_DFF_N_ (D, C, Q);
+    input  D;
+    input  C;
     output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(!R), .S(1'b1));
+    dffn _TECHMAP_REPLACE_ (.C(C), .D(D), .Q(Q));
 endmodule
 
-// Async reset
-module \$_DFF_PN0_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(R), .S(1'b1));
-endmodule
-
-// Async set
-module \$_DFF_PP1_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(1'b1), .S(!R));
-endmodule
-
-// Async set
-module \$_DFF_PN1_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(1'b1), .S(R));
-endmodule
-
-module  \$_DFFE_PP_ (D, C, E, Q);
-    input D;
-    input C;
-    input E;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(1'b1));
-endmodule
-
-module  \$_DFFE_PN_ (D, C, E, Q);
-    input D;
-    input C;
-    input E;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(1'b1), .S(1'b1));
-endmodule
-
-// Async reset, enable
-module  \$_DFFE_PP0P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(!R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_PP0N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(!R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_PN0P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_PN0N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(R), .S(1'b1));
-endmodule
-// Async set, enable
-
-module  \$_DFFE_PP1P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(!R));
-endmodule
-
-module  \$_DFFE_PP1N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(1'b1), .S(!R));
-endmodule
-
-module  \$_DFFE_PN1P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(R));
-endmodule
-
-module  \$_DFFE_PN1N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(1'b1), .S(R));
-endmodule
-
-// Async set & reset
-
-module \$_DFFSR_PPP_ (D, C, R, S, Q);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(!R), .S(!S));
-endmodule
-
-module \$_DFFSR_PNP_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(!R), .S(S));
-endmodule
-
-module \$_DFFSR_PNN_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(R), .S(S));
-endmodule
-
-module \$_DFFSR_PPN_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(R), .S(!S));
-endmodule
-
-module \$_DFFSR_NPP_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(!R), .S(!S));
-endmodule
-
-module \$_DFFSR_NNP_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(!R), .S(S));
-endmodule
-
-module \$_DFFSR_NNN_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(R), .S(S));
-endmodule
-
-module \$_DFFSR_NPN_ (D, Q, C, R, S);
-    input D;
-    input C;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(R), .S(!S));
-endmodule
-
-// Async set, reset & enable
-
-module \$_DFFSRE_PPPP_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(!R), .S(!S));
-endmodule
-
-module \$_DFFSRE_PNPP_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(!R), .S(S));
-endmodule
-
-module \$_DFFSRE_PPNP_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(!S));
-endmodule
-
-module \$_DFFSRE_PNNP_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
+// DFF, asynchronous set/reset, enable
+module \$_DFFSRE_PNNP_ (C, S, R, E, D, Q);
+    input  C;
+    input  S;
+    input  R;
+    input  E;
+    input  D;
     output Q;
     dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(S));
 endmodule
 
-module \$_DFFSRE_PPPN_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(!R), .S(!S));
-endmodule
-
-module \$_DFFSRE_PNPN_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(!R), .S(S));
-endmodule
-
-module \$_DFFSRE_PPNN_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(R), .S(!S));
-endmodule
-
-module \$_DFFSRE_PNNN_ (D, Q, C, E, R, S);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(R), .S(S));
-endmodule
-
-// Latch with async set and reset
-module  \$_DLATCHSR_PPP_ (input E, S, R, D, output Q);
-    latchsre _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E),  .R(!R), .S(!S));
-endmodule
-
-module  \$_DLATCHSR_NPP_ (input E, S, R, D, output Q);
-    latchnsre _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E),  .R(!R), .S(!S));
-endmodule
-
-// The following techmap operation are not performed right now
-// as Negative edge FF are not legalized in synth_quicklogic for qlf_k6n10
-// but in case we implement clock inversion in the future, the support is ready for it.
-
-module \$_DFF_N_ (D, C, Q);
-    input D;
-    input C;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(1'b1), .S(1'b1));
-endmodule
-
-module \$_DFF_NP0_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(!R), .S(1'b1));
-endmodule
-
-module \$_DFF_NN0_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(R), .S(1'b1));
-endmodule
-
-module \$_DFF_NP1_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(1'b1), .S(!R));
-endmodule
-
-module \$_DFF_NN1_ (D, C, R, Q);
-    input D;
-    input C;
-    input R;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(1'b1), .R(1'b1), .S(R));
-endmodule
-
-module  \$_DFFE_NP_ (D, C, E, Q);
-    input D;
-    input C;
-    input E;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(1'b1));
-endmodule
-
-module  \$_DFFE_NN_ (D, C, E, Q);
-    input D;
-    input C;
-    input E;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(1'b1), .S(1'b1));
-endmodule
-
-module  \$_DFFE_NP0P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(!R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_NP0N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(!R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_NN0P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_NN0N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(R), .S(1'b1));
-endmodule
-
-module  \$_DFFE_NP1P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(!R));
-endmodule
-
-module  \$_DFFE_NP1N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(1'b1), .S(!R));
-endmodule
-
-module  \$_DFFE_NN1P_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(R));
-endmodule
-
-module  \$_DFFE_NN1N_ (D, C, E, R, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    output Q;
-    parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(1'b1), .S(R));
-endmodule
-
-module \$_DFFSRE_NPPP_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(!R), .S(!S));
-endmodule
-
-module \$_DFFSRE_NNPP_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(!R), .S(S));
-endmodule
-
-module \$_DFFSRE_NPNP_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
-    output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(!S));
-endmodule
-
-module \$_DFFSRE_NNNP_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
+module \$_DFFSRE_NNNP_ (C, S, R, E, D, Q);
+    input  C;
+    input  S;
+    input  R;
+    input  E;
+    input  D;
     output Q;
     dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(S));
 endmodule
 
-
-module \$_DFFSRE_NPPN_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
+// DFF, synchronous set or reset, enable
+module \$_SDFFE_PN0P_ (D, C, R, E, Q);
+    input  D;
+    input  C;
+    input  R;
+    input  E;
     output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(!R), .S(!S));
+    sdffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(1'b1));
 endmodule
 
-module \$_DFFSRE_NNPN_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
+module \$_SDFFE_PN1P_ (D, C, R, E, Q);
+    input  D;
+    input  C;
+    input  R;
+    input  E;
     output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(!R), .S(S));
+    sdffsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(R));
 endmodule
 
-module \$_DFFSRE_NPNN_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
+module \$_SDFFE_NN0P_ (D, C, R, E, Q);
+    input  D;
+    input  C;
+    input  R;
+    input  E;
     output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(R), .S(!S));
+    sdffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(R), .S(1'b1));
 endmodule
 
-module \$_DFFSRE_NNNN_ (D, C, E, R, S, Q);
-    input D;
-    input C;
-    input E;
-    input R;
-    input S;
+module \$_SDFFE_NN1P_ (D, C, R, E, Q);
+    input  D;
+    input  C;
+    input  R;
+    input  E;
     output Q;
-    dffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(!E), .R(R), .S(S));
+    sdffnsre _TECHMAP_REPLACE_ (.Q(Q), .D(D), .C(C), .E(E), .R(1'b1), .S(R));
 endmodule
 
-module \$__SHREG_DFF_P_ (D, Q, C);
-    input D;
-    input C;
-    output Q;
+// Latch, no set/reset, no enable
+module  \$_DLATCH_P_ (input E, D, output Q);
+    latch  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .G(E));
+endmodule
 
-    parameter DEPTH = 2;
-    reg [DEPTH-2:0] q;
-    genvar i;
-    generate for (i = 0; i < DEPTH; i = i + 1) begin: slice
+module  \$_DLATCH_N_ (input E, D, output Q);
+    latchn _TECHMAP_REPLACE_ (.D(D), .Q(Q), .G(E));
+endmodule
 
+// Latch with async set and reset and enable
+module  \$_DLATCHSR_PPP_ (input E, S, R, D, output Q);
+    latchsre  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E),  .R(!R), .S(!S));
+endmodule
 
-        // First in chain
-        generate if (i == 0) begin
-                 sh_dff #() shreg_beg (
-                    .Q(q[i]),
-                    .D(D),
-                    .C(C)
-                );
-        end endgenerate
-        // Middle in chain
-        generate if (i > 0 && i != DEPTH-1) begin
-                 sh_dff #() shreg_mid (
-                    .Q(q[i]),
-                    .D(q[i-1]),
-                    .C(C)
-                );
-        end endgenerate
-        // Last in chain
-        generate if (i == DEPTH-1) begin
-                 sh_dff #() shreg_end (
-                    .Q(Q),
-                    .D(q[i-1]),
-                    .C(C)
-                );
-        end endgenerate
-   end: slice
-   endgenerate
-
+module  \$_DLATCHSR_NPP_ (input E, S, R, D, output Q);
+    latchnsre _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E),  .R(!R), .S(!S));
 endmodule
 

--- a/ql-qlf-plugin/qlf_k6n10f/ffs_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/ffs_map.v
@@ -14,21 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// DFF, no set/reset, no enable
-module \$_DFF_P_ (D, C, Q);
-    input  D;
-    input  C;
-    output Q;
-    dff _TECHMAP_REPLACE_ (.C(C), .D(D), .Q(Q));
-endmodule
-
-module \$_DFF_N_ (D, C, Q);
-    input  D;
-    input  C;
-    output Q;
-    dffn _TECHMAP_REPLACE_ (.C(C), .D(D), .Q(Q));
-endmodule
-
 // DFF, asynchronous set/reset, enable
 module \$_DFFSRE_PNNP_ (C, S, R, E, D, Q);
     input  C;
@@ -89,11 +74,11 @@ endmodule
 
 // Latch, no set/reset, no enable
 module  \$_DLATCH_P_ (input E, D, output Q);
-    latch  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .G(E));
+    latchsre  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E), .R(1'b1), .S(1'b1));
 endmodule
 
 module  \$_DLATCH_N_ (input E, D, output Q);
-    latchn _TECHMAP_REPLACE_ (.D(D), .Q(Q), .G(E));
+    latchnsre _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E), .R(1'b1), .S(1'b1));
 endmodule
 
 // Latch with async set and reset and enable

--- a/ql-qlf-plugin/qlf_k6n10f/ffs_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/ffs_map.v
@@ -105,3 +105,44 @@ module  \$_DLATCHSR_NPP_ (input E, S, R, D, output Q);
     latchnsre _TECHMAP_REPLACE_ (.D(D), .Q(Q), .E(1'b1), .G(E),  .R(!R), .S(!S));
 endmodule
 
+module \$__SHREG_DFF_P_ (D, Q, C);
+    input  D;
+    input  C;
+    output Q;
+
+    parameter DEPTH = 2;
+
+    reg [DEPTH-2:0] q;
+
+    genvar i;
+    generate for (i = 0; i < DEPTH; i = i + 1) begin: slice
+
+        // First in chain
+        generate if (i == 0) begin
+                 sh_dff #() shreg_beg (
+                    .Q(q[i]),
+                    .D(D),
+                    .C(C)
+                );
+        end endgenerate
+        // Middle in chain
+        generate if (i > 0 && i != DEPTH-1) begin
+                 sh_dff #() shreg_mid (
+                    .Q(q[i]),
+                    .D(q[i-1]),
+                    .C(C)
+                );
+        end endgenerate
+        // Last in chain
+        generate if (i == DEPTH-1) begin
+                 sh_dff #() shreg_end (
+                    .Q(Q),
+                    .D(q[i-1]),
+                    .C(C)
+                );
+        end endgenerate
+   end: slice
+   endgenerate
+
+endmodule
+

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -121,7 +121,17 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         size_t argidx;
         for (argidx = 1; argidx < args.size(); argidx++) {
-            if (args[argidx] == "-top" && argidx + 1 < args.size()) {
+			if (args[argidx] == "-run" && argidx+1 < args.size()) {
+				size_t pos = args[argidx+1].find(':');
+				if (pos == std::string::npos) {
+					run_from = args[++argidx];
+					run_to = args[argidx];
+				} else {
+					run_from = args[++argidx].substr(0, pos);
+					run_to = args[argidx].substr(pos+1);
+				}
+				continue;
+			}            if (args[argidx] == "-top" && argidx + 1 < args.size()) {
                 top_opt = "-top " + args[++argidx];
                 continue;
             }

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -121,17 +121,18 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         size_t argidx;
         for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-run" && argidx+1 < args.size()) {
-				size_t pos = args[argidx+1].find(':');
-				if (pos == std::string::npos) {
-					run_from = args[++argidx];
-					run_to = args[argidx];
-				} else {
-					run_from = args[++argidx].substr(0, pos);
-					run_to = args[argidx].substr(pos+1);
-				}
-				continue;
-			}            if (args[argidx] == "-top" && argidx + 1 < args.size()) {
+            if (args[argidx] == "-run" && argidx + 1 < args.size()) {
+                size_t pos = args[argidx + 1].find(':');
+                if (pos == std::string::npos) {
+                    run_from = args[++argidx];
+                    run_to = args[argidx];
+                } else {
+                    run_from = args[++argidx].substr(0, pos);
+                    run_to = args[argidx].substr(pos + 1);
+                }
+                continue;
+            }
+            if (args[argidx] == "-top" && argidx + 1 < args.size()) {
                 top_opt = "-top " + args[++argidx];
                 continue;
             }
@@ -231,10 +232,7 @@ struct SynthQuickLogicPass : public ScriptPass {
         std::string noDFFArgs;
         if (family == "qlf_k4n8") {
             noDFFArgs = " -nodffe -nosdff";
-        } else if (family == "qlf_k6n10f") {
-            noDFFArgs = " -nosdff";
         }
-
         if (check_label("coarse")) {
             run("check");
             run("opt -nodffe -nosdff");
@@ -365,8 +363,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                 //    $_DLATCH_SRPPP_ 0");
             } else if (family == "qlf_k6n10f") {
                 run("shregmap -minlen 8 -maxlen 20");
-                run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFF_???_ 0 -cell $_DFFE_????_ 0 -cell $_DFFSR_???_ 0 -cell $_DFFSRE_????_ 0 -cell "
-                    "$_DLATCHSR_PPP_ 0");
+                run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFFSRE_?NNP_ 0 -cell $_SDFFE_?N?P_ 0 -cell $_DLATCH_?_ 0 -cell $_DLATCHSR_?NN_ 0");
             } else if (family == "pp3") {
                 run("dfflegalize -cell $_DFFSRE_PPPP_ 0 -cell $_DLATCH_?_ x");
                 run("techmap -map +/quicklogic/" + family + "/cells_map.v");

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -363,7 +363,10 @@ struct SynthQuickLogicPass : public ScriptPass {
                 //    $_DLATCH_SRPPP_ 0");
             } else if (family == "qlf_k6n10f") {
                 run("shregmap -minlen 8 -maxlen 20");
-                run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFFSRE_?NNP_ 0 -cell $_SDFFE_?N?P_ 0 -cell $_DLATCH_?_ 0 -cell $_DLATCHSR_?NN_ 0");
+                // FIXME: dfflegalize seems to leave $_DLATCH_[NP]_ even if it
+                // is not allowed. So we allow them and map them later to
+                // $_DLATCHSR_[NP]NN_.
+                run("dfflegalize -cell $_DFFSRE_?NNP_ 0 -cell $_SDFFE_?N?P_ 0 -cell $_DLATCHSR_?NN_ 0 -cell $_DLATCH_?_ 0");
             } else if (family == "pp3") {
                 run("dfflegalize -cell $_DFFSRE_PPPP_ 0 -cell $_DLATCH_?_ x");
                 run("techmap -map +/quicklogic/" + family + "/cells_map.v");

--- a/ql-qlf-plugin/tests/dffs/dffs.tcl
+++ b/ql-qlf-plugin/tests/dffs/dffs.tcl
@@ -5,6 +5,9 @@ yosys -import  ;# ingest plugin commands
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
+# =============================================================================
+# qlf_k4n8
+
 # DFF
 hierarchy -top my_dff
 yosys proc
@@ -157,7 +160,9 @@ select -assert-count 1 t:\$lut
 
 design -reset
 
-# DFF on qlf_k6n10 device
+# =============================================================================
+# qlf_k6n10
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -406,7 +411,9 @@ select -assert-count 3 t:\$lut
 
 design -reset
 
-# DFF on qlf_k6n10f device
+# =============================================================================
+# qlf_k6n10f
+
 read_verilog $::env(DESIGN_TOP).v
 design -save read
 
@@ -417,236 +424,301 @@ equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_qui
 design -load postopt
 yosys cd my_dff
 stat
-select -assert-count 1 t:dffsre
+select -assert-count 1 t:dff
 
-# DFFR (posedge RST)
+# DFFN
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffr_p
-yosys cd my_dffr_p
+hierarchy -top my_dffn
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffn
+design -load postopt
+yosys cd my_dffn
 stat
-select -assert-count 1 t:dffsre
+select -assert-count 1 t:dffn
 
-# DFFR (posedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffr_p_2
-yosys cd my_dffr_p_2
-stat
-select -assert-count 2 t:dffsre
 
-# DFFR (negedge RST)
+# DFFSRE from DFFR_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffr_n
+hierarchy -top my_dffr_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffr_n
+design -load postopt
 yosys cd my_dffr_n
 stat
 select -assert-count 1 t:dffsre
 
-#DFFRE (posedge RST)
+# DFFSRE from DFFR_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffre_p
+hierarchy -top my_dffr_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffr_p
+design -load postopt
+yosys cd my_dffr_p
+stat
+select -assert-count 1 t:dffsre
+select -assert-count 1 t:\$lut
+
+# DFFSRE from DFFRE_N
+design -load read
+hierarchy -top my_dffre_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffre_n
+design -load postopt
+yosys cd my_dffre_n
+stat
+select -assert-count 1 t:dffsre
+
+# DFFSRE from DFFRE_P
+design -load read
+hierarchy -top my_dffre_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffre_p
+design -load postopt
 yosys cd my_dffre_p
 stat
 select -assert-count 1 t:dffsre
 select -assert-count 1 t:\$lut
 
-#DFFRE (negedge RST)
+
+# DFFSRE from DFFS_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffre_n
-yosys cd my_dffre_n
+hierarchy -top my_dffs_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffs_n
+design -load postopt
+yosys cd my_dffs_n
 stat
 select -assert-count 1 t:dffsre
 
-# DFFS (posedge SET)
+# DFFSRE from DFFS_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffs_p
+hierarchy -top my_dffs_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffs_p
+design -load postopt
 yosys cd my_dffs_p
 stat
 select -assert-count 1 t:dffsre
 select -assert-count 1 t:\$lut
 
-# DFFS (negedge SET)
+# DFFSRE from DFFSE_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffs_n
-yosys cd my_dffs_n
+hierarchy -top my_dffse_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffse_n
+design -load postopt
+yosys cd my_dffse_n
 stat
 select -assert-count 1 t:dffsre
 
-# DFFSE (posedge SET)
+# DFFSRE from DFFSE_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffse_p
+hierarchy -top my_dffse_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffse_p
+design -load postopt
 yosys cd my_dffse_p
 stat
 select -assert-count 1 t:dffsre
 select -assert-count 1 t:\$lut
 
-# DFFSE (negedge SET)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffse_n
-yosys cd my_dffse_n
-stat
-select -assert-count 1 t:dffsre
 
-# DFFN
+# SDFFSRE from SDFFR_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffn
-yosys cd my_dffn
+hierarchy -top my_sdffr_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffr_n
+design -load postopt
+yosys cd my_sdffr_n
 stat
-select -assert-count 1 t:dffnsre
+select -assert-count 1 t:sdffsre
 
-# DFFNR (negedge CLK posedge RST)
+# SDFFSRE from SDFFR_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffnr_p
-yosys cd my_dffnr_p
+hierarchy -top my_sdffr_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffr_p
+design -load postopt
+yosys cd my_sdffr_p
 stat
-select -assert-count 1 t:dffnsre
+select -assert-count 1 t:sdffsre
 select -assert-count 1 t:\$lut
 
-# DFFNR (negedge CLK negedge RST)
+# SDFFSRE from SDFFS_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffnr_n
-yosys cd my_dffnr_n
+hierarchy -top my_sdffs_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffs_n
+design -load postopt
+yosys cd my_sdffs_n
 stat
-select -assert-count 1 t:dffnsre
+select -assert-count 1 t:sdffsre
 
-# DFFNS (negedge CLK posedge SET)
+# SDFFSRE from SDFFS_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffns_p
-yosys cd my_dffns_p
+hierarchy -top my_sdffs_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffs_p
+design -load postopt
+yosys cd my_sdffs_p
 stat
-select -assert-count 1 t:dffnsre
+select -assert-count 1 t:sdffsre
 select -assert-count 1 t:\$lut
 
-# DFFS (negedge CLK negedge SET)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffns_n
-yosys cd my_dffns_n
-stat
-select -assert-count 1 t:dffnsre
 
-# DFFSR (posedge CLK posedge SET posedge RST)
+# SDFFNSRE from SDFFNR_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_ppp
-yosys cd my_dffsr_ppp
+hierarchy -top my_sdffnr_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffnr_n
+design -load postopt
+yosys cd my_sdffnr_n
 stat
-select -assert-count 1 t:dffsre
-select -assert-count 2 t:\$lut
+select -assert-count 1 t:sdffnsre
 
-# DFFSR (posedge CLK negedge SET posedge RST)
+# SDFFNSRE from SDFFRN_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_pnp
-yosys cd my_dffsr_pnp
+hierarchy -top my_sdffnr_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffnr_p
+design -load postopt
+yosys cd my_sdffnr_p
 stat
-select -assert-count 1 t:dffsre
-select -assert-count 2 t:\$lut
-
-# DFFSR (posedge CLK posedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_ppn
-yosys cd my_dffsr_ppn
-stat
-select -assert-count 1 t:dffsre
+select -assert-count 1 t:sdffnsre
 select -assert-count 1 t:\$lut
 
-# DFFSR (posedge CLK negedge SET negedge RST)
+# SDFFNSRE from SDFFNS_N
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_pnn
-yosys cd my_dffsr_pnn
+hierarchy -top my_sdffns_n
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffns_n
+design -load postopt
+yosys cd my_sdffns_n
 stat
-select -assert-count 1 t:dffsre
+select -assert-count 1 t:sdffnsre
 
-# DFFSR (negedge CLK posedge SET posedge RST)
+# SDFFSRE from SDFFNS_P
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_npp
-yosys cd my_dffsr_npp
+hierarchy -top my_sdffns_p
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffns_p
+design -load postopt
+yosys cd my_sdffns_p
 stat
-select -assert-count 1 t:dffnsre
-select -assert-count 2 t:\$lut
-
-# DFFSR (negedge CLK negedge SET posedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_nnp
-yosys cd my_dffsr_nnp
-stat
-select -assert-count 1 t:dffnsre
-select -assert-count 2 t:\$lut
-
-# DFFSR (negedge CLK posedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_npn
-yosys cd my_dffsr_npn
-stat
-select -assert-count 1 t:dffnsre
+select -assert-count 1 t:sdffnsre
 select -assert-count 1 t:\$lut
 
-# DFFSR (negedge CLK negedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsr_nnn
-yosys cd my_dffsr_nnn
-stat
-select -assert-count 1 t:dffnsre
 
-# DFFSRE (posedge CLK posedge SET posedge RST)
+# LATCH
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_ppp
-yosys cd my_dffsre_ppp
+hierarchy -top my_latch
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latch
+design -load postopt
+yosys cd my_latch
 stat
-select -assert-count 1 t:dffsre
-select -assert-count 2 t:\$lut
+select -assert-count 1 t:latch
 
-# DFFSRE (posedge CLK negedge SET posedge RST)
+# LATCHN
 design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_pnp
-yosys cd my_dffsre_pnp
+hierarchy -top my_latchn
+yosys proc
+equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchn
+design -load postopt
+yosys cd my_latchn
 stat
-select -assert-count 1 t:dffsre
-select -assert-count 2 t:\$lut
+select -assert-count 1 t:latchn
 
-# DFFSRE (posedge CLK posedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_ppn
-yosys cd my_dffsre_ppn
-stat
-select -assert-count 1 t:dffsre
-select -assert-count 1 t:\$lut
 
-# DFFSRE (posedge CLK negedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_pnn
-yosys cd my_dffsre_pnn
-stat
-select -assert-count 1 t:dffsre
+## LATCHSRE from LATCHR_N
+#design -load read
+#hierarchy -top my_latchr_n
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchr_n
+#design -load postopt
+#yosys cd my_latchr_n
+#stat
+#select -assert-count 1 t:latchr_n
+#
+## LATCHSRE from LATCHR_P
+#design -load read
+#hierarchy -top my_latchr_p
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchr_p
+#design -load postopt
+#yosys cd my_latchr_p
+#stat
+#select -assert-count 1 t:latchr_p
+#select -assert-count 1 t:\$lut
+#
+## LATCHSRE from LATCHS_N
+#design -load read
+#hierarchy -top my_latchs_n
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchs_n
+#design -load postopt
+#yosys cd my_latchs_n
+#stat
+#select -assert-count 1 t:latchs_n
+#
+## LATCHSRE from LATCHS_P
+#design -load read
+#hierarchy -top my_latchs_p
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchs_p
+#design -load postopt
+#yosys cd my_latchs_p
+#stat
+#select -assert-count 1 t:latchs_p
+#select -assert-count 1 t:\$lut
+#
+#
+## LATCHSRE from LATCHNR_N
+#design -load read
+#hierarchy -top my_latchnr_n
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchnr_n
+#design -load postopt
+#yosys cd my_latchnr_n
+#stat
+#select -assert-count 1 t:latchnr_n
+#
+## LATCHSRE from LATCHNR_P
+#design -load read
+#hierarchy -top my_latchnr_p
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchnr_p
+#design -load postopt
+#yosys cd my_latchnr_p
+#stat
+#select -assert-count 1 t:latchnr_p
+#select -assert-count 1 t:\$lut
+#
+## LATCHSRE from LATCHNS_N
+#design -load read
+#hierarchy -top my_latchns_n
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchns_n
+#design -load postopt
+#yosys cd my_latchns_n
+#stat
+#select -assert-count 1 t:latchns_n
+#
+## LATCHSRE from LATCHNS_P
+#design -load read
+#hierarchy -top my_latchns_p
+#yosys proc
+#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchns_p
+#design -load postopt
+#yosys cd my_latchns_p
+#stat
+#select -assert-count 1 t:latchns_p
+#select -assert-count 1 t:\$lut
 
-# DFFSRE (negedge CLK posedge SET posedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_npp
-yosys cd my_dffsre_npp
-stat
-select -assert-count 1 t:dffnsre
-select -assert-count 2 t:\$lut
-
-# DFFSRE (negedge CLK negedge SET posedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_nnp
-yosys cd my_dffsre_nnp
-stat
-select -assert-count 1 t:dffnsre
-select -assert-count 2 t:\$lut
-
-# DFFSRE (negedge CLK posedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_npn
-yosys cd my_dffsre_npn
-stat
-select -assert-count 1 t:dffnsre
-select -assert-count 1 t:\$lut
-
-# DFFSRE (negedge CLK negedge SET negedge RST)
-design -load read
-synth_quicklogic -family qlf_k6n10f -top my_dffsre_nnn
-yosys cd my_dffsre_nnn
-stat
-select -assert-count 1 t:dffnsre
 
 design -reset
+
+# =============================================================================
 
 # DFF on pp3 device
 design -reset
@@ -720,11 +792,11 @@ select -assert-none t:LUT1 t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad
 
 # DFFS (posedge, sync set)
 design -load read
-hierarchy -top my_dffs_clk_p
+hierarchy -top my_sdffs_p
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_dffs_clk_p
+equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_sdffs_p
 design -load postopt
-yosys cd my_dffs_clk_p
+yosys cd my_sdffs_p
 stat
 select -assert-count 1 t:LUT2
 select -assert-count 1 t:dffepc
@@ -738,11 +810,11 @@ select -assert-none t:LUT2 t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad
 
 # DFFS (negedge, sync reset)
 design -load read
-hierarchy -top my_dffs_clk_n
+hierarchy -top my_sdffns_p
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_dffs_clk_n
+equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_sdffns_p
 design -load postopt
-yosys cd my_dffs_clk_n
+yosys cd my_sdffns_p
 stat
 select -assert-count 1 t:LUT1
 select -assert-count 1 t:LUT2

--- a/ql-qlf-plugin/tests/dffs/dffs.tcl
+++ b/ql-qlf-plugin/tests/dffs/dffs.tcl
@@ -424,7 +424,7 @@ equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_qui
 design -load postopt
 yosys cd my_dff
 stat
-select -assert-count 1 t:dff
+select -assert-count 1 t:sdffsre
 
 # DFFN
 design -load read
@@ -434,7 +434,7 @@ equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_qui
 design -load postopt
 yosys cd my_dffn
 stat
-select -assert-count 1 t:dffn
+select -assert-count 1 t:sdffnsre
 
 
 # DFFSRE from DFFR_N
@@ -617,7 +617,7 @@ equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_qui
 design -load postopt
 yosys cd my_latch
 stat
-select -assert-count 1 t:latch
+select -assert-count 1 t:latchsre
 
 # LATCHN
 design -load read
@@ -627,7 +627,7 @@ equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_qui
 design -load postopt
 yosys cd my_latchn
 stat
-select -assert-count 1 t:latchn
+select -assert-count 1 t:latchnsre
 
 
 ## LATCHSRE from LATCHR_N

--- a/ql-qlf-plugin/tests/dffs/dffs.v
+++ b/ql-qlf-plugin/tests/dffs/dffs.v
@@ -434,7 +434,67 @@ module my_dffsre_nnn (
     else if (en) q <= d;
 endmodule
 
-module my_dffs_clk_p (
+module my_sdffr_n (
+    input d,
+    clk,
+    clr,
+    output reg q
+);
+  initial q <= 0;
+  always @(posedge clk)
+    if (!clr) q <= 1'b0;
+    else q <= d;
+endmodule
+
+module my_sdffs_n (
+    input d,
+    clk,
+    pre,
+    output reg q
+);
+  initial q <= 0;
+  always @(posedge clk)
+    if (!pre) q <= 1'b1;
+    else q <= d;
+endmodule
+
+module my_sdffnr_n (
+    input d,
+    clk,
+    clr,
+    output reg q
+);
+  initial q <= 0;
+  always @(negedge clk)
+    if (!clr) q <= 1'b0;
+    else q <= d;
+endmodule
+
+module my_sdffns_n(
+    input d,
+    clk,
+    pre,
+    output reg q
+);
+  initial q <= 0;
+  always @(negedge clk)
+    if (!pre) q <= 1'b1;
+    else q <= d;
+endmodule
+
+module my_sdffr_p (
+    input d,
+    clk,
+    clr,
+    output reg q
+);
+  initial q <= 0;
+  always @(posedge clk)
+    if (clr) q <= 1'b0;
+    else q <= d;
+endmodule
+
+module my_sdffs_p (
     input d,
     clk,
     pre,
@@ -446,7 +506,7 @@ module my_dffs_clk_p (
     else q <= d;
 endmodule
 
-module my_dffs_clk_n (
+module my_sdffnr_p (
     input d,
     clk,
     clr,
@@ -454,7 +514,126 @@ module my_dffs_clk_n (
 );
   initial q <= 0;
   always @(negedge clk)
-    if (!clr) q <= 1'b0;
+    if (clr) q <= 1'b0;
     else q <= d;
+endmodule
+
+module my_sdffns_p (
+    input d,
+    clk,
+    pre,
+    output reg q
+);
+  initial q <= 0;
+  always @(negedge clk)
+    if (pre) q <= 1'b1;
+    else q <= d;
+endmodule
+
+
+module my_latch (
+    input  wire d, g,
+    output reg  q
+);
+    always @(*)
+        if (g) q <= d;
+endmodule
+
+module my_latchn (
+    input  wire d, g,
+    output reg  q
+);
+    always @(*)
+        if (!g) q <= d;
+endmodule
+
+
+module my_latchs_p (
+    input  wire d, g, s,
+    output reg  q
+);
+    always @(*)
+        if (s)
+            q <= 1'b1;
+        else if (g)
+            q <= d;
+endmodule
+
+module my_latchs_n (
+    input  wire d, g, s,
+    output reg  q
+);
+    always @(*)
+        if (!s)
+            q <= 1'b1;
+        else if (g)
+            q <= d;
+endmodule
+
+module my_latchr_p (
+    input  wire d, g, r,
+    output reg  q
+);
+    always @(*)
+        if (r)
+            q <= 1'b0;
+        else if (g)
+            q <= d;
+endmodule
+
+module my_latchr_n (
+    input  wire d, g, r,
+    output reg  q
+);
+    always @(*)
+        if (!r)
+            q <= 1'b0;
+        else if (g)
+            q <= d;
+endmodule
+
+
+module my_latchns_p (
+    input  wire d, g, s,
+    output reg  q
+);
+    always @(*)
+        if (s)
+            q <= 1'b1;
+        else if (!g)
+            q <= d;
+endmodule
+
+module my_latchns_n (
+    input  wire d, g, s,
+    output reg  q
+);
+    always @(*)
+        if (!s)
+            q <= 1'b1;
+        else if (!g)
+            q <= d;
+endmodule
+
+module my_latchnr_p (
+    input  wire d, g, r,
+    output reg  q
+);
+    always @(*)
+        if (r)
+            q <= 1'b0;
+        else if (!g)
+            q <= d;
+endmodule
+
+module my_latchnr_n (
+    input  wire d, g, r,
+    output reg  q
+);
+    always @(*)
+        if (!r)
+            q <= 1'b0;
+        else if (!g)
+            q <= d;
 endmodule
 


### PR DESCRIPTION
This PR makes the synthesis flow for `qlf_k6n10f` infer and emit the following flip-flop and latch types:
- ~`DFF` - regular posedge D flip-flop, no set/reset~
- ~`DFFN` - regular negedge D flip-flop, no set/reset~
- `DFFSRE` - regular posedge D flip-flop, asynchronous low-active set and reset, enable input
- `DFFNSRE` - regular negedge D flip-flop, asynchronous low-active set and reset, enable input
- `SDFFSRE` - regular posedge D flip-flop, synchronous low-active set and reset, enable input
- `SDFFNSRE` - regular negedge D flip-flop, synchronous low-active set and reset, enable input
- ~`LATCH` - regular D-latch, active high gate, no set/reset~
- ~`LATCHN` - regular D-latch, active low gate, no set/reset~
- `LATCHSRE` - regular D-latch, active high gate, asynchronous low-active set and reset, enable input
- `LATCHNSRE` - regular D-latch, active low gate, asynchronous low-active set and reset, enable input

`LATCHSRE` and `LATCHNSRE` are supported and can be legalized but Yosys seems to be unable to infer them.