### PR TITLE
ql-qlf: k6n10f: ql_dsp_simd: change naming scheme

### DIFF
--- a/ql-qlf-plugin/ql-dsp-simd.cc
+++ b/ql-qlf-plugin/ql-dsp-simd.cc
@@ -162,7 +162,7 @@ struct QlDspSimdPass : public Pass {
                     const RTLIL::Cell *dsp_a = group[i];
                     const RTLIL::Cell *dsp_b = group[i + 1];
 
-                    std::string name = stringf("simd_%s_%s", RTLIL::unescape_id(dsp_a->name).c_str(), RTLIL::unescape_id(dsp_b->name).c_str());
+                    std::string name = stringf("simd%ld", i / 2);
                     std::string SimdDspType;
 
                     if (use_cfg_params)


### PR DESCRIPTION
RTLIL::Cell 'name' field contains path to source verilog file. Assigning two of those as the name of new DSP cell will likely cause generation of very long module names, especially when the path argument to 'read_verilog' is a long absolute path.
Long module names will propagate to long net names through 'autoname' pass and cause readability issues in post-synthesis verilog. This change prevents that.

Signed-off-by: Pawel Czarnecki <pczarnecki@antmicro.com>