### PR TITLE
Use a canonical way to test for an empty string.

### DIFF
--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -314,7 +314,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                     run("techmap -map +/mul2dsp.v [...]", "  (for qlf_k6n10f if not -no_dsp)");
                     run("chtype -set $mul t:$__soft_mul", "  (for qlf_k6n10f if not -no_dsp)");
                     run("techmap -map +/quicklogic/" + family + "/dsp_map.v", "(for qlf_k6n10f if not -no_dsp)");
-                    if (use_dsp_cfg_params == "")
+                    if (use_dsp_cfg_params.empty())
                         run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0", "(for qlf_k6n10f if not -no_dsp)");
                     else
                         run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1", "(for qlf_k6n10f if not -no_dsp)");
@@ -334,7 +334,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                                     rule.a_maxwidth, rule.b_maxwidth, rule.a_minwidth, rule.b_minwidth, rule.type.c_str()));
                         run("chtype -set $mul t:$__soft_mul");
                     }
-                    if (use_dsp_cfg_params == "")
+                    if (use_dsp_cfg_params.empty())
                         run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0");
                     else
                         run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1");

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3638,7 +3638,7 @@ void UhdmAst::process_repeat()
         if (node->type != AST::AST_BLOCK) {
             node = new AST::AstNode(AST::AST_BLOCK, node);
         }
-        if (node->str == "") {
+        if (node->str.empty()) {
             node->str = loop->str; // Needed in simplify step
         }
         loop->children.push_back(node);


### PR DESCRIPTION
Testing for empty strings or containers with empty() is always
the best and canonical choice.

Signed-off-by: Henner Zeller <h.zeller@acm.org>