### PR TITLE
systemverilog: Make UhdmAstUpstream.cc proper compilation unit.

### DIFF
--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -18,6 +18,7 @@ PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 NAME = systemverilog
 SOURCES = UhdmAst.cc \
+          UhdmAstUpstream.cc \
           uhdmastfrontend.cc \
           uhdmcommonfrontend.cc \
           uhdmsurelogastfrontend.cc \

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -14,6 +14,8 @@
 #include <uhdm/uhdm.h>
 #include <uhdm/vpi_user.h>
 
+#include "UhdmAstUpstream.h"
+
 YOSYS_NAMESPACE_BEGIN
 
 /*static*/ const IdString &UhdmAst::partial()
@@ -124,8 +126,6 @@ static void copy_packed_unpacked_attribute(AST::AstNode *from, AST::AstNode *to)
         }
     }
 }
-
-#include "UhdmAstUpstream.cc"
 
 static int get_max_offset_struct(AST::AstNode *node)
 {

--- a/systemverilog-plugin/UhdmAstUpstream.cc
+++ b/systemverilog-plugin/UhdmAstUpstream.cc
@@ -1,21 +1,24 @@
-namespace AST
-{
-enum AstNodeTypeExtended {
-    AST_DOT = AST::AST_BIND + 1, // here we always want to point to the last element of yosys' AstNodeType
-    AST_BREAK,
-    AST_CONTINUE
-};
-}
+#include <algorithm>
+#include <string>
+#include <vector>
 
-static AST::AstNode *mkconst_real(double d)
+#include "UhdmAstUpstream.h"
+#include "frontends/ast/ast.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+AST::AstNode *mkconst_real(double d)
 {
     AST::AstNode *node = new AST::AstNode(AST::AST_REALVALUE);
     node->realvalue = d;
     return node;
 }
+
 namespace VERILOG_FRONTEND
 {
+
 using namespace AST;
+
 // divide an arbitrary length decimal number by two and return the rest
 static int my_decimal_div_by_two(std::vector<uint8_t> &digits)
 {
@@ -120,7 +123,7 @@ static void my_strtobin(std::vector<RTLIL::State> &data, const char *str, int le
 }
 
 // convert the Verilog code for a constant to an AST node
-static AST::AstNode *const2ast(std::string code, char case_type, bool warn_z)
+AST::AstNode *const2ast(std::string code, char case_type, bool warn_z)
 {
     if (warn_z) {
         AST::AstNode *ret = const2ast(code, case_type, false);
@@ -214,3 +217,5 @@ static AST::AstNode *const2ast(std::string code, char case_type, bool warn_z)
     return NULL;
 }
 } // namespace VERILOG_FRONTEND
+
+YOSYS_NAMESPACE_END

--- a/systemverilog-plugin/UhdmAstUpstream.h
+++ b/systemverilog-plugin/UhdmAstUpstream.h
@@ -1,0 +1,33 @@
+#ifndef YOSYS_SYSTEMVERILOG_PLUGIN_UHDM_AST_UPSTREAM_H_
+#define YOSYS_SYSTEMVERILOG_PLUGIN_UHDM_AST_UPSTREAM_H_
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "frontends/ast/ast.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+namespace AST
+{
+enum AstNodeTypeExtended {
+    AST_DOT = AST::AST_BIND + 1, // here we always want to point to the last element of yosys' AstNodeType
+    AST_BREAK,
+    AST_CONTINUE
+};
+}
+
+AST::AstNode *mkconst_real(double d);
+
+namespace VERILOG_FRONTEND
+{
+
+// convert the Verilog code for a constant to an AST node
+AST::AstNode *const2ast(std::string code, char case_type, bool warn_z);
+
+} // namespace VERILOG_FRONTEND
+
+YOSYS_NAMESPACE_END
+
+#endif // YOSYS_SYSTEMVERILOG_PLUGIN_UHDM_AST_UPSTREAM_H_


### PR DESCRIPTION
UhdmAstUpstream.cc is currently included in the middle of UhdmAst.cc and doesn't have any includes inside, which breaks code completion/hints.

Changes made in this PR:
- Compile UhdmAstUpstream.cc as independent object
- Provide and use a header file.

yosys-systemverilog CI: https://github.com/antmicro/yosys-systemverilog/actions/runs/3548600969