### PR TITLE
Signed vars support

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2559,6 +2559,7 @@ void UhdmAst::process_io_decl()
                 current_node->is_logic = node->is_logic;
                 current_node->is_reg = node->is_reg;
             }
+            current_node->is_signed = node->is_signed;
             delete node;
         }
     });
@@ -3559,6 +3560,7 @@ void UhdmAst::process_logic_var()
             current_node->children.push_back(wiretype_node);
             current_node->is_custom_type = true;
         }
+        current_node->is_signed = node->is_signed;
         delete node;
     });
     // TODO: Handling below seems similar to other typespec accesses for range. Candidate for extraction to a function.

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1136,6 +1136,7 @@ AST::AstNode *UhdmAst::process_value(vpiHandle obj_h)
             // above by vpi*StrVal
             if (size == 64) {
                 size = 32;
+                is_signed = true;
             }
             auto c = AST::AstNode::mkconst_int(val.format == vpiUIntVal ? val.value.uint : val.value.integer, is_signed, size > 0 ? size : 32);
             if (size == 0 || size == -1)

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3267,14 +3267,13 @@ void UhdmAst::process_for()
     current_node->str = "$fordecl_block" + std::to_string(loop_id);
     auto loop = make_ast_node(AST::AST_FOR);
     loop->str = "$loop" + std::to_string(loop_id);
-    current_node->children.push_back(loop);
     visit_one_to_many({vpiForInitStmt}, obj_h, [&](AST::AstNode *node) {
         if (node->type == AST::AST_ASSIGN_LE)
             node->type = AST::AST_ASSIGN_EQ;
         auto lhs = node->children[0];
         if (lhs->type == AST::AST_WIRE) {
             auto *wire = lhs->clone();
-            wire->is_reg = true;
+            wire->is_logic = true;
             current_node->children.push_back(wire);
             lhs->type = AST::AST_IDENTIFIER;
             lhs->is_signed = false;
@@ -3301,6 +3300,7 @@ void UhdmAst::process_for()
             loop->children.push_back(node);
         }
     });
+    current_node->children.push_back(loop);
     transform_breaks_continues(loop, current_node);
 }
 

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3874,6 +3874,8 @@ void UhdmAst::process_port()
         case vpiStructVar:
         case vpiUnionVar:
         case vpiEnumVar:
+        case vpiBitVar:
+        case vpiByteVar:
         case vpiShortIntVar:
         case vpiLongIntVar:
         case vpiIntVar:

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1891,27 +1891,27 @@ void UhdmAst::process_typespec_member()
         break;
     }
     case vpiByteTypespec: {
-        current_node->is_signed = true;
+        current_node->is_signed = vpi_get(vpiSigned, typespec_h);
         packed_ranges.push_back(make_range(7, 0));
         shared.report.mark_handled(typespec_h);
         break;
     }
     case vpiShortIntTypespec: {
-        current_node->is_signed = true;
+        current_node->is_signed = vpi_get(vpiSigned, typespec_h);
         packed_ranges.push_back(make_range(15, 0));
         shared.report.mark_handled(typespec_h);
         break;
     }
     case vpiIntTypespec:
     case vpiIntegerTypespec: {
-        current_node->is_signed = true;
+        current_node->is_signed = vpi_get(vpiSigned, typespec_h);
         packed_ranges.push_back(make_range(31, 0));
         shared.report.mark_handled(typespec_h);
         break;
     }
     case vpiTimeTypespec:
     case vpiLongIntTypespec: {
-        current_node->is_signed = true;
+        current_node->is_signed = vpi_get(vpiSigned, typespec_h);
         packed_ranges.push_back(make_range(63, 0));
         shared.report.mark_handled(typespec_h);
         break;
@@ -2016,7 +2016,7 @@ void UhdmAst::process_enum_typespec()
         case vpiByteTypespec:
         case vpiIntTypespec:
         case vpiIntegerTypespec: {
-            current_node->is_signed = true;
+            current_node->is_signed = vpi_get(vpiSigned, typespec_h);
             shared.report.mark_handled(typespec_h);
             break;
         }
@@ -2078,7 +2078,7 @@ void UhdmAst::process_int_var()
     auto right_const = AST::AstNode::mkconst_int(0, true);
     auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
     current_node->children.push_back(range);
-    current_node->is_signed = true;
+    current_node->is_signed = vpi_get(vpiSigned, obj_h);
     visit_default_expr(obj_h);
 }
 


### PR DESCRIPTION
This PR aims to fix (and in some cases, add) correct handling of `signed` status to variables, nets and constants.

Fixes:
* https://github.com/antmicro/yosys-systemverilog/issues/1244
* https://github.com/antmicro/yosys-systemverilog/issues/1115
* https://github.com/antmicro/yosys-systemverilog/issues/1085
* https://github.com/antmicro/yosys-systemverilog/issues/1029
