### PR TITLE
Improve build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.so
 *.swp
 *.log
-ql-qlf-plugin/pmgen/*
+/*/build

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PLUGINS_INSTALL := $(foreach plugin,$(PLUGIN_LIST),install_$(plugin))
 PLUGINS_CLEAN := $(foreach plugin,$(PLUGIN_LIST),clean_$(plugin))
 PLUGINS_TEST := $(foreach plugin,$(PLUGIN_LIST),test_$(plugin))
 
+.PHONY: all
 all: plugins
 
 TOP_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
@@ -29,15 +30,19 @@ ENVIRONMENT_FILE ?= environment.yml
 -include third_party/make-env/conda.mk
 
 define install_plugin =
+.PHONY: $(1).so
 $(1).so:
 	$$(MAKE) -C $(1)-plugin $$@
 
+.PHONY: install_$(1)
 install_$(1):
 	$$(MAKE) -C $(1)-plugin install
 
+.PHONY: clean_$(1)
 clean_$(1):
 	$$(MAKE) -C $(1)-plugin clean
 
+.PHONY: test_$(1)
 test_$(1):
 	@$$(MAKE) --no-print-directory -C $(1)-plugin test
 endef
@@ -47,21 +52,28 @@ $(foreach plugin,$(PLUGIN_LIST),$(eval $(call install_plugin,$(plugin))))
 pmgen.py:
 	wget -nc -O $@ https://raw.githubusercontent.com/YosysHQ/yosys/master/passes/pmgen/pmgen.py
 
+.PHONY: plugins
 plugins: $(PLUGINS)
 
+.PHONY: install
 install: $(PLUGINS_INSTALL)
 
+.PHONY: test
 test: $(PLUGINS_TEST)
 
+.PHONY: plugins_clean
 plugins_clean: $(PLUGINS_CLEAN)
 
+.PHONY: clean
 clean:: plugins_clean
 	rm -rf pmgen.py
 
 CLANG_FORMAT ?= clang-format-8
+.PHONY: format
 format:
 	find . \( -name "*.h" -o -name "*.cc" \) -and -not -path './third_party/*' -print0 | xargs -0 -P $$(nproc) ${CLANG_FORMAT} -style=file -i
 
 VERIBLE_FORMAT ?= verible-verilog-format
+.PHONY: format-verilog
 format-verilog:
 	find */tests \( -name "*.v" -o -name "*.sv" \) -and -not -path './third_party/*' -print0 | xargs -0 $(VERIBLE_FORMAT) --inplace

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -55,13 +55,13 @@ LDFLAGS := $(shell $(YOSYS_CONFIG) --ldflags) $(LDFLAGS)
 LDLIBS := $(shell $(YOSYS_CONFIG) --ldlibs) $(LDLIBS)
 EXTRA_FLAGS ?=
 
-DATA_DIR = $(DESTDIR)$(shell $(YOSYS_CONFIG) --datdir)
-PLUGINS_DIR = $(DATA_DIR)/plugins
+YOSYS_DATA_DIR = $(DESTDIR)$(shell $(YOSYS_CONFIG) --datdir)
+YOSYS_PLUGINS_DIR = $(YOSYS_DATA_DIR)/plugins
 
 OBJS := $(patsubst %.cc,%.o,$(SOURCES))
 DEPS ?=
 
-$(PLUGINS_DIR):
+$(YOSYS_PLUGINS_DIR):
 	@mkdir -p $@
 
 all: $(NAME).so
@@ -75,8 +75,8 @@ $(NAME).so: $(OBJS)
 ../pmgen.py:
 	@$(MAKE) -C .. pmgen.py
 
-install_plugin: $(NAME).so | $(PLUGINS_DIR)
-	install -D $< $(PLUGINS_DIR)/$<
+install_plugin: $(NAME).so | $(YOSYS_PLUGINS_DIR)
+	install -D $< $(YOSYS_PLUGINS_DIR)/$<
 
 test:
 	@$(MAKE) -C tests all

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -5,6 +5,7 @@
 # This shared object can be imported to Yosys with `plugin -i` command.
 #
 # Below is an example of a plugin Makefile that uses this template:
+# PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 # NAME = plugin_name
 # SOURCES = source1.cc source2.cc
 # include ../Makefile_plugin.common
@@ -40,6 +41,11 @@
 
 SHELL := /usr/bin/env bash
 
+# Directory containing this Makefile
+TOP_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+_MAKEFILES := $(abspath $(filter-out %.d,$(MAKEFILE_LIST)))
+
 # Either find yosys in system and use its path or use the given path
 YOSYS_PATH ?= $(realpath $(dir $(shell command -v yosys))/..)
 
@@ -58,32 +64,89 @@ EXTRA_FLAGS ?=
 YOSYS_DATA_DIR = $(DESTDIR)$(shell $(YOSYS_CONFIG) --datdir)
 YOSYS_PLUGINS_DIR = $(YOSYS_DATA_DIR)/plugins
 
-OBJS := $(patsubst %.cc,%.o,$(SOURCES))
-DEPS ?=
+BUILD_DIR := $(PLUGIN_DIR)/build
 
-$(YOSYS_PLUGINS_DIR):
-	@mkdir -p $@
+# Filled below with all object file paths
+_ALL_OBJECTS :=
+# Filled below with all build directory paths
+_ALL_BUILD_SUBDIRS :=
 
+# Default rule
+
+.PHONY: all
 all: $(NAME).so
 
-$(OBJS): %.o: %.cc $(DEPS)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) -c -o $@ $(filter %.cc, $^)
+# Object files
 
-$(NAME).so: $(OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
+define _process-single-source-file
+_source_abs := $(abspath $(addprefix $(PLUGIN_DIR)/,$(source)))
+_object_abs := $(abspath $(addprefix $(BUILD_DIR)/,$(source).o))
+_object_dir := $(abspath $(dir $(_object_abs)))
+_ALL_OBJECTS += $(_object_abs)
+_ALL_BUILD_SUBDIRS += $(_object_dir)
 
-../pmgen.py:
-	@$(MAKE) -C .. pmgen.py
+$(_object_abs): TARGET_SOURCES := $(_source_abs)
+$(_object_abs): $(_source_abs) | $(_object_dir)
+endef
+$(foreach source,$(SOURCES),$(eval $(value _process-single-source-file)))
 
-install_plugin: $(NAME).so | $(YOSYS_PLUGINS_DIR)
-	install -D $< $(YOSYS_PLUGINS_DIR)/$<
+$(_ALL_OBJECTS): $(_MAKEFILES)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) -c -o $@ $(TARGET_SOURCES)
 
+# Objects list for the purpose of adding extra dependencies after inclusion.
+# Example use: `$(OBJECTS): $(BUILD_DIR)/some-file.h`
+OBJECTS := $(_ALL_OBJECTS)
+
+# Shared library
+
+_SO_LIB := $(BUILD_DIR)/$(NAME).so
+_ALL_BUILD_SUBDIRS += $(abspath $(dir $(_SO_LIB)))
+
+$(_SO_LIB): $(_ALL_OBJECTS) $(_MAKEFILES) | $(abspath $(dir $(_SO_LIB)))
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $(_ALL_OBJECTS) $(LDLIBS)
+
+.PHONY: $(NAME).so
+$(NAME).so: $(_SO_LIB)
+
+# Tests
+
+.PHONY: test test_clean
+ifneq ($(wildcard $(PLUGIN_DIR)/tests/Makefile),)
 test:
 	@$(MAKE) -C tests all
+test_clean:
+	$(MAKE) -C tests clean
+else
+test:
+test_clean:
+endif
+
+# Installation
+
+$(YOSYS_PLUGINS_DIR)/$(NAME).so: $(_SO_LIB) | $(YOSYS_PLUGINS_DIR)
+	install -D $(_SO_LIB) $@
+
+.PHONY: install_plugin
+install_plugin: $(YOSYS_PLUGINS_DIR)/$(NAME).so
 
 .PHONY: install
 install: install_plugin
 
