### PR TITLE
CI: Explicitly use ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on: [push, pull_request]
 jobs:
 
   Run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 


### PR DESCRIPTION
`ubuntu-latest` is transitioning to Ubuntu 22.04. The CI relies on packages from 20.04.

https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/