### PR TITLE
Adapt to new UHDM::SynthSubset constructor signature.

### DIFF
--- a/systemverilog-plugin/uhdmastfrontend.cc
+++ b/systemverilog-plugin/uhdmastfrontend.cc
@@ -44,7 +44,8 @@ struct UhdmAstFrontend : public UhdmCommonFrontend {
         UHDM::Serializer serializer;
 
         std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
-        UHDM::SynthSubset *synthSubset = new UHDM::SynthSubset(&serializer, this->shared.nonSynthesizableObjects, false, true);
+        UHDM::SynthSubset *synthSubset =
+          make_new_object_with_optional_extra_true_arg<UHDM::SynthSubset>(&serializer, this->shared.nonSynthesizableObjects, false);
         synthSubset->listenDesigns(restoredDesigns);
         delete synthSubset;
         if (this->shared.debug_flag || !this->report_directory.empty()) {

--- a/systemverilog-plugin/uhdmastfrontend.cc
+++ b/systemverilog-plugin/uhdmastfrontend.cc
@@ -44,7 +44,7 @@ struct UhdmAstFrontend : public UhdmCommonFrontend {
         UHDM::Serializer serializer;
 
         std::vector<vpiHandle> restoredDesigns = serializer.Restore(filename);
-        UHDM::SynthSubset *synthSubset = new UHDM::SynthSubset(&serializer, this->shared.nonSynthesizableObjects, false);
+        UHDM::SynthSubset *synthSubset = new UHDM::SynthSubset(&serializer, this->shared.nonSynthesizableObjects, false, true);
         synthSubset->listenDesigns(restoredDesigns);
         delete synthSubset;
         if (this->shared.debug_flag || !this->report_directory.empty()) {

--- a/systemverilog-plugin/uhdmcommonfrontend.h
+++ b/systemverilog-plugin/uhdmcommonfrontend.h
@@ -23,9 +23,27 @@
 #include "uhdm/SynthSubset.h"
 #include "uhdm/VpiListener.h"
 #include <string>
+#include <type_traits>
 #include <vector>
 
 YOSYS_NAMESPACE_BEGIN
+
+// FIXME (mglb): temporary fix to support UHDM both before and after the following change:
+// https://github.com/chipsalliance/UHDM/commit/d78d094448bd94926644e48adea4df293b82f101
+// The commit introducing this code should to be reverted after Surelog is bumped to recent versions in all our repositories.
+template <typename ObjT, typename... ArgN, std::enable_if_t<std::is_constructible_v<ObjT, ArgN...>, bool> = true>
+static inline ObjT *make_new_object_with_optional_extra_true_arg(ArgN &&... arg_n)
+{
+    // Older UHDM version
+    return new ObjT(std::forward<ArgN>(arg_n)...);
+}
+
+template <typename ObjT, typename... ArgN, std::enable_if_t<!std::is_constructible_v<ObjT, ArgN...>, bool> = true>
+static inline ObjT *make_new_object_with_optional_extra_true_arg(ArgN &&... arg_n)
+{
+    // Newer UHDM version
+    return new ObjT(std::forward<ArgN>(arg_n)..., true);
+}
 
 struct UhdmCommonFrontend : public Frontend {
     UhdmAstShared shared;

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -149,7 +149,7 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         // Should be called 1. for normal flow 2. after finishing with `-link`
         if (!this->shared.defer) {
             UHDM::Serializer serializer;
-            UHDM::SynthSubset *synthSubset = new UHDM::SynthSubset(&serializer, this->shared.nonSynthesizableObjects, false);
+            UHDM::SynthSubset *synthSubset = new UHDM::SynthSubset(&serializer, this->shared.nonSynthesizableObjects, false, true);
             synthSubset->listenDesigns(uhdm_design);
             delete synthSubset;
         }

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -149,7 +149,8 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         // Should be called 1. for normal flow 2. after finishing with `-link`
         if (!this->shared.defer) {
             UHDM::Serializer serializer;
-            UHDM::SynthSubset *synthSubset = new UHDM::SynthSubset(&serializer, this->shared.nonSynthesizableObjects, false, true);
+            UHDM::SynthSubset *synthSubset =
+              make_new_object_with_optional_extra_true_arg<UHDM::SynthSubset>(&serializer, this->shared.nonSynthesizableObjects, false);
             synthSubset->listenDesigns(uhdm_design);
             delete synthSubset;
         }


### PR DESCRIPTION
`UHDM::SynthSubset` constructor has a new argument - `allowFormal`. When it is set to `true` everything behaves like before.

Commit introducing the argument:
https://github.com/chipsalliance/UHDM/commit/d78d094448bd94926644e48adea4df293b82f101

Fixes #404

This also works with previous revisions of UHDM repository due to a temporary workaround. The workaround will be safe to be reverted after fixing issues with OpenTitan builds.
yosys-systemverilog CI  (which uses older UHDM revision) results: https://github.com/antmicro/yosys-systemverilog/actions/runs/3534236958