### PR TITLE
ql-qlf: k6n10f: add asymmetric RAM inference

### DIFF
--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -23,10 +23,13 @@ SOURCES = synth_quicklogic.cc \
           ql-dsp-simd.cc \
           ql-dsp-macc.cc \
           ql-bram-split.cc \
-          ql-dsp-io-regs.cc
+          ql-dsp-io-regs.cc \
+          ql-bram-asymmetric.cc
 
 DEPS = pmgen/ql-dsp-pm.h \
-       pmgen/ql-dsp-macc.h
+       pmgen/ql-dsp-macc.h \
+       pmgen/ql-bram-asymmetric-wider-write.h \
+       pmgen/ql-bram-asymmetric-wider-read.h
 
 include ../Makefile_plugin.common
 
@@ -84,6 +87,12 @@ pmgen/ql-dsp-pm.h: ../pmgen.py ql_dsp.pmg | pmgen
 
 pmgen/ql-dsp-macc.h: ../pmgen.py ql-dsp-macc.pmg | pmgen
 	python3 ../pmgen.py -o $@ -p ql_dsp_macc ql-dsp-macc.pmg
+
+pmgen/ql-bram-asymmetric-wider-write.h: ../pmgen.py ql-bram-asymmetric-wider-write.pmg | pmgen
+	python3 ../pmgen.py -o $@ -p ql_bram_asymmetric_wider_write ql-bram-asymmetric-wider-write.pmg
+
+pmgen/ql-bram-asymmetric-wider-read.h: ../pmgen.py ql-bram-asymmetric-wider-read.pmg | pmgen
+	python3 ../pmgen.py -o $@ -p ql_bram_asymmetric_wider_read ql-bram-asymmetric-wider-read.pmg
 
 install_modules: $(VERILOG_MODULES)
 	$(foreach f,$^,install -D $(f) $(DATA_DIR)/quicklogic/$(f);)

--- a/ql-qlf-plugin/ql-bram-asymmetric-wider-read.pmg
+++ b/ql-qlf-plugin/ql-bram-asymmetric-wider-read.pmg
@@ -1,0 +1,66 @@
+pattern ql_bram_asymmetric_wider_read
+
+state <SigSpec> mem_wr_data
+state <SigSpec> mem_wr_en
+state <SigSpec> mem_wr_addr
+state <SigSpec> mem_rd_data
+state <SigSpec> mem_rd_addr
+state <SigSpec> mux_ab
+state <SigSpec> mux_s
+state <SigSpec> mux_ba
+state <SigSpec> mux_input
+state <SigSpec> wr_data_shift_a
+state <SigSpec> wr_data_shift_b
+state <SigSpec> wr_en_and_a
+state <SigSpec> wr_en_and_b
+state <SigSpec> wr_en_and_y
+state <SigSpec> wr_en_shift_a
+state <SigSpec> wr_en_shift_b
+state <SigSpec> wr_en_shift_y
+
+match mem
+    select mem->type == ($mem_v2)
+    // 2 because it is a primary output connected to one cell (rq port or $shiftx cell)
+    select nusers(port(mem, \WR_DATA)) == 2
+    set mem_wr_data port(mem, \WR_DATA)
+    set mem_wr_en port(mem, \WR_EN)
+    set mem_wr_addr port(mem, \WR_ADDR)
+    set mem_rd_data port(mem, \RD_DATA)
+    set mem_rd_addr port(mem, \RD_ADDR)
+endmatch
+
+match wr_en_and
+    select wr_en_and->type == ($and)
+    set wr_en_and_a port(wr_en_and, \A)
+    set wr_en_and_b port(wr_en_and, \B)
+    set wr_en_and_y port(wr_en_and, \Y)
+endmatch
+
+match wr_en_shift
+    select wr_en_shift->type.in($shl)
+    set wr_en_shift_a port(wr_en_shift, \A)
+    set wr_en_shift_b port(wr_en_shift, \B)
+    set wr_en_shift_y port(wr_en_shift, \Y)
+endmatch
+
+match mux
+    select mux->type == ($mux)
+    choice <IdString> AB {\A, \B}
+    define <IdString> BA (AB == \A ? \B : \A)
+    index <SigSpec> port(mux, \Y) === mem_wr_en
+    index <SigSpec> port(mux, AB) === wr_en_shift_y
+    set mux_ab port(mux, AB)
+    set mux_s port(mux, \S)
+    set mux_ba port(mux, BA)
+endmatch
+
+match wr_data_shift
+    select wr_data_shift->type.in($shl)
+    index <SigSpec> port(wr_data_shift, \Y) === mem_wr_data
+    set wr_data_shift_a port(wr_data_shift, \A)
+    set wr_data_shift_b port(wr_data_shift, \B)
+endmatch
+
+code
+    accept;
+endcode

--- a/ql-qlf-plugin/ql-bram-asymmetric-wider-write.pmg
+++ b/ql-qlf-plugin/ql-bram-asymmetric-wider-write.pmg
@@ -1,0 +1,65 @@
+pattern ql_bram_asymmetric_wider_write
+
+state <SigSpec> mem_rd_data
+state <SigSpec> mem_rd_addr
+state <SigSpec> mem_wr_data
+state <SigSpec> mem_wr_addr
+state <SigSpec> mem_wr_en
+state <SigSpec> rd_data_shift_y
+state <SigSpec> rd_data_ff_q
+state <SigSpec> rd_data_ff_en
+state <SigSpec> rd_data_ff_clk
+state <SigSpec> wr_addr_ff_d
+state <SigSpec> wr_en_mux_s
+state <SigSpec> rd_addr_and_a
+state <SigSpec> rd_addr_and_b
+
+match mem
+    select mem->type == ($mem_v2)
+    // 2 because it is a primary output connected to one cell (rq port or $shiftx cell)
+    select nusers(port(mem, \RD_DATA)) == 2
+    set mem_rd_data port(mem, \RD_DATA)
+    set mem_rd_addr port(mem, \RD_ADDR)
+    set mem_wr_data port(mem, \WR_DATA)
+    set mem_wr_addr port(mem, \WR_ADDR)
+    set mem_wr_en port(mem, \WR_EN)
+endmatch
+
+match rd_data_shift
+    select rd_data_shift->type.in($shiftx)
+    index <SigSpec> port(rd_data_shift, \A) === mem_rd_data
+    set rd_data_shift_y port(rd_data_shift, \Y)
+endmatch
+
+match rd_data_ff
+    select rd_data_ff->type.in($dffe)
+    select nusers(port(rd_data_ff, \D)) == 2
+    index <SigSpec> port(rd_data_ff, \D) === rd_data_shift_y
+    set rd_data_ff_q port(rd_data_ff, \Q)
+    set rd_data_ff_en port(rd_data_ff, \EN)
+    set rd_data_ff_clk port(rd_data_ff, \CLK)
+endmatch
+
+match wr_addr_ff
+    select wr_addr_ff->type.in($dff)
+    select nusers(port(wr_addr_ff, \Q)) == 2
+    index <SigSpec> port(wr_addr_ff, \Q) === mem_wr_addr
+    set wr_addr_ff_d port(wr_addr_ff, \D)
+    optional
+endmatch
+
+match wr_en_mux
+    select wr_en_mux->type.in($mux)
+    index <SigSpec> port(wr_en_mux, \Y) === mem_wr_en[0]
+    set wr_en_mux_s port(wr_en_mux, \S)
+endmatch
+
+match rd_addr_and
+    select rd_addr_and->type.in($and)
+    set rd_addr_and_a port(rd_addr_and, \A)
+    set rd_addr_and_b port(rd_addr_and, \B)
+endmatch
+
+code
+    accept;
+endcode

