### PR TITLE
ql-qlf: k6n10f: ql-bram-split: set INIT params only if those exist

### DIFF
--- a/ql-qlf-plugin/ql-bram-split.cc
+++ b/ql-qlf-plugin/ql-bram-split.cc
@@ -249,8 +249,10 @@ struct QlBramSplitPass : public Pass {
                         bram_2x18->setParam(RTLIL::escape_id("CFG_ENABLE_B"), bram_0->getParam(RTLIL::escape_id("CFG_ENABLE_B")));
                         bram_2x18->setParam(RTLIL::escape_id("CFG_ENABLE_D"), bram_1->getParam(RTLIL::escape_id("CFG_ENABLE_B")));
                     }
-                    bram_2x18->setParam(RTLIL::escape_id("INIT0"), bram_0->getParam(RTLIL::escape_id("INIT")));
-                    bram_2x18->setParam(RTLIL::escape_id("INIT1"), bram_1->getParam(RTLIL::escape_id("INIT")));
+                    if (bram_0->hasParam(RTLIL::escape_id("INIT")))
+                        bram_2x18->setParam(RTLIL::escape_id("INIT0"), bram_0->getParam(RTLIL::escape_id("INIT")));
+                    if (bram_1->hasParam(RTLIL::escape_id("INIT")))
+                        bram_2x18->setParam(RTLIL::escape_id("INIT1"), bram_1->getParam(RTLIL::escape_id("INIT")));
 
                     // Mark BRAM parts for removal
                     cellsToRemove.push_back(bram_0);


### PR DESCRIPTION
This PR fixes a bug reported in https://github.com/chipsalliance/yosys-f4pga-plugins/issues/341. `INIT` parameter is optional so we should check if it exist in the first place.

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>