### PR TITLE
[k6n10f] Preserve manually inserted DSPs

### DIFF
--- a/ql-qlf-plugin/ql-dsp-io-regs.cc
+++ b/ql-qlf-plugin/ql-dsp-io-regs.cc
@@ -82,6 +82,15 @@ struct QlDspIORegs : public Pass {
             std::string cell_type = cell.second->type.str();
             if (cell_type == RTLIL::escape_id("QL_DSP2") || cell_type == RTLIL::escape_id("QL_DSP3")) {
                 auto dsp = cell.second;
+
+                // If the cell does not have the "is_inferred" attribute set
+                // then don't touch it.
+                if (!dsp->has_attribute(RTLIL::escape_id("is_inferred")) ||
+                     dsp->get_bool_attribute(RTLIL::escape_id("is_inferred")) == false)
+                {
+                    continue;
+                }
+
                 bool del_clk = true;
                 bool use_dsp_cfg_params = (cell_type == RTLIL::escape_id("QL_DSP3"));
 

--- a/ql-qlf-plugin/ql-dsp-io-regs.cc
+++ b/ql-qlf-plugin/ql-dsp-io-regs.cc
@@ -85,9 +85,7 @@ struct QlDspIORegs : public Pass {
 
                 // If the cell does not have the "is_inferred" attribute set
                 // then don't touch it.
-                if (!dsp->has_attribute(RTLIL::escape_id("is_inferred")) ||
-                     dsp->get_bool_attribute(RTLIL::escape_id("is_inferred")) == false)
-                {
+                if (!dsp->has_attribute(RTLIL::escape_id("is_inferred")) || dsp->get_bool_attribute(RTLIL::escape_id("is_inferred")) == false) {
                     continue;
                 }
 

--- a/ql-qlf-plugin/ql-dsp-macc.cc
+++ b/ql-qlf-plugin/ql-dsp-macc.cc
@@ -131,6 +131,9 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
     // Add the DSP cell
     RTLIL::Cell *cell = pm.module->addCell(RTLIL::escape_id(name), type);
 
+    // Set attributes
+    cell->set_bool_attribute(RTLIL::escape_id("is_inferred"), true);
+
     // Get input/output data signals
     RTLIL::SigSpec sig_a;
     RTLIL::SigSpec sig_b;

--- a/ql-qlf-plugin/ql-dsp-simd.cc
+++ b/ql-qlf-plugin/ql-dsp-simd.cc
@@ -263,13 +263,12 @@ struct QlDspSimdPass : public Pass {
 
                     // Handle the "is_inferred" attribute. If one of the fragments
                     // is not inferred mark the whole DSP as not inferred
-                    bool is_inferred_a = dsp_a->has_attribute(RTLIL::escape_id("is_inferred")) ?
-                        dsp_a->get_bool_attribute(RTLIL::escape_id("is_inferred")) : false;
-                    bool is_inferred_b = dsp_b->has_attribute(RTLIL::escape_id("is_inferred")) ?
-                        dsp_b->get_bool_attribute(RTLIL::escape_id("is_inferred")) : false;
+                    bool is_inferred_a =
+                      dsp_a->has_attribute(RTLIL::escape_id("is_inferred")) ? dsp_a->get_bool_attribute(RTLIL::escape_id("is_inferred")) : false;
+                    bool is_inferred_b =
+                      dsp_b->has_attribute(RTLIL::escape_id("is_inferred")) ? dsp_b->get_bool_attribute(RTLIL::escape_id("is_inferred")) : false;
 
-                    simd->set_bool_attribute(RTLIL::escape_id("is_inferred"),
-                        is_inferred_a && is_inferred_b);
+                    simd->set_bool_attribute(RTLIL::escape_id("is_inferred"), is_inferred_a && is_inferred_b);
 
                     // Mark DSP parts for removal
                     cellsToRemove.push_back(dsp_a);

--- a/ql-qlf-plugin/ql-dsp-simd.cc
+++ b/ql-qlf-plugin/ql-dsp-simd.cc
@@ -261,6 +261,16 @@ struct QlDspSimdPass : public Pass {
                     simd->setParam(RTLIL::escape_id("MODE_BITS"), RTLIL::Const(mode_bits));
                     log_assert(mode_bits.size() == mode_bits_size);
 
+                    // Handle the "is_inferred" attribute. If one of the fragments
+                    // is not inferred mark the whole DSP as not inferred
+                    bool is_inferred_a = dsp_a->has_attribute(RTLIL::escape_id("is_inferred")) ?
+                        dsp_a->get_bool_attribute(RTLIL::escape_id("is_inferred")) : false;
+                    bool is_inferred_b = dsp_b->has_attribute(RTLIL::escape_id("is_inferred")) ?
+                        dsp_b->get_bool_attribute(RTLIL::escape_id("is_inferred")) : false;
+
+                    simd->set_bool_attribute(RTLIL::escape_id("is_inferred"),
+                        is_inferred_a && is_inferred_b);
+
                     // Mark DSP parts for removal
                     cellsToRemove.push_back(dsp_a);
                     cellsToRemove.push_back(dsp_b);

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
@@ -34,6 +34,7 @@ module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
                             {{(18 - B_WIDTH){1'b0}},         B};
 
     generate if (`USE_DSP_CFG_PARAMS == 0) begin
+        (* is_inferred=1 *)
         dsp_t1_20x18x64_cfg_ports _TECHMAP_REPLACE_ (
             .a_i                (a),
             .b_i                (b),
@@ -53,6 +54,7 @@ module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
             .register_inputs_i  (1'b0)
         );
     end else begin
+        (* is_inferred=1 *)
         dsp_t1_20x18x64_cfg_params #(
             .OUTPUT_SELECT      (3'd0),
             .SATURATE_ENABLE    (1'b0),
@@ -98,6 +100,7 @@ module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
                             {{( 9 - B_WIDTH){1'b0}},         B};
 
     generate if (`USE_DSP_CFG_PARAMS == 0) begin
+        (* is_inferred=1 *)
         dsp_t1_10x9x32_cfg_ports _TECHMAP_REPLACE_ (
             .a_i                (a),
             .b_i                (b),
@@ -117,6 +120,7 @@ module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
             .register_inputs_i  (1'b0)
         );
     end else begin
+        (* is_inferred=1 *)
         dsp_t1_10x9x32_cfg_params #(
             .OUTPUT_SELECT      (3'd0),
             .SATURATE_ENABLE    (1'b0),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_madd/dsp_madd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_madd/dsp_madd.v
@@ -23,8 +23,12 @@ module madd_simple_ports (
 
     // There is no support for autmoatic inference of multiply+add hence the
     // DSP cell needs to be instanced manually.
+    //
+    // To test the type change the "is_inferred" attribute is set here
+    // explicitily to mimic possible inference
 
     // B * coeff[C] + A
+    (* is_inferred=1 *)
     dsp_t1_10x9x32_cfg_ports # (
         .COEFF_0            (10'h011),
         .COEFF_1            (10'h022),
@@ -62,8 +66,12 @@ module madd_simple_params (
 
     // There is no support for autmoatic inference of multiply+add hence the
     // DSP cell needs to be instanced manually.
+    //
+    // To test the type change the "is_inferred" attribute is set here
+    // explicitily to mimic possible inference
 
     // B * coeff[C] + A
+    (* is_inferred=1 *)
     dsp_t1_10x9x32_cfg_params # (
         .COEFF_0            (10'h011),
         .COEFF_1            (10'h022),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
@@ -48,7 +48,6 @@ proc test_dsp_cfg_ports {top expected_cell_suffix cells2match} {
     design -load postopt
     yosys cd ${top}
     select -assert-count ${cells2match} t:QL_DSP2${expected_cell_suffix}
-    select -assert-count 0 t:QL_DSP2
     select -assert-count 0 t:dsp_t1_10x9x32_cfg_ports
     select -assert-count 0 t:dsp_t1_20x18x64_cfg_ports
 
@@ -71,7 +70,6 @@ proc test_dsp_cfg_params {top expected_cell_suffix cells2match} {
     design -load postopt
     yosys cd ${TOP}
     select -assert-count ${cells2match} t:QL_DSP3${expected_cell_suffix}
-    select -assert-count 0 t:QL_DSP3
     select -assert-count 0 t:dsp_t1_10x9x32_cfg_params
     select -assert-count 0 t:dsp_t1_20x18x64_cfg_params
 
@@ -87,18 +85,15 @@ proc test_dsp_cfg_params {top expected_cell_suffix cells2match} {
 #           of the inference, eg. _MULT, _MACC_REGIN, MADD_REGIN_REGOUT
 proc test_dsp_cfg_conflict {top expected_cell_suffix} {
     set TOP ${top}
-    set USE_DSP_CFG_PARAMS 1
+    set USE_DSP_CFG_PARAMS 0
     design -load read
     hierarchy -top $TOP
     check_equiv ${TOP} ${USE_DSP_CFG_PARAMS}
     design -load postopt
     yosys cd ${TOP}
-    select -assert-count 1 t:QL_DSP2${expected_cell_suffix}
-    select -assert-count 1 t:QL_DSP3${expected_cell_suffix}
-    select -assert-count 0 t:QL_DSP2
+    select -assert-count 2 t:QL_DSP2${expected_cell_suffix}
     select -assert-count 0 t:dsp_t1_10x9x32_cfg_ports
     select -assert-count 0 t:dsp_t1_20x18x64_cfg_ports
-    select -assert-count 0 t:QL_DSP3
     select -assert-count 0 t:dsp_t1_10x9x32_cfg_params
     select -assert-count 0 t:dsp_t1_20x18x64_cfg_params
 
@@ -111,12 +106,12 @@ yosys -import  ;# ingest plugin commands
 read_verilog dsp_simd.v
 design -save read
 
-test_dsp_cfg_ports      "simd_mult_explicit_ports"      "_MULT_REGIN"   1
-test_dsp_cfg_params     "simd_mult_explicit_params"     "_MULT_REGIN"   1
-test_dsp_cfg_ports      "simd_mult_inferred"            "_MULT"         1
-test_dsp_cfg_params     "simd_mult_inferred"            "_MULT"         1
-test_dsp_cfg_ports      "simd_mult_odd_ports"           "_MULT_REGIN"   2
-test_dsp_cfg_params     "simd_mult_odd_params"          "_MULT_REGIN"   2
-test_dsp_cfg_ports      "simd_mult_conflict_ports"      "_MULT_REGIN"   2
-test_dsp_cfg_conflict   "simd_mult_conflict_config"     "_MULT_REGIN"
+test_dsp_cfg_ports      "simd_mult_explicit_ports"      ""       1
+test_dsp_cfg_params     "simd_mult_explicit_params"     ""       1
+test_dsp_cfg_ports      "simd_mult_inferred"            "_MULT"  1
+test_dsp_cfg_params     "simd_mult_inferred"            "_MULT"  1
+test_dsp_cfg_ports      "simd_mult_odd_ports"           ""       2
+test_dsp_cfg_params     "simd_mult_odd_params"          ""       2
+test_dsp_cfg_ports      "simd_mult_conflict_ports"      ""       2
+test_dsp_cfg_conflict   "simd_mult_conflict_config"     ""
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
@@ -371,33 +371,12 @@ module simd_mult_conflict_config (
     output wire [15:0]  z1
 );
 
-    dsp_t1_10x9x32_cfg_params #(
-        .OUTPUT_SELECT      (3'd0),
-        .SATURATE_ENABLE    (1'b0),
-        .SHIFT_RIGHT        (6'd0),
-        .ROUND              (1'b0),
-        .REGISTER_INPUTS    (1'b1)
-    ) dsp_0 (
+    dsp_t1_10x9x32_cfg_ports dsp_0 (
         .a_i    (a0),
         .b_i    (b0),
         .z_o    (z0),
 
-        .clock_i            (clk),
-
-        .feedback_i         (3'd0),
-        .load_acc_i         (1'b0),
-        .unsigned_a_i       (1'b1),
-        .unsigned_b_i       (1'b1),
-
-        .subtract_i         (1'b0)
-    );
-
-    dsp_t1_10x9x32_cfg_ports dsp_1 (
-        .a_i    (a1),
-        .b_i    (b1),
-        .z_o    (z1),
-
-        .clock_i            (clk),
+        .clock_i            (clk0),
 
         .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
@@ -409,7 +388,27 @@ module simd_mult_conflict_config (
         .shift_right_i      (6'd0),
         .round_i            (1'b0),
         .subtract_i         (1'b0),
-        .register_inputs_i  (1'b1)
+        .register_inputs_i  (1'b0)
+    );
+
+    dsp_t1_10x9x32_cfg_ports dsp_1 (
+        .a_i    (a1),
+        .b_i    (b1),
+        .z_o    (z1),
+
+        .clock_i            (clk1),
+
+        .feedback_i         (3'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b0)
     );
 
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd_post_synth_sim/dsp_simd_post_synth_sim.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd_post_synth_sim/dsp_simd_post_synth_sim.tcl
@@ -24,7 +24,7 @@ opt_expr -undriven
 opt_clean
 stat
 write_verilog sim/simd_mult_explicit_ports_post_synth.v
-select -assert-count 1 t:QL_DSP2_MULT_REGIN
+select -assert-count 1 t:QL_DSP2
 
 select -clear
 design -load dsp_simd
@@ -35,4 +35,4 @@ opt_expr -undriven
 opt_clean
 stat
 write_verilog sim/simd_mult_explicit_params_post_synth.v
-select -assert-count 1 t:QL_DSP3_MULT_REGIN
+select -assert-count 1 t:QL_DSP3


### PR DESCRIPTION
This PR adds preservation of all manually inserted `QL_DSP2` cells - their types will never get changed.

The feature is implemented by annotating inferred DSP cells with an attribute which tells the pass that changes types that the change is allowed.