### PR TITLE
process task call nodes

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3601,9 +3601,9 @@ void UhdmAst::process_sys_func_call()
         current_node->str = current_node->str.substr(1);
 }
 
-void UhdmAst::process_func_call()
+void UhdmAst::process_tf_call(AST::AstNodeType type)
 {
-    current_node = make_ast_node(AST::AST_FCALL);
+    current_node = make_ast_node(type);
     visit_one_to_many({vpiArgument}, obj_h, [&](AST::AstNode *node) {
         if (node) {
             if (node->type == AST::AST_PARAMETER || node->type == AST::AST_LOCALPARAM) {
@@ -4344,10 +4344,10 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         process_sys_func_call();
         break;
     case vpiFuncCall:
-        process_func_call();
+        process_tf_call(AST::AST_FCALL);
         break;
     case vpiTaskCall:
-        current_node = make_ast_node(AST::AST_TCALL);
+        process_tf_call(AST::AST_TCALL);
         break;
     case vpiImmediateAssert:
         if (!shared.no_assert)

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -127,7 +127,8 @@ class UhdmAst
     void process_function();
     void process_logic_var();
     void process_sys_func_call();
-    void process_func_call();
+    // use for task calls and function calls
+    void process_tf_call(AST::AstNodeType type);
     void process_immediate_assert();
     void process_hier_path();
     void process_logic_typespec();


### PR DESCRIPTION
Previously, the plugin would just create a node of type `AST_TCLL`, while Yosys also processes the parameters of the task, and creates `AST_IDENTIFIER` nodes accordingly, inside the `AST_TCLL`.
With this change, the plugin processes the parameters, too.

This solves the issue described here: https://github.com/antmicro/yosys-systemverilog/issues/1137

See tests here:
https://github.com/antmicro/yosys-systemverilog/pull/1293