### PR TITLE
Minimize diffs between frontends

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1277,8 +1277,17 @@ AST::AstNode *UhdmAst::make_ast_node(AST::AstNodeType type, std::vector<AST::Ast
     if (auto filename = vpi_get_str(vpiFile, obj_h)) {
         node->filename = filename;
     }
-    if (unsigned int line = vpi_get(vpiLineNo, obj_h)) {
-        node->location.first_line = node->location.last_line = line;
+    if (unsigned int first_line = vpi_get(vpiStartLine, obj_h)) {
+        node->location.first_line = first_line;
+    }
+    if (unsigned int last_line = vpi_get(vpiEndLine, obj_h)) {
+        node->location.last_line = last_line;
+    }
+    if (unsigned int first_col = vpi_get(vpiColumn, obj_h)) {
+        node->location.first_column = first_col;
+    }
+    if (unsigned int last_col = vpi_get(vpiEndColumn, obj_h)) {
+        node->location.last_column = last_col;
     }
     node->children = children;
     return node;

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1567,6 +1567,13 @@ void UhdmAst::process_design()
             pair.second = nullptr;
         }
     }
+    if (!shared.debug_flag) {
+        // Ranges were already converted, erase obsolete attributes
+        visitEachDescendant(current_node, [&](AST::AstNode *node) {
+            node->attributes.erase(UhdmAst::packed_ranges());
+            node->attributes.erase(UhdmAst::unpacked_ranges());
+        });
+    }
 }
 
 void UhdmAst::simplify_parameter(AST::AstNode *parameter, AST::AstNode *module_node)

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1277,16 +1277,16 @@ AST::AstNode *UhdmAst::make_ast_node(AST::AstNodeType type, std::vector<AST::Ast
     if (auto filename = vpi_get_str(vpiFile, obj_h)) {
         node->filename = filename;
     }
-    if (unsigned int first_line = vpi_get(vpiStartLine, obj_h)) {
+    if (unsigned int first_line = vpi_get(vpiLineNo, obj_h)) {
         node->location.first_line = first_line;
     }
-    if (unsigned int last_line = vpi_get(vpiEndLine, obj_h)) {
+    if (unsigned int last_line = vpi_get(vpiEndLineNo, obj_h)) {
         node->location.last_line = last_line;
     }
-    if (unsigned int first_col = vpi_get(vpiColumn, obj_h)) {
+    if (unsigned int first_col = vpi_get(vpiColumnNo, obj_h)) {
         node->location.first_column = first_col;
     }
-    if (unsigned int last_col = vpi_get(vpiEndColumn, obj_h)) {
+    if (unsigned int last_col = vpi_get(vpiEndColumnNo, obj_h)) {
         node->location.last_column = last_col;
     }
     node->children = children;

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1282,12 +1282,16 @@ AST::AstNode *UhdmAst::make_ast_node(AST::AstNodeType type, std::vector<AST::Ast
     }
     if (unsigned int last_line = vpi_get(vpiEndLineNo, obj_h)) {
         node->location.last_line = last_line;
+    } else {
+        node->location.last_line = node->location.first_line;
     }
     if (unsigned int first_col = vpi_get(vpiColumnNo, obj_h)) {
         node->location.first_column = first_col;
     }
     if (unsigned int last_col = vpi_get(vpiEndColumnNo, obj_h)) {
         node->location.last_column = last_col;
+    } else {
+        node->location.last_column = node->location.first_column;
     }
     node->children = children;
     return node;


### PR DESCRIPTION
This PR adds some features that should make comparing diffs between the plugin and the default frontend easier:
* remove additional ranges attributes that were already converted
* retrieve Verilog line and column information from UHDM