--- a/ql-qlf-plugin/ql-bram-asymmetric.cc
+++ b/ql-qlf-plugin/ql-bram-asymmetric.cc
@@ -1,0 +1,370 @@
+#include "kernel/sigtools.h"
+#include "kernel/yosys.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+#include "pmgen/ql-bram-asymmetric-wider-read.h"
+#include "pmgen/ql-bram-asymmetric-wider-write.h"
+
+void test_ql_bram_asymmetric_wider_read(ql_bram_asymmetric_wider_read_pm &pm)
+{
+    auto mem = pm.st_ql_bram_asymmetric_wider_read.mem;
+    auto mem_wr_addr = pm.st_ql_bram_asymmetric_wider_read.mem_wr_addr;
+    auto mem_rd_data = pm.st_ql_bram_asymmetric_wider_read.mem_rd_data;
+    auto mem_rd_addr = pm.st_ql_bram_asymmetric_wider_read.mem_rd_addr;
+    auto mux = pm.st_ql_bram_asymmetric_wider_read.mux;
+    auto mux_s = pm.st_ql_bram_asymmetric_wider_read.mux_s;
+    auto wr_en_shift = pm.st_ql_bram_asymmetric_wider_read.wr_en_shift;
+    auto wr_en_shift_b = pm.st_ql_bram_asymmetric_wider_read.wr_en_shift_b;
+    auto wr_data_shift = pm.st_ql_bram_asymmetric_wider_read.wr_data_shift;
+    auto wr_data_shift_a = pm.st_ql_bram_asymmetric_wider_read.wr_data_shift_a;
+    auto wr_data_shift_b = pm.st_ql_bram_asymmetric_wider_read.wr_data_shift_b;
+    auto wr_en_and = pm.st_ql_bram_asymmetric_wider_read.wr_en_and;
+    auto wr_en_and_a = pm.st_ql_bram_asymmetric_wider_read.wr_en_and_a;
+    auto wr_en_and_b = pm.st_ql_bram_asymmetric_wider_read.wr_en_and_b;
+    auto wr_en_and_y = pm.st_ql_bram_asymmetric_wider_read.wr_en_and_y;
+
+    // Add the BRAM cell
+    RTLIL::Cell *cell = pm.module->addCell(RTLIL::escape_id("bram_asymmetric"), mem);
+
+    // Set new type for cell so that it won't be processed by memory_bram pass
+    cell->type = IdString("$mem_v2_asymmetric");
+
+    // Prepare wires from memory cell side to compare against module wires
+    if (!mux_s.as_wire())
+        log_error("WR_EN input wire not found");
+    RTLIL::Wire *wr_en_cw = mux_s.as_wire();
+    if (!mem_wr_addr.as_wire())
+        log_error("WR_ADDR input wire not found");
+    RTLIL::Wire *wr_addr_cw = mem_wr_addr.as_wire();
+    if (!wr_data_shift_a.as_wire())
+        log_error("WR_DATA input wire not found");
+    RTLIL::Wire *wr_data_cw = wr_data_shift_a.as_wire();
+    if (!mem_rd_addr.as_wire())
+        log_error("RD_ADDR input wire not found");
+    RTLIL::Wire *rd_addr_cw = mem_rd_addr.as_wire();
+    if (!mem_rd_data.as_wire())
+        log_error("RD_DATA input wire not found");
+    RTLIL::Wire *rd_data_cw = mem_rd_data.as_wire();
+
+    // Check if wr_en_and cell has one of its inputs connected to write address
+    RTLIL::Wire *wr_en_and_a_w = nullptr;
+    RTLIL::Wire *wr_en_and_b_w = nullptr;
+    bool has_wire = false;
+    if (wr_en_and_a.is_wire()) {
+        has_wire = true;
+        wr_en_and_a_w = wr_en_and_a.as_wire();
+    }
+    if (wr_en_and_b.is_wire()) {
+        has_wire = true;
+        wr_en_and_b_w = wr_en_and_b.as_wire();
+    }
+    if (!has_wire)
+        log_error("RD_ADDR $and cell input wire not found");
+    if ((wr_en_and_a_w != mem_wr_addr.as_wire()) & (wr_en_and_b_w != mem_wr_addr.as_wire()))
+        log_error("This is not the $and cell we are looking for");
+
+    // Compare and assign wires
+    RTLIL::Wire *wr_en_w = nullptr;
+    RTLIL::Wire *wr_addr_w = nullptr;
+    RTLIL::Wire *wr_data_w = nullptr;
+    RTLIL::Wire *rd_addr_w = nullptr;
+    RTLIL::Wire *rd_data_w = nullptr;
+
+    for (auto wire : pm.module->wires_) {
+        if (wire.second == wr_en_cw)
+            wr_en_w = wire.second;
+        if (wire.second == wr_addr_cw)
+            wr_addr_w = wire.second;
+        if (wire.second == wr_data_cw)
+            wr_data_w = wire.second;
+        if (wire.second == rd_data_cw)
+            rd_data_w = wire.second;
+        if (wire.second == rd_addr_cw)
+            rd_addr_w = wire.second;
+    }
+
+    if (!wr_en_w | !wr_addr_w | !wr_data_w | !rd_data_w | !rd_addr_w)
+        log_error("Match between RAM input wires and memory cell ports not found\n");
+
+    // Get address and data lines widths
+    int rd_addr_width = rd_addr_w->width;
+    int wr_addr_width = wr_addr_w->width;
+    int wr_data_width = wr_data_w->width;
+    int rd_data_width = rd_data_w->width;
+
+    log_debug("Set RD_ADDR_WIDTH = %d, ", rd_addr_width);
+    log_debug("WR_ADDR_WIDTH = %d, ", wr_addr_width);
+    log_debug("RD_DATA_WIDTH = %d, ", rd_data_width);
+    log_debug("WR_DATA_WIDTH = %d\n", wr_data_width);
+
+    // Set address and data lines width parameters used later in techmap
+    cell->setParam(RTLIL::escape_id("RD_ADDR_WIDTH"), RTLIL::Const(rd_addr_width));
+    cell->setParam(RTLIL::escape_id("RD_DATA_WIDTH"), RTLIL::Const(rd_data_width));
+    cell->setParam(RTLIL::escape_id("WR_ADDR_WIDTH"), RTLIL::Const(wr_addr_width));
+    cell->setParam(RTLIL::escape_id("WR_DATA_WIDTH"), RTLIL::Const(wr_data_width));
+
+    int offset;
+
+    switch (wr_data_width) {
+    case 1:
+        offset = 0;
+        break;
+    case 2:
+        offset = 1;
+        break;
+    case 4:
+        offset = 2;
+        break;
+    case 8:
+    case 9:
+        offset = 3;
+        break;
+    case 16:
+    case 18:
+        offset = 4;
+        break;
+    case 32:
+    case 36:
+        offset = 5;
+        break;
+    default:
+        offset = 0;
+        break;
+    }
+
+    if (wr_en_and_y != wr_en_shift_b.extract(offset, wr_addr_width))
+        log_error("This is not the wr_en $shl cell we are looking for");
+    if (wr_en_and_y != wr_data_shift_b.extract(offset, wr_addr_width))
+        log_error("This is not the wr_data $shl cell we are looking for");
+
+    // Bypass shift on write address line
+    cell->setPort(RTLIL::escape_id("WR_ADDR"), RTLIL::SigSpec(wr_addr_w));
+
+    // Bypass shift on write address line
+    cell->setPort(RTLIL::escape_id("WR_DATA"), RTLIL::SigSpec(wr_data_w));
+
+    // Bypass shift on write address line
+    cell->setPort(RTLIL::escape_id("WR_EN"), RTLIL::SigSpec(wr_en_w));
+
+    // Cleanup the module from unused cells
+    pm.module->remove(mem);
+    pm.module->remove(mux);
+    pm.module->remove(wr_en_shift);
+    pm.module->remove(wr_en_and);
+    pm.module->remove(wr_data_shift);
+}
+
+void test_ql_bram_asymmetric_wider_write(ql_bram_asymmetric_wider_write_pm &pm)
+{
+    auto mem = pm.st_ql_bram_asymmetric_wider_write.mem;
+    auto mem_wr_addr = pm.st_ql_bram_asymmetric_wider_write.mem_wr_addr;
+    auto mem_wr_data = pm.st_ql_bram_asymmetric_wider_write.mem_wr_data;
+    auto mem_rd_data = pm.st_ql_bram_asymmetric_wider_write.mem_rd_data;
+    auto mem_rd_addr = pm.st_ql_bram_asymmetric_wider_write.mem_rd_addr;
+    auto rd_data_shift = pm.st_ql_bram_asymmetric_wider_write.rd_data_shift;
+    auto rd_data_shift_y = pm.st_ql_bram_asymmetric_wider_write.rd_data_shift_y;
+    auto rd_data_ff = pm.st_ql_bram_asymmetric_wider_write.rd_data_ff;
+    auto rd_data_ff_q = pm.st_ql_bram_asymmetric_wider_write.rd_data_ff_q;
+    auto rd_data_ff_en = pm.st_ql_bram_asymmetric_wider_write.rd_data_ff_en;
+    auto rd_data_ff_clk = pm.st_ql_bram_asymmetric_wider_write.rd_data_ff_clk;
+    auto wr_addr_ff = pm.st_ql_bram_asymmetric_wider_write.wr_addr_ff;
+    auto wr_addr_ff_d = pm.st_ql_bram_asymmetric_wider_write.wr_addr_ff_d;
+    auto wr_en_mux = pm.st_ql_bram_asymmetric_wider_write.wr_en_mux;
+    auto wr_en_mux_s = pm.st_ql_bram_asymmetric_wider_write.wr_en_mux_s;
+    auto rd_addr_and = pm.st_ql_bram_asymmetric_wider_write.rd_addr_and;
+    auto rd_addr_and_a = pm.st_ql_bram_asymmetric_wider_write.rd_addr_and_a;
+    auto rd_addr_and_b = pm.st_ql_bram_asymmetric_wider_write.rd_addr_and_b;
+
+    // Add the BRAM cell
+    RTLIL::Cell *cell = pm.module->addCell(RTLIL::escape_id("bram_asymmetric"), mem);
+
+    // Set new type for cell so that it won't be processed by memory_bram pass
+    cell->type = IdString("$mem_v2_asymmetric");
+
+    // Prepare wires from memory cell side to compare against module wires
+    RTLIL::Wire *rd_data_wc = nullptr;
+    RTLIL::Wire *rd_en_wc = nullptr;
+    RTLIL::Wire *clk_wc = nullptr;
+    RTLIL::Wire *rd_addr_and_a_wc = nullptr;
+    RTLIL::Wire *rd_addr_and_b_wc = nullptr;
+
+    if (rd_data_ff) {
+        if (!rd_data_ff_q.as_wire())
+            log_error("RD_DATA input wire not found");
+        rd_data_wc = rd_data_ff_q.as_wire();
+        if (!rd_data_ff_en.as_wire())
+            log_error("RD_EN input wire not found");
+        rd_en_wc = rd_data_ff_en.as_wire();
+        if (!rd_data_ff_clk.as_wire())
+            log_error("RD_CLK input wire not found");
+        clk_wc = rd_data_ff_clk.as_wire();
+    } else {
+        log_error("output FF not found");
+    }
+
+    if (rd_addr_and) {
+        bool has_wire = false;
+        if (rd_addr_and_a.is_wire()) {
+            has_wire = true;
+            rd_addr_and_a_wc = rd_addr_and_a.as_wire();
+        }
+        if (rd_addr_and_b.is_wire()) {
+            has_wire = true;
+            rd_addr_and_b_wc = rd_addr_and_b.as_wire();
+        }
+        if (!has_wire)
+            log_error("RD_ADDR $and cell input wire not found");
+    } else {
+        log_debug("RD_ADDR $and cell not found");
+    }
+
+    RTLIL::Wire *wr_addr_wc;
+    if (wr_addr_ff) {
+        if (!wr_addr_ff_d.as_wire())
+            log_error("WR_ADDR input wire not found");
+        wr_addr_wc = wr_addr_ff_d.as_wire();
+    } else {
+        if (!mem_wr_addr.as_wire())
+            log_error("WR_ADDR input wire not found");
+        wr_addr_wc = mem_wr_addr.as_wire();
+    }
+
+    if (!mem_rd_addr.as_wire())
+        log_error("RD_ADDR input wire not found");
+    auto rd_addr_wc = mem_rd_addr.as_wire();
+    if (!mem_wr_data.as_wire())
+        log_error("WR_DATA input wire not found");
+    auto wr_data_wc = mem_wr_data.as_wire();
+
+    // Check if wr_en_and cell has one of its inputs connected to write address
+
+    // Compare and assign wires
+    RTLIL::Wire *rd_addr_w = nullptr;
+    RTLIL::Wire *rd_data_w = nullptr;
+    RTLIL::Wire *rd_en_w = nullptr;
+    RTLIL::Wire *rd_clk_w = nullptr;
+    RTLIL::Wire *wr_addr_w = nullptr;
+    RTLIL::Wire *wr_data_w = nullptr;
+
+    for (auto wire : pm.module->wires_) {
+        if (wire.second == rd_addr_wc)
+            rd_addr_w = wire.second;
+        if (wire.second == rd_data_wc)
+            rd_data_w = wire.second;
+        if (wire.second == rd_en_wc)
+            rd_en_w = wire.second;
+        if (wire.second == clk_wc)
+            rd_clk_w = wire.second;
+        if (wire.second == wr_addr_wc)
+            wr_addr_w = wire.second;
+        if (wire.second == wr_data_wc)
+            wr_data_w = wire.second;
+    }
+
+    if (!rd_addr_w | !rd_data_w | !rd_en_w | !rd_clk_w | !wr_addr_w | !wr_data_w)
+        log_error("Match between RAM input wires and memory cell ports not found\n");
+
+    // Set shift output SigSpec as RD_DATA
+    cell->setPort(RTLIL::escape_id("RD_DATA"), rd_data_shift_y);
+
+    // Get address and data lines widths
+    int rd_addr_width = rd_addr_w->width;
+    int wr_addr_width = wr_addr_w->width;
+    int wr_data_width = wr_data_w->width;
+    int rd_data_width = rd_data_w->width;
+
+    log_debug("Set RD_ADDR_WIDTH = %d, ", rd_addr_width);
+    log_debug("WR_ADDR_WIDTH = %d, ", wr_addr_width);
+    log_debug("RD_DATA_WIDTH = %d, ", rd_data_width);
+    log_debug("WR_DATA_WIDTH = %d\n", wr_data_width);
+
+    // Set address and data lines width parameters used later in techmap
+    cell->setParam(RTLIL::escape_id("RD_ADDR_WIDTH"), RTLIL::Const(rd_addr_width));
+    cell->setParam(RTLIL::escape_id("RD_DATA_WIDTH"), RTLIL::Const(rd_data_width));
+    cell->setParam(RTLIL::escape_id("WR_ADDR_WIDTH"), RTLIL::Const(wr_addr_width));
+    cell->setParam(RTLIL::escape_id("WR_DATA_WIDTH"), RTLIL::Const(wr_data_width));
+
+    // Bypass read address shift and connect line straight to memory cell
+    auto rd_addr_s = RTLIL::SigSpec(rd_addr_w);
+    cell->setPort(RTLIL::escape_id("RD_ADDR"), rd_addr_s);
+
+    if (wr_addr_ff) {
+        // Bypass FF on write address line if exists
+        // wr_addr_ff_d will not be assigned if wr_addr_ff was not detected earlier
+        cell->setPort(RTLIL::escape_id("WR_ADDR"), wr_addr_ff_d);
+    } else {
+        // When there are no regs on address lines, the clock isn't connected to memory
+        // Reconnect the clock
+        auto rd_clk_s = RTLIL::SigSpec(rd_clk_w);
+        cell->setPort(RTLIL::escape_id("RD_CLK"), rd_clk_s);
+    }
+
+    // Bypass FF on Data Output and connect the output straight to RD_DATA port
+    cell->setPort(RTLIL::escape_id("RD_DATA"), rd_data_ff_q);
+
+    // Bypass MUX on WRITE ENABLE and connect the output straight to WR_EN port
+    cell->setPort(RTLIL::escape_id("WR_EN"), wr_en_mux_s);
+
+    // Connect Read Enable signal to memory cell
+    if (!rd_en_w)
+        log_error("Wire \\rce not found");
+    auto rd_en_s = RTLIL::SigSpec(rd_en_w);
+    cell->setPort(RTLIL::escape_id("RD_EN"), rd_en_s);
+
+    // Cleanup the module from unused cells
+    pm.module->remove(mem);
+    pm.module->remove(rd_data_shift);
+    pm.module->remove(rd_data_ff);
+    pm.module->remove(wr_en_mux);
+    if (wr_addr_ff)
+        pm.module->remove(wr_addr_ff);
+    // Check if detected $and is connected to RD_ADDR
+    if ((rd_addr_and_a_wc != rd_addr_w) & (rd_addr_and_b_wc != rd_addr_w))
+        log_error("This is not the $and cell we are looking for");
+    else
+        pm.module->remove(rd_addr_and);
+}
+
+struct QLBramAsymmetric : public Pass {
+
+    QLBramAsymmetric()
+        : Pass("ql_bram_asymmetric",
+               "Detects memory cells with asymmetric read and write port widths implemented with shifts and infers custom asymmetric memory cell")
+    {
+    }
+
+    void help() override
+    {
+        log("\n");
+        log("    ql_bram_asymmetric\n");
+        log("\n");
+        log("		Detects memory cells with asymmetric read and write port widths implemented with shifts and infers custom asymmetric memory "
+            "cell");
+        log("\n");
+    }
+
+    void execute(std::vector<std::string> a_Args, RTLIL::Design *a_Design) override
+    {
+        log_header(a_Design, "Executing QL_BRAM_ASYMMETRIC pass.\n");
+
+        size_t argidx;
+        for (argidx = 1; argidx < a_Args.size(); argidx++) {
+            break;
+        }
+        extra_args(a_Args, argidx, a_Design);
+
+        int found_cells;
+        for (auto module : a_Design->selected_modules()) {
+            found_cells = ql_bram_asymmetric_wider_write_pm(module, module->selected_cells())
+                            .run_ql_bram_asymmetric_wider_write(test_ql_bram_asymmetric_wider_write);
+            log_debug("found %d cells matching for wider write port\n", found_cells);
+            found_cells = ql_bram_asymmetric_wider_read_pm(module, module->selected_cells())
+                            .run_ql_bram_asymmetric_wider_read(test_ql_bram_asymmetric_wider_read);
+            log_debug("found %d cells matching for wider read port\n", found_cells);
+        }
+    }
+} QLBramAsymmetric;
+
+PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1150,10 +1150,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
             assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
             assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
