### PR TITLE
systemverilog: Support binary bitwise NAND and NOR

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2709,14 +2709,26 @@ void UhdmAst::process_operation(const UHDM::BaseClass *object)
             current_node->type = AST::AST_REDUCE_XNOR;
             break;
         case vpiUnaryNandOp: {
-            current_node->type = AST::AST_REDUCE_AND;
-            auto not_node = new AST::AstNode(AST::AST_LOGIC_NOT, current_node);
+            auto not_node = new AST::AstNode(AST::AST_NONE, current_node);
+            if (current_node->children.size() == 2) {
+                current_node->type = AST::AST_BIT_AND;
+                not_node->type = AST::AST_BIT_NOT;
+            } else {
+                current_node->type = AST::AST_REDUCE_AND;
+                not_node->type = AST::AST_LOGIC_NOT;
+            }
             current_node = not_node;
             break;
         }
         case vpiUnaryNorOp: {
-            current_node->type = AST::AST_REDUCE_OR;
-            auto not_node = new AST::AstNode(AST::AST_LOGIC_NOT, current_node);
+            auto not_node = new AST::AstNode(AST::AST_NONE, current_node);
+            if (current_node->children.size() == 2) {
+                current_node->type = AST::AST_BIT_OR;
+                not_node->type = AST::AST_BIT_NOT;
+            } else {
+                current_node->type = AST::AST_REDUCE_OR;
+                not_node->type = AST::AST_LOGIC_NOT;
+            }
             current_node = not_node;
             break;
         }


### PR DESCRIPTION
Binary bitwise NAND and NOR are modeled in Surelog as bitwise reduction operations with two operands, so they need to be re-interpreted as binary bitwise operations by the plugin. Basing on how many operands are present for the operation, we decide whether it should be reduction or binary bitwise NAND/NOR.