-clean:
-	rm -f *.d *.o *.so
-	$(MAKE) -C tests clean
+# Cleanup
+
+clean: test_clean
+	rm -rf $(BUILD_DIR)
+
+# Other
+
+$(sort $(_ALL_BUILD_SUBDIRS)):
+	mkdir -p $@
+
+$(YOSYS_PLUGINS_DIR):
+	@mkdir -p $@
+
+PMGEN_PY := $(TOP_DIR)/pmgen.py
+
+$(PMGEN_PY):
+	@$(MAKE) -C $(TOP_DIR) pmgen.py
+

--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -85,13 +85,15 @@ _object_dir := $(abspath $(dir $(_object_abs)))
 _ALL_OBJECTS += $(_object_abs)
 _ALL_BUILD_SUBDIRS += $(_object_dir)
 
+-include $(abspath $(addprefix $(BUILD_DIR)/,$(source).d))
+
 $(_object_abs): TARGET_SOURCES := $(_source_abs)
 $(_object_abs): $(_source_abs) | $(_object_dir)
 endef
 $(foreach source,$(SOURCES),$(eval $(value _process-single-source-file)))
 
 $(_ALL_OBJECTS): $(_MAKEFILES)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) -c -o $@ $(TARGET_SOURCES)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_FLAGS) -MMD -c -o $@ $(TARGET_SOURCES)
 
 # Objects list for the purpose of adding extra dependencies after inclusion.
 # Example use: `$(OBJECTS): $(BUILD_DIR)/some-file.h`

--- a/design_introspection-plugin/Makefile
+++ b/design_introspection-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = design_introspection
 SOURCES = design_introspection.cc \
 	  get_cmd.cc \

--- a/dsp-ff-plugin/Makefile
+++ b/dsp-ff-plugin/Makefile
@@ -20,5 +20,5 @@ SOURCES = dsp_ff.cc
 include ../Makefile_plugin.common
 
 install:
-	install -D nexus-dsp_rules.txt $(DATA_DIR)/nexus/dsp_rules.txt
+	install -D nexus-dsp_rules.txt $(YOSYS_DATA_DIR)/nexus/dsp_rules.txt
 

--- a/dsp-ff-plugin/Makefile
+++ b/dsp-ff-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = dsp-ff
 SOURCES = dsp_ff.cc 
 

--- a/fasm-plugin/Makefile
+++ b/fasm-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = fasm
 SOURCES = fasm.cc
 include ../Makefile_plugin.common

--- a/integrateinv-plugin/Makefile
+++ b/integrateinv-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = integrateinv
 SOURCES = integrateinv.cc
 include ../Makefile_plugin.common

--- a/params-plugin/Makefile
+++ b/params-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = params
 SOURCES = params.cc
 include ../Makefile_plugin.common

--- a/ql-iob-plugin/Makefile
+++ b/ql-iob-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = ql-iob
 SOURCES = ql-iob.cc pcf_parser.cc pinmap_parser.cc
 include ../Makefile_plugin.common

--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = ql-qlf
 SOURCES = synth_quicklogic.cc \
           ql-dsp.cc \
@@ -26,12 +28,10 @@ SOURCES = synth_quicklogic.cc \
           ql-dsp-io-regs.cc \
           ql-bram-asymmetric.cc
 
-DEPS = pmgen/ql-dsp-pm.h \
-       pmgen/ql-dsp-macc.h \
-       pmgen/ql-bram-asymmetric-wider-write.h \
-       pmgen/ql-bram-asymmetric-wider-read.h
-
 include ../Makefile_plugin.common
+
+# For pmgen/*.h
+CXXFLAGS += -I$(BUILD_DIR)
 
 COMMON          = common
 QLF_K4N8_DIR    = qlf_k4n8
