### PR TITLE
Check for range of integer types

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3977,7 +3977,10 @@ void UhdmAst::process_parameter()
         }
         case vpiIntTypespec:
         case vpiIntegerTypespec: {
-            packed_ranges.push_back(make_range(31, 0));
+            visit_one_to_many({vpiRange}, typespec_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
+            if (packed_ranges.empty()) {
+                packed_ranges.push_back(make_range(31, 0));
+            }
             shared.report.mark_handled(typespec_h);
             break;
         }


### PR DESCRIPTION
Solution for https://github.com/antmicro/yosys-systemverilog/issues/1184

There are parameters declared without explicit types. In this case, the type of the parameter should default to the type of the final value assigned to the parameter .
In case if the assigned value has fixed width lesser than 32 bits, it would be assumed to be 32 bits anyway.

In the issue linked above, we have a case with 3-bit wide integers, and in the AST they were assigned a 32 bit range, which is incorrect.

I've run tests here: https://github.com/antmicro/yosys-systemverilog/pull/1272