### PR TITLE
Use fullSVMode in Surelog

### DIFF
--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -110,6 +110,7 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         clp->setParse(true);
         clp->setCompile(true);
         clp->setElaborate(true);
+        clp->fullSVMode(true);
 
         SURELOG::scompiler *compiler = nullptr;
         const std::vector<vpiHandle> uhdm_design = executeCompilation(symbolTable, errors, clp, compiler);


### PR DESCRIPTION
This is the option set in compiler when using `-sverilog` switch in Surelog. It affects cases when SystemVerilog files with non-`.sv` extension are parsed.