### PR TITLE
systemverilog: use RTTI for resource management in UhdmSurelogAstFrontend

### DIFF
--- a/systemverilog-plugin/tests/Makefile
+++ b/systemverilog-plugin/tests/Makefile
@@ -16,10 +16,14 @@
 
 TESTS = counter \
 		break_continue \
-		separate-compilation
+		separate-compilation \
+		debug-flag \
+		report-flag
 
 include $(shell pwd)/../../Makefile_test.common
 
 counter_verify = true
 break_continue_verify = $(call diff_test,break_continue,out)
 separate-compilation_verify = true
+debug-flag_verify = true
+report-flag_verify = true

--- a/systemverilog-plugin/tests/debug-flag/debug-flag-buf.sv
+++ b/systemverilog-plugin/tests/debug-flag/debug-flag-buf.sv
@@ -1,0 +1,21 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+module BUF (
+  input I,
+  output O
+);
+  assign O = I;
+endmodule;

--- a/systemverilog-plugin/tests/debug-flag/debug-flag-pkg.sv
+++ b/systemverilog-plugin/tests/debug-flag/debug-flag-pkg.sv
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package pkg;
+  parameter BITS = 4;
+  parameter LOG2DELAY = 22;
+endpackage

--- a/systemverilog-plugin/tests/debug-flag/debug-flag.tcl
+++ b/systemverilog-plugin/tests/debug-flag/debug-flag.tcl
@@ -1,0 +1,16 @@
+yosys -import
+if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
+yosys -import  ;# ingest plugin commands
+
+set TMP_DIR /tmp
+if { [info exists ::env(TMPDIR) ] } {
+  set TMP_DIR $::env(TMPDIR)
+}
+
+# Testing simple round-trip
+read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -defer $::env(DESIGN_TOP)-pkg.sv
+read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -defer $::env(DESIGN_TOP)-buf.sv
+read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -defer $::env(DESIGN_TOP).v
+read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -link
+hierarchy
+write_verilog

--- a/systemverilog-plugin/tests/debug-flag/debug-flag.v
+++ b/systemverilog-plugin/tests/debug-flag/debug-flag.v
@@ -1,0 +1,31 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+module top (
+  input clk,
+  output [3:0] led
+);
+
+  wire bufg;
+  BUF bufgctrl (
+      .I(clk),
+      .O(bufg)
+  );
+  reg [pkg::BITS + pkg::LOG2DELAY-1 : 0] counter = 0;
+  always @(posedge bufg) begin
+    counter <= counter + 1;
+  end
+  assign led[3:0] = counter >> pkg::LOG2DELAY;
+endmodule

--- a/systemverilog-plugin/tests/report-flag/report-flag-buf.sv
+++ b/systemverilog-plugin/tests/report-flag/report-flag-buf.sv
@@ -1,0 +1,21 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+module BUF (
+  input I,
+  output O
+);
+  assign O = I;
+endmodule;

--- a/systemverilog-plugin/tests/report-flag/report-flag-pkg.sv
+++ b/systemverilog-plugin/tests/report-flag/report-flag-pkg.sv
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package pkg;
+  parameter BITS = 4;
+  parameter LOG2DELAY = 22;
+endpackage

--- a/systemverilog-plugin/tests/report-flag/report-flag.tcl
+++ b/systemverilog-plugin/tests/report-flag/report-flag.tcl
@@ -1,0 +1,16 @@
+yosys -import
+if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
+yosys -import  ;# ingest plugin commands
+
+set TMP_DIR /tmp
+if { [info exists ::env(TMPDIR) ] } {
+  set TMP_DIR $::env(TMPDIR)
+}
+
+# Testing simple round-trip
+read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -defer $::env(DESIGN_TOP)-pkg.sv
+read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -defer $::env(DESIGN_TOP)-buf.sv
+read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -defer $::env(DESIGN_TOP).v
+read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -link
+hierarchy
+write_verilog

--- a/systemverilog-plugin/tests/report-flag/report-flag.v
+++ b/systemverilog-plugin/tests/report-flag/report-flag.v
@@ -1,0 +1,31 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+module top (
+  input clk,
+  output [3:0] led
+);
+
+  wire bufg;
+  BUF bufgctrl (
+      .I(clk),
+      .O(bufg)
+  );
+  reg [pkg::BITS + pkg::LOG2DELAY-1 : 0] counter = 0;
+  always @(posedge bufg) begin
+    counter <= counter + 1;
+  end
+  assign led[3:0] = counter >> pkg::LOG2DELAY;
+endmodule

--- a/systemverilog-plugin/uhdmastfrontend.cc
+++ b/systemverilog-plugin/uhdmastfrontend.cc
@@ -50,8 +50,8 @@ struct UhdmAstFrontend : public UhdmCommonFrontend {
         delete synthSubset;
         if (this->shared.debug_flag || !this->report_directory.empty()) {
             for (auto design : restoredDesigns) {
-                std::stringstream strstr;
-                UHDM::visit_object(design, 1, "", &this->shared.report.unhandled, this->shared.debug_flag ? std::cout : strstr);
+                std::ofstream null_stream;
+                UHDM::visit_object(design, 1, "", &this->shared.report.unhandled, this->shared.debug_flag ? std::cout : null_stream);
             }
         }
         UhdmAst uhdm_ast(this->shared);

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -152,8 +152,8 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
 
         if (this->shared.debug_flag || !this->report_directory.empty()) {
             for (auto design : uhdm_designs) {
-                std::stringstream strstr;
-                UHDM::visit_object(design, 1, "", &this->shared.report.unhandled, this->shared.debug_flag ? std::cout : strstr);
+                std::ofstream null_stream;
+                UHDM::visit_object(design, 1, "", &this->shared.report.unhandled, this->shared.debug_flag ? std::cout : null_stream);
             }
         }
 


### PR DESCRIPTION
According to documentation comment, `SURELOG::shutdown_compiler`
releases all UHDM/VPI resources. This happened before a call to
`visit_designs`, which uses those resources. Compiler instance along
with a few other related pointers is now managed using RAII.

yosys-sytemverilog CI: https://github.com/antmicro/yosys-systemverilog/actions/runs/3577650685

New formal verification passes:

- core_net_or_var.sv
- simple_const_func_shadow.v
- simple_scopes.v
- simple_loop_var_shadow.v
- simple_case_expr_const.v
- simple_signedexpr.v