### PR TITLE
Fix QuickLogic asymmetric BRAM inference

### DIFF
--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -577,32 +577,32 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				2: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0
 					};
 				end
 				4: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0
 					};
 				end
 				8, 9: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0
 					};
 				end
 				16, 18: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0
 					};
 				end
 				32, 36: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0
 					};
 				end
 				default: begin
@@ -617,8 +617,8 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 			case (WR_DATA_WIDTH)
 				1: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_2, `MODE_2, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_2, `MODE_2, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0
 					};
 				end
 				2: begin
@@ -629,32 +629,32 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				4: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_2, `MODE_2, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_2, `MODE_2, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_4, `MODE_2, `MODE_4, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_4, `MODE_2, `MODE_4, 1'd0
 					};
 				end
 				8, 9: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_2, `MODE_2, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_2, `MODE_2, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_9, `MODE_2, `MODE_9, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_9, `MODE_2, `MODE_9, 1'd0
 					};
 				end
 				16, 18: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_2, `MODE_2, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_2, `MODE_2, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_18, `MODE_2, `MODE_18, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_18, `MODE_2, `MODE_18, 1'd0
 					};
 				end
 				32, 36: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_2, `MODE_2, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_2, `MODE_2, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_36, `MODE_2, `MODE_36, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_36, `MODE_2, `MODE_36, 1'd0
 					};
 				end
 				default: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_2, `MODE_2, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_2, `MODE_2, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0
 					};
 				end
 			endcase
@@ -663,14 +663,14 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 			case (WR_DATA_WIDTH)
 				1: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_4, `MODE_4, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_4, `MODE_4, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0
 					};
 				end
 				2: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_4, `MODE_4, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_4, `MODE_4, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_2, `MODE_4, `MODE_2, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_2, `MODE_4, `MODE_2, 1'd0
 					};
 				end
 				4: begin
@@ -681,26 +681,26 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				8, 9: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_4, `MODE_4, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_4, `MODE_4, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_9, `MODE_4, `MODE_9, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_9, `MODE_4, `MODE_9, 1'd0
 					};
 				end
 				16, 18: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_4, `MODE_4, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_4, `MODE_4, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_18, `MODE_4, `MODE_18, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_18, `MODE_4, `MODE_18, 1'd0
 					};
 				end
 				32, 36: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_4, `MODE_4, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_4, `MODE_4, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_36, `MODE_4, `MODE_36, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_36, `MODE_4, `MODE_36, 1'd0
 					};
 				end
 				default: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_4, `MODE_4, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_4, `MODE_4, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0
 					};
 				end
 			endcase
@@ -709,20 +709,20 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 			case (WR_DATA_WIDTH)
 				1: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_9, `MODE_9, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_9, `MODE_9, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0
 					};
 				end
 				2: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_9, `MODE_9, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_9, `MODE_9, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_2, `MODE_9, `MODE_2, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_2, `MODE_9, `MODE_2, 1'd0
 					};
 				end
 				4: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_9, `MODE_9, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_9, `MODE_9, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_4, `MODE_9, `MODE_4, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_4, `MODE_9, `MODE_4, 1'd0
 					};
 				end
 				8, 9: begin
@@ -733,20 +733,20 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				16, 18: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_9, `MODE_9, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_9, `MODE_9, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0
 					};
 				end
 				32, 36: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_9, `MODE_9, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_9, `MODE_9, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'd0
 					};
 				end
 				default: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_9, `MODE_9, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_9, `MODE_9, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0
 					};
 				end
 			endcase
@@ -755,26 +755,26 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 			case (WR_DATA_WIDTH)
 				1: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_18, `MODE_18, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_18, `MODE_18, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0
 					};
 				end
 				2: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_18, `MODE_18, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_18, `MODE_18, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_2, `MODE_18, `MODE_2, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_2, `MODE_18, `MODE_2, 1'd0
 					};
 				end
 				4: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_18, `MODE_18, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_18, `MODE_18, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_4, `MODE_18, `MODE_4, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_4, `MODE_18, `MODE_4, 1'd0
 					};
 				end
 				8, 9: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_18, `MODE_18, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_18, `MODE_18, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0
 					};
 				end
 				16, 18: begin
