### PR TITLE
systemverilog-plugin: Remove typedef simplification

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1566,8 +1566,6 @@ void UhdmAst::simplify_parameter(AST::AstNode *parameter, AST::AstNode *module_n
     visitEachDescendant(shared.current_top_node, [&](AST::AstNode *current_scope_node) {
         if (current_scope_node->type == AST::AST_TYPEDEF || current_scope_node->type == AST::AST_PARAMETER ||
             current_scope_node->type == AST::AST_LOCALPARAM) {
-            if (current_scope_node->type == AST::AST_TYPEDEF)
-                simplify(current_scope_node, nullptr);
             AST_INTERNAL::current_scope[current_scope_node->str] = current_scope_node;
         }
     });


### PR DESCRIPTION
Fixes (partially) https://github.com/antmicro/yosys-systemverilog/issues/1064.

Test: https://github.com/chipsalliance/UHDM-integration-tests/pull/698

yosys-systemverilog workflow run: https://github.com/antmicro/yosys-systemverilog/actions/runs/3477216107