### PR TITLE
Handle vpiInterfaceTypespec

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4114,6 +4114,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case vpiAssignment:
         process_assignment();
         break;
+    case vpiInterfaceTypespec:
     case vpiRefVar:
     case vpiRefObj:
         current_node = make_ast_node(AST::AST_IDENTIFIER);


### PR DESCRIPTION
This adds support for missing typespec that is present in newest UHDM version.

It is enough to get the interface name, Yosys can then bind the correct node.