-        defparam bram_2x18k.MODE_BITS = { 1'b1,
-        11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
-        12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
-        };
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+            };
         end
 
         2: begin
@@ -1161,10 +1161,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 1) : (F1EN ? (F1ADDR_TOTAL << 1) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 1) : (H1EN ? (H1ADDR_TOTAL << 1) : 14'd0);
-        defparam bram_2x18k.MODE_BITS = { 1'b1,
-        11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
-        12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
-        };
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+            };
         end
 
         4: begin
@@ -1172,10 +1172,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 2) : (D1EN ? (D1ADDR_TOTAL << 2) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 2) : (F1EN ? (F1ADDR_TOTAL << 2) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 2) : (H1EN ? (H1ADDR_TOTAL << 2) : 14'd0);
-        defparam bram_2x18k.MODE_BITS = { 1'b1,
-        11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
-        12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
-        };
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+            };
         end
 
         8, 9: begin
@@ -1183,10 +1183,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 3) : (F1EN ? (F1ADDR_TOTAL << 3) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 3) : (H1EN ? (H1ADDR_TOTAL << 3) : 14'd0);
-        defparam bram_2x18k.MODE_BITS = { 1'b1,
-        11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
-        12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
-        };
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+            };
         end
 
         16, 18: begin
@@ -1194,10 +1194,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 14'd0);
             assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 4) : (F1EN ? (F1ADDR_TOTAL << 4) : 14'd0);
             assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 4) : (H1EN ? (H1ADDR_TOTAL << 4) : 14'd0);
-        defparam bram_2x18k.MODE_BITS = { 1'b1,
-        11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
-        12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
-        };
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+            };
         end
 
         default: begin