@@ -785,14 +785,14 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				32, 36: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_18, `MODE_18, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_18, `MODE_18, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'd0
 					};
 				end
 				default: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_18, `MODE_18, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_18, `MODE_18, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0
 					};
 				end
 			endcase
@@ -801,32 +801,32 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 			case (WR_DATA_WIDTH)
 				1: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_36, `MODE_36, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_36, `MODE_36, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0
 					};
 				end
 				2: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_36, `MODE_36, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_36, `MODE_36, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_2, `MODE_36, `MODE_2, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_2, `MODE_36, `MODE_2, 1'd0
 					};
 				end
 				4: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_36, `MODE_36, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_36, `MODE_36, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_4, `MODE_36, `MODE_4, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_4, `MODE_36, `MODE_4, 1'd0
 					};
 				end
 				8, 9: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_36, `MODE_36, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_36, `MODE_36, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'd0
 					};
 				end
 				16, 18: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_36, `MODE_36, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_36, `MODE_36, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'd0
 					};
 				end
 				32, 36: begin
@@ -837,8 +837,8 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				default: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_36, `MODE_36, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_36, `MODE_36, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0
 					};
 				end
 			endcase
@@ -853,32 +853,32 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 				end
 				2: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0
 					};
 				end
 				4: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0
 					};
 				end
 				8, 9: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0
 					};
 				end
 				16, 18: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0
 					};
 				end
 				32, 36: begin
 					defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b0,
-						11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_1, `MODE_1, 1'd0,
-						12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_1, `MODE_1, 1'd0
+						11'd10, 11'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0,
+						12'd10, 12'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0
 					};
 				end
 				default: begin
@@ -940,10 +940,6 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 		end
 	endcase
 
