### PR TITLE
systemverilog: Support op type on assignment

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2271,7 +2271,7 @@ void UhdmAst::process_assignment(const UHDM::BaseClass *object)
     AST::AstNodeType node_type;
     current_node = make_ast_node(type);
 
-    if (op_type && op_type != 82) {
+    if (op_type && op_type != vpiAssignmentOp) {
         simple_assign = false;
         visit_one_to_one({vpiLhs}, obj_h, [&](AST::AstNode *node) {
             if (node) {

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2262,10 +2262,8 @@ void UhdmAst::process_cont_assign()
         process_cont_assign_net();
 }
 
-void UhdmAst::process_assignment()
+void UhdmAst::process_assignment(const UHDM::BaseClass *object)
 {
-    const uhdm_handle *const handle = (const uhdm_handle *)obj_h;
-    const UHDM::BaseClass *const object = (const UHDM::BaseClass *)handle->object;
     auto type = vpi_get(vpiBlocking, obj_h) == 1 ? AST::AST_ASSIGN_EQ : AST::AST_ASSIGN_LE;
     bool simple_assign = true;
     bool shift_unsigned = false;
@@ -4189,7 +4187,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         break;
     case vpiAssignStmt:
     case vpiAssignment:
-        process_assignment();
+        process_assignment(object);
         break;
     case vpiInterfaceTypespec:
     case vpiRefVar:

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -93,7 +93,7 @@ class UhdmAst
     void process_cont_assign();
     void process_cont_assign_net();
     void process_cont_assign_var_init();
-    void process_assignment();
+    void process_assignment(const UHDM::BaseClass *object);
     void process_net();
     void process_packed_array_net();
     void process_array_net(const UHDM::BaseClass *object);


### PR DESCRIPTION
Compound assignments used to be interpreted as simple assignments, like it is described in this issue: antmicro/yosys-systemverilog#1050. This was caused by the fact, that _vpiOpType_ of _assignment_ node in UHDM tree was not taken into account.
This PR introduces operation type check in the assignment node and expanding it to include operation sub-nodes in cases where it is needed. 