@@ -1205,10 +1205,10 @@ module BRAM2x18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
             assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
             assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
             assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
-        defparam bram_2x18k.MODE_BITS = { 1'b1,
-            11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
-            12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
-        };
+            defparam bram_2x18k.MODE_BITS = { 1'b1,
+                11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+            };
         end
     endcase
 
@@ -1295,12 +1295,12 @@ module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
     parameter [18431:0] INIT0 = 18432'bx;
     parameter [18431:0] INIT1 = 18432'bx;
 
-        localparam MODE_36 = 3'b011; // 36- or 32-bit
-        localparam MODE_18 = 3'b010; // 18- or 16-bit
-        localparam MODE_9 = 3'b001; // 9- or 8-bit
-        localparam MODE_4 = 3'b100; // 4-bit
-        localparam MODE_2 = 3'b110; // 2-bit
-        localparam MODE_1 = 3'b101; // 1-bit
+    localparam MODE_36 = 3'b011; // 36- or 32-bit
+    localparam MODE_18 = 3'b010; // 18- or 16-bit
+    localparam MODE_9 = 3'b001; // 9- or 8-bit
+    localparam MODE_4 = 3'b100; // 4-bit
+    localparam MODE_2 = 3'b110; // 2-bit
+    localparam MODE_1 = 3'b101; // 1-bit
 
     input CLK1;
     input CLK2;
