### PR TITLE
systemverilog: Fix parameter width when not specified

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3959,6 +3959,8 @@ void UhdmAst::process_parameter()
     current_node = make_ast_node(type, {}, true);
     std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
     std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
+    s_vpi_value val;
+    vpi_get_value(obj_h, &val);
     // currently unused, but save it for future use
     if (const char *imported = vpi_get_str(vpiImported, obj_h); imported != nullptr && strlen(imported) > 0) {
         current_node->attributes[UhdmAst::is_imported()] = AST::AstNode::mkconst_int(1, true);
@@ -3990,19 +3992,19 @@ void UhdmAst::process_parameter()
         case vpiIntegerTypespec: {
             visit_one_to_many({vpiRange}, typespec_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
             if (packed_ranges.empty()) {
-                packed_ranges.push_back(make_range(31, 0));
+                packed_ranges.push_back(make_range(val.value.integer ? val.value.integer : 31, 0));
             }
             shared.report.mark_handled(typespec_h);
             break;
         }
         case vpiShortIntTypespec: {
-            packed_ranges.push_back(make_range(15, 0));
+            packed_ranges.push_back(make_range(val.value.integer ? val.value.integer : 15, 0));
             shared.report.mark_handled(typespec_h);
             break;
         }
         case vpiTimeTypespec:
         case vpiLongIntTypespec: {
-            packed_ranges.push_back(make_range(63, 0));
+            packed_ranges.push_back(make_range(val.value.integer ? val.value.integer : 63, 0));
             shared.report.mark_handled(typespec_h);
             break;
         }


### PR DESCRIPTION
Fixes https://github.com/antmicro/yosys-systemverilog/issues/1185

`AST_PARAMETER` before:
```
AST_PARAMETER <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:23.11-23.19> [0x5651607581a0] str='\SIZE' basic_prep range=[31:0] multirange=[ 0 32 ] multirange_swapped=[ 0 ]
AST_CONSTANT <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x565160779ad0] bits='00000000000000000000000000000011'(32) basic_prep range=[31:0] int=3
AST_RANGE <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x565160685fb0] basic_prep range=[31:0]
    AST_CONSTANT <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x5651606c88d0] bits='00000000000000000000000000011111'(32) signed basic_prep range=[31:0] int=31
    AST_CONSTANT <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x56516077e5b0] bits='00000000000000000000000000000000'(32) signed basic_prep range=[31:0]
```
`AST_PARAMETER` with PR fix:
```
AST_PARAMETER <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:23.11-23.19> [0x55c53b7771a0] str='\SIZE' basic_prep range=[3:0] multirange=[ 0 4 ] multirange_swapped=[ 0 ]
AST_CONSTANT <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x55c53b799af0] bits='0011'(4) basic_prep range=[3:0] int=3
AST_RANGE <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x55c53b6a4fb0] basic_prep range=[3:0]
    AST_CONSTANT <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x55c53b6e78d0] bits='00000000000000000000000000000011'(32) signed basic_prep range=[31:0] int=3
    AST_CONSTANT <build/tests/asicworld_code_tidbits_fsm_using_always.v/slpp_all/work/asicworld_12235670529217528500/code_tidbits_fsm_using_always.v:0.0-0.0> [0x55c53b79d5b0] bits='00000000000000000000000000000000'(32) signed basic_prep range=[31:0]
```