-	wire [14:0] PORT_A_ADDR = WR_EN ? WR_ADDR_SHIFTED : (RD_EN ? RD_ADDR_SHIFTED : 14'd0);
-	wire [14:0] PORT_A1_ADDR = PORT_A_ADDR;
-	wire [14:0] PORT_A2_ADDR = PORT_A_ADDR;
-
 	assign FLUSH1 = 1'b0;
 	assign FLUSH2 = 1'b0;
 
@@ -974,21 +970,38 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 
 	TDP36K _TECHMAP_REPLACE_ (
 		.RESET_ni(1'b1),
+
 		.WDATA_A1_i(PORT_A1_WDATA),
-		.RDATA_A1_o(PORT_A1_RDATA),
-		.ADDR_A1_i(PORT_A1_ADDR),
+		.RDATA_A1_o(),
+		.ADDR_A1_i(WR_ADDR_SHIFTED),
 		.CLK_A1_i(PORT_A1_CLK),
-		.REN_A1_i(PORT_A1_REN),
+		.REN_A1_i(1'b0),
 		.WEN_A1_i(PORT_A1_WEN),
 		.BE_A1_i(PORT_A1_BE),
 
+		.WDATA_B1_i(),
+		.RDATA_B1_o(PORT_A1_RDATA),
+		.ADDR_B1_i(RD_ADDR_SHIFTED),
+		.CLK_B1_i(PORT_A1_CLK),
+		.REN_B1_i(PORT_A1_REN),
+		.WEN_B1_i(1'b0),
+		.BE_B1_i(PORT_A1_BE),
+
 		.WDATA_A2_i(PORT_A2_WDATA),
-		.RDATA_A2_o(PORT_A2_RDATA),
-		.ADDR_A2_i(PORT_A2_ADDR),
+		.RDATA_A2_o(),
+		.ADDR_A2_i(WR_ADDR_SHIFTED),
 		.CLK_A2_i(PORT_A2_CLK),
-		.REN_A2_i(PORT_A2_REN),
+		.REN_A2_i(1'b0),
 		.WEN_A2_i(PORT_A2_WEN),
 		.BE_A2_i(PORT_A2_BE),
+
+		.WDATA_B2_i(),
+		.RDATA_B2_o(PORT_A2_RDATA),
+		.ADDR_B2_i(RD_ADDR_SHIFTED),
+		.CLK_B2_i(PORT_A2_CLK),
+		.REN_B2_i(PORT_A2_REN),
+		.WEN_B2_i(1'b0),
+		.BE_B2_i(PORT_A2_BE),
 
 		.FLUSH1_i(FLUSH1),
 		.FLUSH2_i(FLUSH2)

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -483,7 +483,7 @@ module \$__QLF_FACTOR_BRAM36_SDP (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1ADDR, B1DA
 	);
 endmodule
 
-(* techmap_celltype = "$mem_v2_asymmetric" *)
+(* techmap_celltype = "_$_mem_v2_asymmetric" *)
 module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, RD_EN, RD_SRST, WR_ADDR, WR_CLK, WR_DATA, WR_EN);
 	parameter CFG_ABITS = 10;
 	parameter CFG_DBITS = 36;

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -1507,7 +1507,7 @@ module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
     );
 endmodule
 
-module \$mem_v2_asymmetric (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, RD_EN, RD_SRST, WR_ADDR, WR_CLK, WR_DATA, WR_EN);
+module \_$_mem_v2_asymmetric (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, RD_EN, RD_SRST, WR_ADDR, WR_CLK, WR_DATA, WR_EN);
     localparam CFG_ABITS = 10;
     localparam CFG_DBITS = 36;
     localparam CFG_ENABLE_B = 4;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.tcl
@@ -14,6 +14,7 @@ opt_clean
 stat
 write_verilog sim/spram_16x2048_32x1024_post_synth.v
 select -assert-count 1 t:TDP36K
+select -assert-count 1 t:*
 
 select -clear
 design -load bram_tdp
@@ -25,6 +26,7 @@ opt_clean
 stat
 write_verilog sim/spram_8x4096_16x2048_post_synth.v
 select -assert-count 1 t:TDP36K
+select -assert-count 1 t:*
 
 select -clear
 design -load bram_tdp
@@ -36,6 +38,7 @@ opt_clean
 stat
 write_verilog sim/spram_8x2048_16x1024_post_synth.v
 select -assert-count 1 t:TDP36K
+select -assert-count 1 t:*
 
 select -clear
 design -load bram_tdp
@@ -47,5 +50,4 @@ opt_clean
 stat
 write_verilog sim/spram_8x4096_32x1024_post_synth.v
 select -assert-count 1 t:TDP36K
-
-
+select -assert-count 1 t:*

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.tcl
@@ -14,6 +14,7 @@ opt_clean
 stat
 write_verilog sim/spram_16x1024_8x2048_post_synth.v
 select -assert-count 1 t:TDP36K
+select -assert-count 1 t:*
 
 select -clear
 design -load bram_tdp
@@ -25,6 +26,7 @@ opt_clean
 stat
 write_verilog sim/spram_16x2048_8x4096_post_synth.v
 select -assert-count 1 t:TDP36K
+select -assert-count 1 t:*
 
 select -clear
 design -load bram_tdp
@@ -36,6 +38,7 @@ opt_clean
 stat
 write_verilog sim/spram_32x1024_16x2048_post_synth.v
 select -assert-count 1 t:TDP36K
+select -assert-count 1 t:*
 
 select -clear
 design -load bram_tdp
@@ -47,5 +50,4 @@ opt_clean
 stat
 write_verilog sim/spram_32x1024_8x4096_post_synth.v
 select -assert-count 1 t:TDP36K
-
-
+select -assert-count 1 t:*


### PR DESCRIPTION
This PR fixes the inference mechanism by changing the way BRAM wires are looked up which does not trigger Yosys assertions in specific cases. Moreover, it also ensures that inferred BRAM cell names remain unique.