@@ -1501,6 +1501,189 @@ module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
         .REN_B2_i(PORT_B2_REN),
         .WEN_B2_i(PORT_B2_WEN),
         .BE_B2_i(PORT_B2_BE),
+
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+    );
+endmodule
+
+module \$mem_v2_asymmetric (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, RD_EN, RD_SRST, WR_ADDR, WR_CLK, WR_DATA, WR_EN);
+    localparam CFG_ABITS = 10;
+    localparam CFG_DBITS = 36;
+    localparam CFG_ENABLE_B = 4;
+
+    localparam CLKPOL2 = 1;
+    localparam CLKPOL3 = 1;
+
+    parameter READ_ADDR_WIDTH = 11;
+    parameter READ_DATA_WIDTH = 16;
+    parameter WRITE_ADDR_WIDTH = 10;
+    parameter WRITE_DATA_WIDTH = 32;
+    parameter ABITS = 0;
+    parameter MEMID = 0;
+    parameter [36863:0] INIT = 36864'bx;
+    parameter OFFSET = 0;
+    parameter RD_ARST_VALUE = 0;
+    parameter RD_CE_OVER_SRST = 0;
+    parameter RD_CLK_ENABLE = 0;
+    parameter RD_CLK_POLARITY = 0;
+    parameter RD_COLLISION_X_MASK = 0;
+    parameter RD_INIT_VALUE = 0;
+    parameter RD_PORTS = 0;
+    parameter RD_SRST_VALUE = 0;
+    parameter RD_TRANSPARENCY_MASK = 0;
+    parameter RD_WIDE_CONTINUATION = 0;
+    parameter SIZE = 0;
+    parameter WIDTH = 0;
+    parameter WR_CLK_ENABLE = 0;
+    parameter WR_CLK_POLARITY = 0;
+    parameter WR_PORTS = 0;
+    parameter WR_PRIORITY_MASK = 0;
+    parameter WR_WIDE_CONTINUATION = 0;
+
+    localparam MODE_36  = 3'b111;   // 36 or 32-bit
+    localparam MODE_18  = 3'b110;   // 18 or 16-bit
+    localparam MODE_9   = 3'b101;   // 9 or 8-bit
+    localparam MODE_4   = 3'b100;   // 4-bit
+    localparam MODE_2   = 3'b010;   // 32-bit
+    localparam MODE_1   = 3'b001;   // 32-bit
+
+    input RD_CLK;
+    input WR_CLK;
+    input RD_ARST;
+    input RD_SRST;
+
+    input [CFG_ABITS-1:0] RD_ADDR;
+    output [CFG_DBITS-1:0] RD_DATA;
+    input RD_EN;
+
+    input [CFG_ABITS-1:0] WR_ADDR;
+    input [CFG_DBITS-1:0] WR_DATA;
+    input [CFG_ENABLE_B-1:0] WR_EN;
+
+    wire [14:0] RD_ADDR_15;
+    wire [14:0] WR_ADDR_15;
+
+    wire [35:0] DOBDO;
+
+    wire [14:CFG_ABITS] RD_ADDR_CMPL;
+    wire [14:CFG_ABITS] WR_ADDR_CMPL;
+    wire [35:CFG_DBITS] RD_DATA_CMPL;
+    wire [35:CFG_DBITS] WR_DATA_CMPL;
+
+    wire [14:0] RD_ADDR_TOTAL;
+    wire [14:0] WR_ADDR_TOTAL;
+    wire [35:0] RD_DATA_TOTAL;
+    wire [35:0] WR_DATA_TOTAL;
+
+    wire FLUSH1;
+    wire FLUSH2;
+
+    assign RD_ADDR_CMPL = {15-CFG_ABITS{1'b0}};
+    assign WR_ADDR_CMPL = {15-CFG_ABITS{1'b0}};
+
+    assign RD_ADDR_TOTAL = {RD_ADDR_CMPL, RD_ADDR};
+    assign WR_ADDR_TOTAL = {WR_ADDR_CMPL, WR_ADDR};
+
+    assign RD_DATA_TOTAL = {RD_DATA_CMPL, RD_DATA};
+    assign WR_DATA_TOTAL = {WR_DATA_CMPL, WR_DATA};
+
+    case (CFG_DBITS)
+        1: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+            };
+        end
+
+        2: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL << 1;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL << 1;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+            };
+        end
+
+        4: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL << 2;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL << 2;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+            };
+        end
+        8, 9: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL << 3;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL << 3;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+            };
+        end
+
+        16, 18: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL << 4;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL << 4;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+            };
+        end
+        32, 36: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL << 5;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL << 5;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+            };
+        end
+        default: begin
+            assign RD_ADDR_15 = RD_ADDR_TOTAL;
+            assign WR_ADDR_15 = WR_ADDR_TOTAL;
+            defparam bram_asymmetric.MODE_BITS = { 1'b0,
+                11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+                12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+            };
+        end
+    endcase
+
+    assign FLUSH1 = 1'b0;
+    assign FLUSH2 = 1'b0;
+
+    TDP36K bram_asymmetric (
+        .RESET_ni(1'b1),
+        .WDATA_A1_i(18'h3FFFF),
+        .WDATA_A2_i(18'h3FFFF),
+        .RDATA_A1_o(RD_DATA_TOTAL[17:0]),
+        .RDATA_A2_o(RD_DATA_TOTAL[35:18]),
+        .ADDR_A1_i(RD_ADDR_15),
+        .ADDR_A2_i(RD_ADDR_15),
+        .CLK_A1_i(RD_CLK),
+        .CLK_A2_i(RD_CLK),
+        .REN_A1_i(RD_EN),
+        .REN_A2_i(RD_EN),
+        .WEN_A1_i(1'b0),
+        .WEN_A2_i(1'b0),
+        .BE_A1_i({RD_EN, RD_EN}),
+        .BE_A2_i({RD_EN, RD_EN}),
+
+        .WDATA_B1_i(WR_DATA[17:0]),
+        .WDATA_B2_i(WR_DATA[35:18]),
+        .RDATA_B1_o(DOBDO[17:0]),
+        .RDATA_B2_o(DOBDO[35:18]),
+        .ADDR_B1_i(WR_ADDR_15),
+        .ADDR_B2_i(WR_ADDR_15),
+        .CLK_B1_i(WR_CLK),
+        .CLK_B2_i(WR_CLK),
+        .REN_B1_i(1'b0),
+        .REN_B2_i(1'b0),
+        .WEN_B1_i(WR_EN[0]),
+        .WEN_B2_i(WR_EN[0]),
+        .BE_B1_i(WR_EN[1:0]),
+        .BE_B2_i(WR_EN[3:2]),
 
         .FLUSH1_i(FLUSH1),
         .FLUSH2_i(FLUSH2)

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -354,13 +354,17 @@ struct SynthQuickLogicPass : public ScriptPass {
             run("opt_clean");
         }
 
+        if (family == "qlf_k6n10f") {
+            run("ql_bram_asymmetric");
+        }
+
         if (check_label("map_bram", "(skip if -no_bram)") && (family == "qlf_k6n10" || family == "qlf_k6n10f" || family == "pp3") && inferBram) {
             run("memory_bram -rules +/quicklogic/" + family + "/brams.txt");
             if (family == "pp3") {
                 run("pp3_braminit");
             }
             run("ql_bram_split                   ", "(for qlf_k6n10f if not -no_bram)");
-            run("techmap -map +/quicklogic/" + family + "/brams_map.v");
+            run("techmap -autoproc -map +/quicklogic/" + family + "/brams_map.v");
             if (family == "qlf_k6n10f") {
                 run("techmap -map +/quicklogic/" + family + "/brams_final_map.v");
             }

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -54,7 +54,9 @@ POST_SYNTH_SIM_TESTS = \
     qlf_k6n10f/bram_tdp_split \
     qlf_k6n10f/bram_sdp_split \
     qlf_k6n10f/dsp_mult_post_synth_sim \
-    qlf_k6n10f/dsp_simd_post_synth_sim
+    qlf_k6n10f/dsp_simd_post_synth_sim \
+    qlf_k6n10f/bram_asymmetric_wider_write \
+    qlf_k6n10f/bram_asymmetric_wider_read
 
 include $(shell pwd)/../../Makefile_test.common
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.tcl
@@ -1,0 +1,51 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram_tdp
+
+select spram_16x2048_32x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_16x2048_32x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_16x2048_32x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select spram_8x4096_16x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_8x4096_16x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_8x4096_16x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select spram_8x2048_16x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_8x2048_16x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_8x2048_16x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select spram_8x4096_32x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_8x4096_32x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_8x4096_32x1024_post_synth.v
+select -assert-count 1 t:TDP36K
+
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.v
@@ -1,0 +1,127 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module spram_16x2048_32x1024 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [9:0] ra;
+	output reg [31:0] rq;
+	input wce;
+	input [10:0] wa;
+	input [15:0] wd;
+	reg [31:0] memory [0:1023];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra];
+		if (wce)
+			memory[wa / 2][(wa % 2) * 16+:16] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 1024; i = i + 1)
+		memory[i] = 0;
+endmodule
+
+module spram_8x2048_16x1024 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [9:0] ra;
+	output reg [15:0] rq;
+	input wce;
+	input [10:0] wa;
+	input [7:0] wd;
+	reg [15:0] memory [0:1023];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra];
+		if (wce)
+			memory[wa / 2][(wa % 2) * 8+:8] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 1024; i = i + 1)
+		memory[i] = 0;
+endmodule
+
+module spram_8x4096_16x2048 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [10:0] ra;
+	output reg [15:0] rq;
+	input wce;
+	input [11:0] wa;
+	input [7:0] wd;
+	reg [15:0] memory [0:2047];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra];
+		if (wce)
+			memory[wa / 2][(wa % 2) * 8+:8] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 2048; i = i + 1)
+		memory[i] = 0;
+endmodule
+
+module spram_8x4096_32x1024 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [9:0] ra;
+	output reg [31:0] rq;
+	input wce;
+	input [11:0] wa;
+	input [7:0] wd;
+	reg [31:0] memory [0:1023];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra];
+		if (wce)
+			memory[wa / 4][(wa % 4) * 8+:8] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 1024; i = i + 1)
+		memory[i] = 0;
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/sim/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram_asymmetric_wider_read_tb.v
+POST_SYNTH = spram_16x2048_32x1024_post_synth spram_8x4096_16x2048_post_synth spram_8x2048_16x1024_post_synth spram_8x4096_32x1024_post_synth
+READ_ADDR_WIDTH = 10 11 10 10
+WRITE_ADDR_WIDTH = 11 12 11 12
+READ_DATA_WIDTH = 32 16 16 32
+WRITE_DATA_WIDTH = 16 8 8 8
+TOP = spram_16x2048_32x1024 spram_8x4096_16x2048 spram_8x2048_16x1024 spram_8x4096_32x1024
+READ_ADDR_DEFINES = $(foreach awidth, $(READ_ADDR_WIDTH),-DREAD_ADDR_WIDTH="$(awidth)")
+WRITE_ADDR_DEFINES = $(foreach awidth, $(WRITE_ADDR_WIDTH),-DWRITE_ADDR_WIDTH="$(awidth)")
+READ_DATA_DEFINES = $(foreach dwidth, $(READ_DATA_WIDTH),-DREAD_DATA_WIDTH="$(dwidth)")
+WRITE_DATA_DEFINES = $(foreach dwidth, $(WRITE_DATA_WIDTH),-DWRITE_DATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(READ_ADDR_DEFINES)) $(word $(1),$(WRITE_ADDR_DEFINES)) $(word $(1),$(READ_DATA_DEFINES)) $(word $(1),$(WRITE_DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+sim:
+	$(call simulate_post_synth,1)
+	$(call simulate_post_synth,2)
+	$(call simulate_post_synth,3)
+	$(call simulate_post_synth,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/sim/bram_asymmetric_wider_read_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/sim/bram_asymmetric_wider_read_tb.v
@@ -1,0 +1,157 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk;
+	reg rce;
+	reg [`READ_ADDR_WIDTH-1:0] ra;
+	wire [`READ_DATA_WIDTH-1:0] rq;
+	reg wce;
+	reg [`WRITE_ADDR_WIDTH-1:0] wa;
+	reg [`WRITE_DATA_WIDTH-1:0] wd;
+
+	initial clk = 0;
+	initial ra = 0;
+	initial rce = 0;
+	initial forever #(PERIOD / 2.0) clk = ~clk;
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+
+	reg [`READ_DATA_WIDTH-1:0] expected;
+
+	always @(posedge clk) begin
+		case (`READ_DATA_WIDTH / `WRITE_DATA_WIDTH)
+			1: expected <= (a | (a << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}};
+			2: expected <= ((((2*a+1) | ((2*a+1) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}}) << `WRITE_DATA_WIDTH) |
+					(((2*a) | ((2*a) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}});
+			4: expected <= (((4*a) | ((4*a) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}}) |
+				      ((((4*a+1) | ((4*a+1) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}}) << `WRITE_DATA_WIDTH) |
+				      ((((4*a+2) | ((4*a+2) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}}) << (2 * `WRITE_DATA_WIDTH)) |
+				      ((((4*a+3) | ((4*a+3) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}}) << (3 * `WRITE_DATA_WIDTH));
+			default: expected <= ((a) | ((a) << 20) | 20'h55000) & {`WRITE_DATA_WIDTH{1'b1}};
+		endcase
+	end
+
+	wire error = ((a != 0) && read_test) ? rq !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1;
+	end
+
+	reg read_test;
+	initial read_test = 0;
+
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`WRITE_ADDR_WIDTH); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				wa = a;
+				wd = a | (a << 20) | 20'h55000;
+				wce = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`READ_ADDR_WIDTH); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, rq, expected, a);
+				end
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"spram_16x2048_32x1024": begin
+			spram_16x2048_32x1024 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"spram_8x4096_16x2048": begin
+			spram_8x4096_16x2048 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"spram_8x2048_16x1024": begin
+			spram_8x2048_16x1024 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"spram_8x4096_32x1024": begin
+			spram_8x4096_32x1024 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.tcl
@@ -1,0 +1,51 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram_tdp
+
+select spram_16x1024_8x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_16x1024_8x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_16x1024_8x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select spram_16x2048_8x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_16x2048_8x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_16x2048_8x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select spram_32x1024_16x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_32x1024_16x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_32x1024_16x2048_post_synth.v
+select -assert-count 1 t:TDP36K
+
+select -clear
+design -load bram_tdp
+select spram_32x1024_8x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_32x1024_8x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_32x1024_8x4096_post_synth.v
+select -assert-count 1 t:TDP36K
+
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.v
@@ -1,0 +1,127 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module spram_16x1024_8x2048 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [10:0] ra;
+	output reg [7:0] rq;
+	input wce;
+	input [9:0] wa;
+	input [15:0] wd;
+	reg [15:0] memory [0:1023];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra / 2][(ra % 2) * 8+:8];
+		if (wce)
+			memory[wa] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 1024; i = i + 1)
+		memory[i] = 0;
+endmodule
+
+module spram_16x2048_8x4096 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [11:0] ra;
+	output reg [7:0] rq;
+	input wce;
+	input [10:0] wa;
+	input [15:0] wd;
+	reg [15:0] memory [0:2047];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra / 2][(ra % 2) * 8+:8];
+		if (wce)
+			memory[wa] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 2048; i = i + 1)
+		memory[i] = 0;
+endmodule
+
+module spram_32x1024_16x2048 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [10:0] ra;
+	output reg [15:0] rq;
+	input wce;
+	input [9:0] wa;
+	input [31:0] wd;
+	reg [31:0] memory [0:1023];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra / 2][(ra % 2) * 16+:16];
+		if (wce)
+			memory[wa] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 1024; i = i + 1)
+		memory[i] = 0;
+endmodule
+
+module spram_32x1024_8x4096 (
+	clk,
+	rce,
+	ra,
+	rq,
+	wce,
+	wa,
+	wd
+);
+	input clk;
+	input rce;
+	input [11:0] ra;
+	output reg [7:0] rq;
+	input wce;
+	input [9:0] wa;
+	input [31:0] wd;
+	reg [31:0] memory [0:1023];
+	always @(posedge clk) begin
+		if (rce)
+			rq <= memory[ra / 4][(ra % 4) * 8+:8];
+		if (wce)
+			memory[wa] <= wd;
+	end
+	integer i;
+	initial for (i = 0; i < 1024; i = i + 1)
+		memory[i] = 0;
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/sim/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram_asymmetric_wider_write_tb.v
+POST_SYNTH = spram_16x2048_8x4096_post_synth spram_16x1024_8x2048_post_synth spram_32x1024_8x4096_post_synth spram_32x1024_16x2048_post_synth
+READ_ADDR_WIDTH = 12 11 12 11
+WRITE_ADDR_WIDTH = 11 10 10 10
+READ_DATA_WIDTH = 8 8 8 16
+WRITE_DATA_WIDTH = 16 16 32 32
+TOP = spram_16x2048_8x4096 spram_16x1024_8x2048 spram_32x1024_8x4096 spram_32x1024_16x2048
+READ_ADDR_DEFINES = $(foreach awidth, $(READ_ADDR_WIDTH),-DREAD_ADDR_WIDTH="$(awidth)")
+WRITE_ADDR_DEFINES = $(foreach awidth, $(WRITE_ADDR_WIDTH),-DWRITE_ADDR_WIDTH="$(awidth)")
+READ_DATA_DEFINES = $(foreach dwidth, $(READ_DATA_WIDTH),-DREAD_DATA_WIDTH="$(dwidth)")
+WRITE_DATA_DEFINES = $(foreach dwidth, $(WRITE_DATA_WIDTH),-DWRITE_DATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(READ_ADDR_DEFINES)) $(word $(1),$(WRITE_ADDR_DEFINES)) $(word $(1),$(READ_DATA_DEFINES)) $(word $(1),$(WRITE_DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+sim:
+	$(call simulate_post_synth,1)
+	$(call simulate_post_synth,2)
+	$(call simulate_post_synth,3)
+	$(call simulate_post_synth,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/sim/bram_asymmetric_wider_write_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/sim/bram_asymmetric_wider_write_tb.v
@@ -1,0 +1,164 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk;
+	reg rce;
+	reg [`READ_ADDR_WIDTH-1:0] ra;
+	wire [`READ_DATA_WIDTH-1:0] rq;
+	reg wce;
+	reg [`WRITE_ADDR_WIDTH-1:0] wa;
+	reg [`WRITE_DATA_WIDTH-1:0] wd;
+
+	initial clk = 0;
+	initial ra = 0;
+	initial rce = 0;
+	initial forever #(PERIOD / 2.0) clk = ~clk;
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+
+	reg [`READ_DATA_WIDTH-1:0] expected;
+
+	always @(posedge clk) begin
+		case (`WRITE_DATA_WIDTH / `READ_DATA_WIDTH)
+			1: expected <= (a | (a << 20) | 20'h55000) & {`READ_DATA_WIDTH{1'b1}};
+			2:
+				if (a % 2)
+					expected <= (((a/2) | ((a/2) << 20) | 20'h55000) >> `READ_DATA_WIDTH) & {`READ_DATA_WIDTH{1'b1}};
+				else
+					expected <= ((a/2) | ((a/2) << 20) | 20'h55000) & {`READ_DATA_WIDTH{1'b1}};
+			4:
+				case (a % 4)
+					0: expected <= ((a/4) | ((a/4) << 20) | 20'h55000) & {`READ_DATA_WIDTH{1'b1}};
+					1: expected <= (((a/4) | ((a/4) << 20) | 20'h55000) >> `READ_DATA_WIDTH) & {`READ_DATA_WIDTH{1'b1}};
+					2: expected <= (((a/4) | ((a/4) << 20) | 20'h55000) >> (2 * `READ_DATA_WIDTH)) & {`READ_DATA_WIDTH{1'b1}};
+					3: expected <= (((a/4) | ((a/4) << 20) | 20'h55000) >> (3 * `READ_DATA_WIDTH)) & {`READ_DATA_WIDTH{1'b1}};
+					default: expected <= ((a/4) | ((a/4) << 20) | 20'h55000) & {`READ_DATA_WIDTH{1'b1}};
+				endcase
+			default: expected <= ((a/2) | ((a/2) << 20) | 20'h55000) & {`READ_DATA_WIDTH{1'b1}};
+		endcase
+	end
+
+	wire error = ((a != 0) && read_test) ? rq !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1;
+	end
+
+	reg read_test;
+	initial read_test = 0;
+
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`WRITE_ADDR_WIDTH); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				wa = a;
+				wd = a | (a << 20) | 20'h55000;
+				wce = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`READ_ADDR_WIDTH); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, rq, expected, a);
+				end
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"spram_16x2048_8x4096": begin
+			spram_16x2048_8x4096 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"spram_16x1024_8x2048": begin
+			spram_16x1024_8x2048 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"spram_32x1024_8x4096": begin
+			spram_32x1024_8x4096 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+		"spram_32x1024_16x2048": begin
+			spram_32x1024_16x2048 #() simple (
+				.clk(clk),
+				.rce(rce),
+				.ra(ra),
+				.rq(rq),
+				.wce(wce),
+				.wa(wa),
+				.wd(wd)
+			);
+		end
+	endcase
+endmodule


### PR DESCRIPTION
This PR adds inference of RAMs with asymmetric port widths. A new pass `ql_bram_asymmetric` is introduced in order to recognize circuit patterns that are characteristic to asymmetric RAMs. Detected circuits are then modified and an artificial cell is placed which is then mapped into final configured TDP36K cell. I've added two sets of tests: one for designs with wider read port, and second for designs with wider write port. Each set consist of 4 designs. Those are synthesized and tested for the inference results and the post synthesis verilog file is then simulated to verify the correctness of the configuration.