@@ -78,28 +78,35 @@ VERILOG_MODULES = $(COMMON)/cells_sim.v         \
                   $(PP3_DIR)/bram_init_32.vh   \
                   $(PP3_DIR)/qlal4s3b_sim.v    \
                   $(PP3_DIR)/mult_sim.v        \
-                  $(PP3_DIR)/qlal3_sim.v       \
+                  $(PP3_DIR)/qlal3_sim.v
 
-pmgen:
-	mkdir -p pmgen
+PMGEN_OUT_DIR := $(BUILD_DIR)/pmgen
 
-pmgen/ql-dsp-pm.h: ../pmgen.py ql_dsp.pmg | pmgen
-	python3 ../pmgen.py -o $@ -p ql_dsp ql_dsp.pmg
+$(PMGEN_OUT_DIR):
+	mkdir -p $@
 
-pmgen/ql-dsp-macc.h: ../pmgen.py ql-dsp-macc.pmg | pmgen
-	python3 ../pmgen.py -o $@ -p ql_dsp_macc ql-dsp-macc.pmg
+DEPS := $(PMGEN_OUT_DIR)/ql-dsp-pm.h \
+        $(PMGEN_OUT_DIR)/ql-dsp-macc.h \
+        $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-write.h \
+        $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-read.h
 
-pmgen/ql-bram-asymmetric-wider-write.h: ../pmgen.py ql-bram-asymmetric-wider-write.pmg | pmgen
-	python3 ../pmgen.py -o $@ -p ql_bram_asymmetric_wider_write ql-bram-asymmetric-wider-write.pmg
+$(DEPS): $(PMGEN_PY) | $(PMGEN_OUT_DIR)
 
