### PR TITLE
Fix deprecated use of `which`

### DIFF
--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -38,8 +38,10 @@
 # |-- example2-plugin
 # |-- ...
 
+SHELL := /usr/bin/env bash
+
 # Either find yosys in system and use its path or use the given path
-YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
+YOSYS_PATH ?= $(realpath $(dir $(shell command -v yosys))/..)
 
 # Find yosys-config, throw an error if not found
 YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config

--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -14,8 +14,10 @@
 # test2_verify = $(call diff_test,test2,ext)
 #
 
+SHELL := /usr/bin/env bash
+
 # Either find yosys in system and use its path or use the given path
-YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
+YOSYS_PATH ?= $(realpath $(dir $(shell command -v yosys))/..)
 
 # Find yosys-config, throw an error if not found
 YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config


### PR DESCRIPTION
Instead of `which`, the suggested alternative
is `command -v`

Signed-off-by: Henner Zeller <h.zeller@acm.org>