-pmgen/ql-bram-asymmetric-wider-read.h: ../pmgen.py ql-bram-asymmetric-wider-read.pmg | pmgen
-	python3 ../pmgen.py -o $@ -p ql_bram_asymmetric_wider_read ql-bram-asymmetric-wider-read.pmg
+$(OBJECTS): $(DEPS)
+
+$(PMGEN_OUT_DIR)/ql-dsp-pm.h: ql_dsp.pmg
+	python3 $(PMGEN_PY) -o $@ -p ql_dsp ql_dsp.pmg
+
+$(PMGEN_OUT_DIR)/ql-dsp-macc.h: ql-dsp-macc.pmg
+	python3 $(PMGEN_PY) -o $@ -p ql_dsp_macc ql-dsp-macc.pmg
+
+$(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-write.h: ql-bram-asymmetric-wider-write.pmg
+	python3 $(PMGEN_PY) -o $@ -p ql_bram_asymmetric_wider_write ql-bram-asymmetric-wider-write.pmg
+
+$(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-read.h: ql-bram-asymmetric-wider-read.pmg
+	python3 $(PMGEN_PY) -o $@ -p ql_bram_asymmetric_wider_read ql-bram-asymmetric-wider-read.pmg
 
 install_modules: $(VERILOG_MODULES)
 	$(foreach f,$^,install -D $(f) $(YOSYS_DATA_DIR)/quicklogic/$(f);)
 
 install: install_modules
-
-clean:
-	$(MAKE) -f ../Makefile_plugin.common $@
-	rm -rf pmgen

--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -96,7 +96,7 @@ pmgen/ql-bram-asymmetric-wider-read.h: ../pmgen.py ql-bram-asymmetric-wider-read
 	python3 ../pmgen.py -o $@ -p ql_bram_asymmetric_wider_read ql-bram-asymmetric-wider-read.pmg
 
 install_modules: $(VERILOG_MODULES)
-	$(foreach f,$^,install -D $(f) $(DATA_DIR)/quicklogic/$(f);)
+	$(foreach f,$^,install -D $(f) $(YOSYS_DATA_DIR)/quicklogic/$(f);)
 
 install: install_modules
 

--- a/sdc-plugin/Makefile
+++ b/sdc-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = sdc
 SOURCES = buffers.cc \
           clocks.cc \

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = systemverilog
 SOURCES = UhdmAst.cc \
           uhdmastfrontend.cc \

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -16,22 +16,39 @@
 
 NAME = systemverilog
 SOURCES = UhdmAst.cc \
-	  uhdmastfrontend.cc \
-	  uhdmcommonfrontend.cc \
-	  uhdmsurelogastfrontend.cc \
-	  uhdmastreport.cc
+          uhdmastfrontend.cc \
+          uhdmcommonfrontend.cc \
+          uhdmsurelogastfrontend.cc \
+          uhdmastreport.cc
 
 # Directory to search for Surelog and UHDM libraries
 UHDM_INSTALL_DIR ?= /usr/local
 
 include ../Makefile_plugin.common
 
-CPPFLAGS += -std=c++17 -Wall -W -Wextra \
-              -Wno-deprecated-declarations \
-              -Wno-unused-parameter \
-              -I${UHDM_INSTALL_DIR}/include \
-	      -I${UHDM_INSTALL_DIR}/include/Surelog
+CXXFLAGS += -std=c++17 -Wall -W -Wextra \
+            -Wno-deprecated-declarations \
+            -Wno-unused-parameter \
+            -I${UHDM_INSTALL_DIR}/include \
+            -I${UHDM_INSTALL_DIR}/include/Surelog
 
-CXXFLAGS += -Wno-unused-parameter
-LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm -L${UHDM_INSTALL_DIR}/lib/surelog -L${UHDM_INSTALL_DIR}/lib -L${UHDM_INSTALL_DIR}/lib64/uhdm -L${UHDM_INSTALL_DIR}/lib64/surelog -L${UHDM_INSTALL_DIR}/lib64
-LDLIBS += -Wl,--whole-archive -luhdm -Wl,--no-whole-archive -lsurelog -lantlr4-runtime -lflatbuffers -lcapnp -lkj -ldl -lutil -lm -lrt -lpthread
+LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm \
+           -L${UHDM_INSTALL_DIR}/lib/surelog \
+           -L${UHDM_INSTALL_DIR}/lib \
+           -L${UHDM_INSTALL_DIR}/lib64/uhdm \
+           -L${UHDM_INSTALL_DIR}/lib64/surelog \
+           -L${UHDM_INSTALL_DIR}/lib64
+
+LDLIBS += -Wl,--whole-archive \
+          -luhdm \
+          -Wl,--no-whole-archive \
+          -lsurelog \
+          -lantlr4-runtime \
+          -lflatbuffers \
+          -lcapnp \
+          -lkj \
+          -ldl \
+          -lutil \
+          -lm \
+          -lrt \
+          -lpthread

--- a/uhdm-plugin/Makefile
+++ b/uhdm-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = uhdm
 SOURCES = uhdm.cc
 include ../Makefile_plugin.common

--- a/xdc-plugin/Makefile
+++ b/xdc-plugin/Makefile
@@ -20,6 +20,6 @@ include ../Makefile_plugin.common
 VERILOG_MODULES = BANK.v
 
 install_modules: $(VERILOG_MODULES)
-	install -D $< $(PLUGINS_DIR)/fasm_extra_modules/$<
+	install -D $< $(YOSYS_PLUGINS_DIR)/fasm_extra_modules/$<
 
 install: install_modules

--- a/xdc-plugin/Makefile
+++ b/xdc-plugin/Makefile
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 NAME = xdc
 SOURCES = xdc.cc
 include ../Makefile_plugin.common


### PR DESCRIPTION
- Improves dependency tracking and as a result fixes rebuilds after update of Yosys or other external dependency.
- Outputs build artifacts to `$PLUGIN_DIR/build/` instead of `$PLUGIN_DIR/`.

ql-qlf-plugin has noticeably more changes than other files, but there are no (intentional) functional changes other than mentioned above. I checked only build and installation and those work fine. @mkurc-ant if you have some separate CI for this plugin please check this PR there.

CI results from yosys-systemverilog:
https://github.com/antmicro/yosys-systemverilog/actions/runs/3524421747