### PR TITLE
add fifo & ram macros, add specify block from ram and fifos

### DIFF
--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -55,6 +55,7 @@ VERILOG_MODULES = $(COMMON)/cells_sim.v         \
                   $(QLF_K6N10F_DIR)/brams.txt   \
                   $(QLF_K6N10F_DIR)/cells_sim.v \
                   $(QLF_K6N10F_DIR)/dsp_sim.v \
+                  $(QLF_K6N10F_DIR)/primitives_sim.v \
                   $(QLF_K6N10F_DIR)/brams_sim.v \
                   $(QLF_K6N10F_DIR)/sram1024x18.v \
                   $(QLF_K6N10F_DIR)/TDP18K_FIFO.v \

--- a/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
@@ -486,3 +486,1268 @@ module BRAM2x18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA,
 		.FLUSH2_i(FLUSH2)
 	);
 endmodule
+
+module BRAM2x18_SFIFO (
+    DIN1,
+    PUSH1,
+    POP1,
+    CLK1,
+    Async_Flush1,
+    Overrun_Error1,
+    Full_Watermark1,
+    Almost_Full1,
+    Full1,
+    Underrun_Error1,
+    Empty_Watermark1,
+    Almost_Empty1,
+    Empty1,
+    DOUT1,
+    
+    DIN2,
+    PUSH2,
+    POP2,
+    CLK2,
+    Async_Flush2,
+    Overrun_Error2,
+    Full_Watermark2,
+    Almost_Full2,
+    Full2,
+    Underrun_Error2,
+    Empty_Watermark2,
+    Almost_Empty2,
+    Empty2,
+    DOUT2
+);
+
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+
+  
+  parameter UPAE_DBITS1 = 11'd10;
+  parameter UPAF_DBITS1 = 11'd10;
+  
+  parameter UPAE_DBITS2 = 11'd10;
+  parameter UPAF_DBITS2 = 11'd10;
+
+  input CLK1;
+  input PUSH1, POP1;
+  input [WR_DATA_WIDTH-1:0] DIN1;
+  input Async_Flush1;
+  output [RD_DATA_WIDTH-1:0] DOUT1;
+  output Almost_Full1, Almost_Empty1;
+  output Full1, Empty1;
+  output Full_Watermark1, Empty_Watermark1;
+  output Overrun_Error1, Underrun_Error1;
+  
+  input CLK2;
+  input PUSH2, POP2;
+  input [WR_DATA_WIDTH-1:0] DIN2;
+  input Async_Flush2;
+  output [RD_DATA_WIDTH-1:0] DOUT2;
+  output Almost_Full2, Almost_Empty2;
+  output Full2, Empty2;
+  output Full_Watermark2, Empty_Watermark2;
+  output Overrun_Error2, Underrun_Error2;
+  
+  wire [17:0] in_reg1;
+  wire [17:0] out_reg1;
+  wire [17:0] fifo1_flags;
+  
+  wire [17:0] in_reg2;
+  wire [17:0] out_reg2;
+  wire [17:0] fifo2_flags;
+  
+  wire Push_Clk1, Pop_Clk1;
+  wire Push_Clk2, Pop_Clk2;
+  assign Push_Clk1 = CLK1;
+  assign Pop_Clk1 = CLK1;
+  assign Push_Clk2 = CLK2;
+  assign Pop_Clk2 = CLK2;
+  
+  assign Overrun_Error1 = fifo1_flags[0];
+  assign Full_Watermark1 = fifo1_flags[1];
+  assign Almost_Full1 = fifo1_flags[2];
+  assign Full1 = fifo1_flags[3];
+  assign Underrun_Error1 = fifo1_flags[4];
+  assign Empty_Watermark1 = fifo1_flags[5];
+  assign Almost_Empty1 = fifo1_flags[6];
+  assign Empty1 = fifo1_flags[7];
+  
+  assign Overrun_Error2 = fifo2_flags[0];
+  assign Full_Watermark2 = fifo2_flags[1];
+  assign Almost_Full2 = fifo2_flags[2];
+  assign Full2 = fifo2_flags[3];
+  assign Underrun_Error2 = fifo2_flags[4];
+  assign Empty_Watermark2 = fifo2_flags[5];
+  assign Almost_Empty2 = fifo2_flags[6];
+  assign Empty2 = fifo2_flags[7];
+  
+  generate
+    if (WR_DATA_WIDTH == 9) begin
+      assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
+      assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
+    end else begin
+      assign in_reg1[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg1[WR_DATA_WIDTH-1:0] = DIN1[WR_DATA_WIDTH-1:0];
+      assign in_reg2[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate   
+  
+ case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1
+				};
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+		endcase
+	end
+  endcase
+
+  (* is_fifo = 1 *) 
+  (* sync_fifo = 1 *) 
+  (* is_split = 1 *)
+  (* rd_data_width = RD_DATA_WIDTH *)
+  (* wr_data_width = WR_DATA_WIDTH *) 
+ 	TDP36K U1 (
+		.RESET_ni(1'b1),
+		.WDATA_A1_i(in_reg1[17:0]),
+		.WDATA_A2_i(in_reg2[17:0]),
+		.RDATA_A1_o(fifo1_flags),
+		.RDATA_A2_o(fifo2_flags),
+		.ADDR_A1_i(14'h0),
+		.ADDR_A2_i(14'h0),
+		.CLK_A1_i(Push_Clk1),
+		.CLK_A2_i(Push_Clk2),
+		.REN_A1_i(1'b1),
+		.REN_A2_i(1'b1),
+		.WEN_A1_i(PUSH1),
+		.WEN_A2_i(PUSH2),
+		.BE_A1_i(2'b11),
+		.BE_A2_i(2'b11),
+
+		.WDATA_B1_i(18'h0),
+		.WDATA_B2_i(18'h0),
+		.RDATA_B1_o(out_reg1[17:0]),
+		.RDATA_B2_o(out_reg2[17:0]),
+		.ADDR_B1_i(14'h0),
+		.ADDR_B2_i(14'h0),
+		.CLK_B1_i(Pop_Clk1),
+		.CLK_B2_i(Pop_Clk2),
+		.REN_B1_i(POP1),
+		.REN_B2_i(POP2),
+		.WEN_B1_i(1'b0),
+		.WEN_B2_i(1'b0),
+		.BE_B1_i(2'b11),
+		.BE_B2_i(2'b11),
+
+		.FLUSH1_i(Async_Flush1),
+		.FLUSH2_i(Async_Flush2)
+	);
+
+  generate
+    if (RD_DATA_WIDTH == 9) begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = {out_reg1[16], out_reg1[7:0]};
+      assign DOUT2[RD_DATA_WIDTH-1:0] = {out_reg2[16], out_reg2[7:0]};
+    end else begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = out_reg1[RD_DATA_WIDTH-1:0];
+      assign DOUT2[RD_DATA_WIDTH-1:0] = out_reg2[RD_DATA_WIDTH-1:0];
+    end
+  endgenerate 
+
+endmodule
+
+module BRAM2x18_AFIFO (
+    DIN1,
+    PUSH1,
+    POP1,
+    Push_Clk1,
+    Pop_Clk1,
+    Async_Flush1,
+    Overrun_Error1,
+    Full_Watermark1,
+    Almost_Full1,
+    Full1,
+    Underrun_Error1,
+    Empty_Watermark1,
+    Almost_Empty1,
+    Empty1,
+    DOUT1,
+    
+    DIN2,
+    PUSH2,
+    POP2,
+    Push_Clk2,
+    Pop_Clk2,
+    Async_Flush2,
+    Overrun_Error2,
+    Full_Watermark2,
+    Almost_Full2,
+    Full2,
+    Underrun_Error2,
+    Empty_Watermark2,
+    Almost_Empty2,
+    Empty2,
+    DOUT2
+);
+
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+
+  
+  parameter UPAE_DBITS1 = 11'd10;
+  parameter UPAF_DBITS1 = 11'd10;
+  
+  parameter UPAE_DBITS2 = 11'd10;
+  parameter UPAF_DBITS2 = 11'd10;
+
+  input Push_Clk1, Pop_Clk1;
+  input PUSH1, POP1;
+  input [WR_DATA_WIDTH-1:0] DIN1;
+  input Async_Flush1;
+  output [RD_DATA_WIDTH-1:0] DOUT1;
+  output Almost_Full1, Almost_Empty1;
+  output Full1, Empty1;
+  output Full_Watermark1, Empty_Watermark1;
+  output Overrun_Error1, Underrun_Error1;
+  
+  input Push_Clk2, Pop_Clk2;
+  input PUSH2, POP2;
+  input [WR_DATA_WIDTH-1:0] DIN2;
+  input Async_Flush2;
+  output [RD_DATA_WIDTH-1:0] DOUT2;
+  output Almost_Full2, Almost_Empty2;
+  output Full2, Empty2;
+  output Full_Watermark2, Empty_Watermark2;
+  output Overrun_Error2, Underrun_Error2;
+  
+  wire [17:0] in_reg1;
+  wire [17:0] out_reg1;
+  wire [17:0] fifo1_flags;
+  
+  wire [17:0] in_reg2;
+  wire [17:0] out_reg2;
+  wire [17:0] fifo2_flags;
+  
+  assign Overrun_Error1 = fifo1_flags[0];
+  assign Full_Watermark1 = fifo1_flags[1];
+  assign Almost_Full1 = fifo1_flags[2];
+  assign Full1 = fifo1_flags[3];
+  assign Underrun_Error1 = fifo1_flags[4];
+  assign Empty_Watermark1 = fifo1_flags[5];
+  assign Almost_Empty1 = fifo1_flags[6];
+  assign Empty1 = fifo1_flags[7];
+  
+  assign Overrun_Error2 = fifo2_flags[0];
+  assign Full_Watermark2 = fifo2_flags[1];
+  assign Almost_Full2 = fifo2_flags[2];
+  assign Full2 = fifo2_flags[3];
+  assign Underrun_Error2 = fifo2_flags[4];
+  assign Empty_Watermark2 = fifo2_flags[5];
+  assign Almost_Empty2 = fifo2_flags[6];
+  assign Empty2 = fifo2_flags[7];
+  
+  generate
+    if (WR_DATA_WIDTH == 9) begin
+      assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
+      assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
+    end else begin
+      assign in_reg1[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg1[WR_DATA_WIDTH-1:0] = DIN1[WR_DATA_WIDTH-1:0];
+      assign in_reg2[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate   
+  
+ case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0
+				};
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+		endcase
+	end
+  endcase
+
+  (* is_fifo = 1 *) 
+  (* sync_fifo = 0 *) 
+  (* is_split = 1 *)
+  (* rd_data_width = RD_DATA_WIDTH *)
+  (* wr_data_width = WR_DATA_WIDTH *) 
+ 	TDP36K U1 (
+		.RESET_ni(1'b1),
+		.WDATA_A1_i(in_reg1[17:0]),
+		.WDATA_A2_i(in_reg2[17:0]),
+		.RDATA_A1_o(fifo1_flags),
+		.RDATA_A2_o(fifo2_flags),
+		.ADDR_A1_i(14'h0),
+		.ADDR_A2_i(14'h0),
+		.CLK_A1_i(Push_Clk1),
+		.CLK_A2_i(Push_Clk2),
+		.REN_A1_i(1'b1),
+		.REN_A2_i(1'b1),
+		.WEN_A1_i(PUSH1),
+		.WEN_A2_i(PUSH2),
+		.BE_A1_i(2'b11),
+		.BE_A2_i(2'b11),
+
+		.WDATA_B1_i(18'h0),
+		.WDATA_B2_i(18'h0),
+		.RDATA_B1_o(out_reg1[17:0]),
+		.RDATA_B2_o(out_reg2[17:0]),
+		.ADDR_B1_i(14'h0),
+		.ADDR_B2_i(14'h0),
+		.CLK_B1_i(Pop_Clk1),
+		.CLK_B2_i(Pop_Clk2),
+		.REN_B1_i(POP1),
+		.REN_B2_i(POP2),
+		.WEN_B1_i(1'b0),
+		.WEN_B2_i(1'b0),
+		.BE_B1_i(2'b11),
+		.BE_B2_i(2'b11),
+
+		.FLUSH1_i(Async_Flush1),
+		.FLUSH2_i(Async_Flush2)
+	);
+
+  generate
+    if (RD_DATA_WIDTH == 9) begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = {out_reg1[16], out_reg1[7:0]};
+      assign DOUT2[RD_DATA_WIDTH-1:0] = {out_reg2[16], out_reg2[7:0]};
+    end else begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = out_reg1[RD_DATA_WIDTH-1:0];
+      assign DOUT2[RD_DATA_WIDTH-1:0] = out_reg2[RD_DATA_WIDTH-1:0];
+    end
+  endgenerate  
+
+endmodule
+
+module BRAM2x18_SP (
+    RESET_ni,
+    
+    WEN1_i,
+    REN1_i,
+    WR1_CLK_i,
+    RD1_CLK_i,
+    WR1_BE_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    WEN2_i,
+    REN2_i,
+    WR2_CLK_i,
+    RD2_CLK_i,
+    WR2_BE_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter BE1_WIDTH = 2;
+parameter BE2_WIDTH = 2;
+
+input wire RESET_ni;
+
+input wire WEN1_i;
+input wire REN1_i;
+input wire WR1_CLK_i;
+input wire RD1_CLK_i;
+input wire [BE1_WIDTH-1:0] WR1_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA1_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire WEN2_i;
+input wire REN2_i;
+input wire WR2_CLK_i;
+input wire RD2_CLK_i;
+input wire [BE2_WIDTH-1:0] WR2_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA2_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA2_o;
+
+//localparam READ_DATA_BITS_TO_SKIP = 18 - RD_DATA_WIDTH;
+
+wire [14:RD_ADDR_WIDTH] RD1_ADDR_CMPL;
+wire [14:WR_ADDR_WIDTH] WR1_ADDR_CMPL;
+wire [17:RD_DATA_WIDTH] RD1_DATA_CMPL;
+wire [17:WR_DATA_WIDTH] WR1_DATA_CMPL;
+           
+wire [14:RD_ADDR_WIDTH] RD2_ADDR_CMPL;
+wire [14:WR_ADDR_WIDTH] WR2_ADDR_CMPL;
+wire [17:RD_DATA_WIDTH] RD2_DATA_CMPL;
+wire [17:WR_DATA_WIDTH] WR2_DATA_CMPL;
+
+wire [14:0] RD1_ADDR_TOTAL;
+wire [14:0] WR1_ADDR_TOTAL;
+
+wire [14:0] RD2_ADDR_TOTAL;
+wire [14:0] WR2_ADDR_TOTAL;
+
+wire [14:0] RD1_ADDR_SHIFTED;
+wire [14:0] WR1_ADDR_SHIFTED;
+
+wire [14:0] RD2_ADDR_SHIFTED;
+wire [14:0] WR2_ADDR_SHIFTED;
+
+wire [1:0] WR1_BE;
+wire [1:0] WR2_BE;
+
+wire FLUSH1;
+wire FLUSH2;
+
+generate
+  if (WR_ADDR_WIDTH == 15) begin
+    assign WR1_ADDR_TOTAL = WR1_ADDR_i;
+    assign WR2_ADDR_TOTAL = WR2_ADDR_i;
+  end else begin
+    assign WR1_ADDR_TOTAL[14:WR_ADDR_WIDTH] = 0;
+    assign WR1_ADDR_TOTAL[WR_ADDR_WIDTH-1:0] = WR1_ADDR_i;
+    assign WR2_ADDR_TOTAL[14:WR_ADDR_WIDTH] = 0;
+    assign WR2_ADDR_TOTAL[WR_ADDR_WIDTH-1:0] = WR2_ADDR_i;
+  end
+endgenerate
+
+generate
+  if (RD_ADDR_WIDTH == 15) begin
+    assign RD1_ADDR_TOTAL = RD1_ADDR_i;
+    assign RD2_ADDR_TOTAL = RD2_ADDR_i;
+  end else begin
+    assign RD1_ADDR_TOTAL[14:RD_ADDR_WIDTH] = 0;
+    assign RD1_ADDR_TOTAL[RD_ADDR_WIDTH-1:0] = RD1_ADDR_i;
+    assign RD2_ADDR_TOTAL[14:RD_ADDR_WIDTH] = 0;
+    assign RD2_ADDR_TOTAL[RD_ADDR_WIDTH-1:0] = RD2_ADDR_i;
+  end
+endgenerate
+
+// Assign parameters
+case (RD_DATA_WIDTH)
+	1: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	2: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_4, `MODE_2, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_4, `MODE_2, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_9, `MODE_2, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_9, `MODE_2, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_18, `MODE_2, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_18, `MODE_2, `MODE_18, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	4: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_2, `MODE_4, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_2, `MODE_4, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_9, `MODE_4, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_9, `MODE_4, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_18, `MODE_4, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_18, `MODE_4, `MODE_18, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_2, `MODE_9, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_2, `MODE_9, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_4, `MODE_9, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_4, `MODE_9, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_2, `MODE_18, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_2, `MODE_18, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_4, `MODE_18, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_4, `MODE_18, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+endcase
+
+// Apply shift
+case (RD_DATA_WIDTH)
+	1: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL;
+	end
+	2: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL;
+	end
+endcase
+
+case (WR_DATA_WIDTH)
+	1: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL;
+	end
+	2: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL;
+	end
+endcase
+
+case (RD_DATA_WIDTH)
+	1: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL;
+	end
+	2: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL;
+	end
+endcase
+
+case (WR_DATA_WIDTH)
+	1: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL;
+	end
+	2: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL;
+	end
+endcase
+
+case (BE1_WIDTH)
+	2: begin
+		assign WR1_BE = WR1_BE_i[BE1_WIDTH-1 :0];
+	end
+	default: begin
+		assign WR1_BE[1:BE1_WIDTH] = 0;
+    assign WR1_BE[BE1_WIDTH-1 :0] = WR1_BE_i[BE1_WIDTH-1 :0];
+	end
+endcase
+
+case (BE2_WIDTH)
+	2: begin
+		assign WR2_BE = WR2_BE_i[BE2_WIDTH-1 :0];
+	end
+	default: begin
+		assign WR2_BE[1:BE2_WIDTH] = 0;
+    assign WR2_BE[BE2_WIDTH-1 :0] = WR2_BE_i[BE2_WIDTH-1 :0];
+	end
+endcase
+
+assign FLUSH1 = 1'b0;
+assign FLUSH2 = 1'b0;
+
+// TODO configure per width
+wire [17:0] PORT_B1_RDATA;
+wire [17:0] PORT_B2_RDATA;
+wire [17:0] PORT_A1_WDATA;
+wire [17:0] PORT_A2_WDATA;
+
+generate
+  if (WR_DATA_WIDTH == 18) begin
+    assign PORT_A1_WDATA[WR_DATA_WIDTH-1:0] = WDATA1_i[WR_DATA_WIDTH-1:0];
+    assign PORT_A2_WDATA[WR_DATA_WIDTH-1:0] = WDATA2_i[WR_DATA_WIDTH-1:0];
+  end else if (WR_DATA_WIDTH == 9) begin
+    assign PORT_A1_WDATA = {19'h0, WDATA1_i[8], 8'h0, WDATA1_i[7:0]};
+    assign PORT_A2_WDATA = {19'h0, WDATA2_i[8], 8'h0, WDATA2_i[7:0]};
+  end else begin
+    assign PORT_A1_WDATA[17:WR_DATA_WIDTH] = 0;
+    assign PORT_A1_WDATA[WR_DATA_WIDTH-1:0] = WDATA1_i[WR_DATA_WIDTH-1:0];
+    assign PORT_A2_WDATA[17:WR_DATA_WIDTH] = 0;
+    assign PORT_A2_WDATA[WR_DATA_WIDTH-1:0] = WDATA2_i[WR_DATA_WIDTH-1:0];
+  end
+endgenerate
+
+case (RD_DATA_WIDTH)
+	9: begin
+		assign RDATA1_o = {PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+    assign RDATA2_o = {PORT_B2_RDATA[16], PORT_B2_RDATA[7:0]};
+	end
+	default: begin
+		assign RDATA1_o = PORT_B1_RDATA[RD_DATA_WIDTH-1:0];
+    assign RDATA2_o = PORT_B2_RDATA[RD_DATA_WIDTH-1:0];
+	end
+endcase
+
+(* is_inferred = 1 *)
+(* is_split = 1 *)
+(* rd_data_width = RD_DATA_WIDTH *)
+(* wr_data_width = WR_DATA_WIDTH *)
+TDP36K BRAM_BLK (
+	.RESET_ni(RESET_ni),
+
+  .WDATA_A1_i(PORT_A1_WDATA),
+  .RDATA_A1_o(),
+  .ADDR_A1_i(WR1_ADDR_SHIFTED),
+  .CLK_A1_i(WR1_CLK_i),
+  .REN_A1_i(),
+  .WEN_A1_i(WEN1_i),
+  .BE_A1_i(WR1_BE[1:0]),
+  
+  .WDATA_B1_i(18'h0),
+  .RDATA_B1_o(PORT_B1_RDATA),
+  .ADDR_B1_i(RD1_ADDR_SHIFTED),
+  .CLK_B1_i(RD1_CLK_i),
+  .REN_B1_i(REN1_i),
+  .WEN_B1_i(1'b0),
+  .BE_B1_i({REN1_i,REN1_i}),
+  
+  .WDATA_A2_i(PORT_A2_WDATA),
+  .RDATA_A2_o(),
+  .ADDR_A2_i(WR2_ADDR_SHIFTED),
+  .CLK_A2_i(WR2_CLK_i),
+  .REN_A2_i(1'b0),
+  .WEN_A2_i(WEN2_i),
+  .BE_A2_i(WR2_BE[1:0]),
+  
+  .WDATA_B2_i(18'h0),
+  .RDATA_B2_o(PORT_B2_RDATA),
+  .ADDR_B2_i(RD2_ADDR_SHIFTED),
+  .CLK_B2_i(RD2_CLK_i),
+  .REN_B2_i(REN2_i),
+  .WEN_B2_i(1'b0),
+  .BE_B2_i({REN2_i,REN2_i}),
+
+	.FLUSH1_i(FLUSH1),
+	.FLUSH2_i(FLUSH2)
+);
+
+endmodule
+
+module BRAM2x18_DP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, CLK3, CLK4, D1ADDR, D1DATA, D1EN, E1ADDR, E1DATA, E1EN, F1ADDR, F1DATA, F1EN, G1ADDR, G1DATA, G1EN, H1ADDR, H1DATA, H1EN);
+	parameter CFG_ABITS = 11;
+	parameter CFG_DBITS = 18;
+	parameter CFG_ENABLE_B = 4;
+	parameter CFG_ENABLE_D = 4;
+	parameter CFG_ENABLE_F = 4;
+	parameter CFG_ENABLE_H = 4;
+
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter [18431:0] INIT0 = 18432'bx;
+	parameter [18431:0] INIT1 = 18432'bx;
+
+	input CLK1;
+	input CLK2;
+	input CLK3;
+	input CLK4;
+
+	input [CFG_ABITS-1:0] A1ADDR;
+	output [CFG_DBITS-1:0] A1DATA;
+	input A1EN;
+
+	input [CFG_ABITS-1:0] B1ADDR;
+	input [CFG_DBITS-1:0] B1DATA;
+	input [CFG_ENABLE_B-1:0] B1EN;
+
+	input [CFG_ABITS-1:0] C1ADDR;
+	output [CFG_DBITS-1:0] C1DATA;
+	input C1EN;
+
+	input [CFG_ABITS-1:0] D1ADDR;
+	input [CFG_DBITS-1:0] D1DATA;
+	input [CFG_ENABLE_D-1:0] D1EN;
+
+	input [CFG_ABITS-1:0] E1ADDR;
+	output [CFG_DBITS-1:0] E1DATA;
+	input E1EN;
+
+	input [CFG_ABITS-1:0] F1ADDR;
+	input [CFG_DBITS-1:0] F1DATA;
+	input [CFG_ENABLE_F-1:0] F1EN;
+
+	input [CFG_ABITS-1:0] G1ADDR;
+	output [CFG_DBITS-1:0] G1DATA;
+	input G1EN;
+
+	input [CFG_ABITS-1:0] H1ADDR;
+	input [CFG_DBITS-1:0] H1DATA;
+	input [CFG_ENABLE_H-1:0] H1EN;
+
+	wire FLUSH1;
+	wire FLUSH2;
+
+	wire [14:0] A1ADDR_TOTAL;
+	wire [14:0] B1ADDR_TOTAL;
+	wire [14:0] C1ADDR_TOTAL;
+	wire [14:0] D1ADDR_TOTAL;
+	wire [14:0] E1ADDR_TOTAL;
+	wire [14:0] F1ADDR_TOTAL;
+	wire [14:0] G1ADDR_TOTAL;
+	wire [14:0] H1ADDR_TOTAL;
+  
+  generate
+    if (CFG_ABITS == 15) begin
+      assign A1ADDR_TOTAL = A1ADDR;
+      assign B1ADDR_TOTAL = B1ADDR;
+      assign C1ADDR_TOTAL = C1ADDR;
+      assign D1ADDR_TOTAL = D1ADDR;
+      assign E1ADDR_TOTAL = E1ADDR;
+      assign F1ADDR_TOTAL = F1ADDR;
+      assign G1ADDR_TOTAL = G1ADDR;
+      assign H1ADDR_TOTAL = H1ADDR;
+    end else begin
+      assign A1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign A1ADDR_TOTAL[CFG_ABITS-1:0] = A1ADDR;
+      assign B1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign B1ADDR_TOTAL[CFG_ABITS-1:0] = B1ADDR;
+      assign C1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign C1ADDR_TOTAL[CFG_ABITS-1:0] = C1ADDR;
+      assign D1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign D1ADDR_TOTAL[CFG_ABITS-1:0] = D1ADDR;
+      assign E1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign E1ADDR_TOTAL[CFG_ABITS-1:0] = E1ADDR;
+      assign F1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign F1ADDR_TOTAL[CFG_ABITS-1:0] = F1ADDR;
+      assign G1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign G1ADDR_TOTAL[CFG_ABITS-1:0] = G1ADDR;
+      assign H1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign H1ADDR_TOTAL[CFG_ABITS-1:0] = H1ADDR;
+    end
+  endgenerate
+
+	wire [17:CFG_DBITS] A1_RDATA_CMPL;
+	wire [17:CFG_DBITS] C1_RDATA_CMPL;
+	wire [17:CFG_DBITS] E1_RDATA_CMPL;
+	wire [17:CFG_DBITS] G1_RDATA_CMPL;
+
+	wire [17:CFG_DBITS] B1_WDATA_CMPL = {17-CFG_DBITS{1'b0}};
+	wire [17:CFG_DBITS] D1_WDATA_CMPL = {17-CFG_DBITS{1'b0}};
+	wire [17:CFG_DBITS] F1_WDATA_CMPL = {17-CFG_DBITS{1'b0}};
+	wire [17:CFG_DBITS] H1_WDATA_CMPL = {17-CFG_DBITS{1'b0}};
+
+	wire [14:0] PORT_A1_ADDR;
+	wire [14:0] PORT_A2_ADDR;
+	wire [14:0] PORT_B1_ADDR;
+	wire [14:0] PORT_B2_ADDR;
+
+	case (CFG_DBITS)
+		1: begin
+			assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+			};
+		end
+
+		2: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 1) : (B1EN ? (B1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 1) : (F1EN ? (F1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 1) : (H1EN ? (H1ADDR_TOTAL << 1) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0
+			};
+		end
+
+		4: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 2) : (B1EN ? (B1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 2) : (D1EN ? (D1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 2) : (F1EN ? (F1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 2) : (H1EN ? (H1ADDR_TOTAL << 2) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0
+			};
+		end
+
+		8, 9: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 3) : (B1EN ? (B1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 3) : (F1EN ? (F1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 3) : (H1EN ? (H1ADDR_TOTAL << 3) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0
+			};
+		end
+
+		16, 18: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 4) : (B1EN ? (B1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 4) : (F1EN ? (F1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 4) : (H1EN ? (H1ADDR_TOTAL << 4) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0
+			};
+		end
+
+		default: begin
+			assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+				12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0
+			};
+		end
+	endcase
+
+	assign FLUSH1 = 1'b0;
+	assign FLUSH2 = 1'b0;
+
+	wire [17:0] PORT_A1_RDATA;
+	wire [17:0] PORT_B1_RDATA;
+	wire [17:0] PORT_A2_RDATA;
+	wire [17:0] PORT_B2_RDATA;
+
+	wire [17:0] PORT_A1_WDATA;
+	wire [17:0] PORT_B1_WDATA;
+	wire [17:0] PORT_A2_WDATA;
+	wire [17:0] PORT_B2_WDATA;
+
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
+			assign C1DATA = {PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+			assign E1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
+			assign G1DATA = {PORT_B2_RDATA[16], PORT_B2_RDATA[7:0]};
+			assign PORT_A1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
+			assign PORT_B1_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
+			assign PORT_A2_WDATA = {F1_WDATA_CMPL[17], F1DATA[8], F1_WDATA_CMPL[16:9], F1DATA[7:0]};
+			assign PORT_B2_WDATA = {H1_WDATA_CMPL[17], H1DATA[8], H1_WDATA_CMPL[16:9], H1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
+			assign C1DATA = PORT_B1_RDATA[CFG_DBITS-1:0];
+			assign E1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
+			assign G1DATA = PORT_B2_RDATA[CFG_DBITS-1:0];
+			assign PORT_A1_WDATA = {B1_WDATA_CMPL, B1DATA};
+			assign PORT_B1_WDATA = {D1_WDATA_CMPL, D1DATA};
+			assign PORT_A2_WDATA = {F1_WDATA_CMPL, F1DATA};
+			assign PORT_B2_WDATA = {H1_WDATA_CMPL, H1DATA};
+
+		end
+	endcase
+
+	wire PORT_A1_CLK = CLK1;
+	wire PORT_A2_CLK = CLK3;
+	wire PORT_B1_CLK = CLK2;
+	wire PORT_B2_CLK = CLK4;
+
+	wire PORT_A1_REN = A1EN;
+	wire PORT_A1_WEN = B1EN[0];
+	wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {B1EN[1],B1EN[0]};
+
+	wire PORT_A2_REN = E1EN;
+	wire PORT_A2_WEN = F1EN[0];
+	wire [CFG_ENABLE_F-1:0] PORT_A2_BE = {F1EN[1],F1EN[0]};
+
+	wire PORT_B1_REN = C1EN;
+	wire PORT_B1_WEN = D1EN[0];
+	wire [CFG_ENABLE_D-1:0] PORT_B1_BE = {D1EN[1],D1EN[0]};
+
+	wire PORT_B2_REN = G1EN;
+	wire PORT_B2_WEN = H1EN[0];
+	wire [CFG_ENABLE_H-1:0] PORT_B2_BE = {H1EN[1],H1EN[0]};
+
+    (* is_split = 1 *)
+    (* rd_data_width = CFG_DBITS *)
+    (* wr_data_width = CFG_DBITS *)
+	TDP36K  _TECHMAP_REPLACE_ (
+		.WDATA_A1_i(PORT_A1_WDATA),
+		.RDATA_A1_o(PORT_A1_RDATA),
+		.ADDR_A1_i(PORT_A1_ADDR),
+		.CLK_A1_i(PORT_A1_CLK),
+		.REN_A1_i(PORT_A1_REN),
+		.WEN_A1_i(PORT_A1_WEN),
+		.BE_A1_i(PORT_A1_BE),
+
+		.WDATA_A2_i(PORT_A2_WDATA),
+		.RDATA_A2_o(PORT_A2_RDATA),
+		.ADDR_A2_i(PORT_A2_ADDR),
+		.CLK_A2_i(PORT_A2_CLK),
+		.REN_A2_i(PORT_A2_REN),
+		.WEN_A2_i(PORT_A2_WEN),
+		.BE_A2_i(PORT_A2_BE),
+
+		.WDATA_B1_i(PORT_B1_WDATA),
+		.RDATA_B1_o(PORT_B1_RDATA),
+		.ADDR_B1_i(PORT_B1_ADDR),
+		.CLK_B1_i(PORT_B1_CLK),
+		.REN_B1_i(PORT_B1_REN),
+		.WEN_B1_i(PORT_B1_WEN),
+		.BE_B1_i(PORT_B1_BE),
+
+		.WDATA_B2_i(PORT_B2_WDATA),
+		.RDATA_B2_o(PORT_B2_RDATA),
+		.ADDR_B2_i(PORT_B2_ADDR),
+		.CLK_B2_i(PORT_B2_CLK),
+		.REN_B2_i(PORT_B2_REN),
+		.WEN_B2_i(PORT_B2_WEN),
+		.BE_B2_i(PORT_B2_BE),
+
+		.FLUSH1_i(FLUSH1),
+		.FLUSH2_i(FLUSH2)
+	);
+endmodule

--- a/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_final_map.v
@@ -583,7 +583,10 @@ module BRAM2x18_SFIFO (
   assign Empty2 = fifo2_flags[7];
   
   generate
-    if (WR_DATA_WIDTH == 9) begin
+    if (WR_DATA_WIDTH == 18) begin
+      assign in_reg1[17:0] = DIN1[17:0];
+      assign in_reg2[17:0] = DIN2[17:0];
+    end else if (WR_DATA_WIDTH == 9) begin
       assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
       assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
     end else begin
@@ -592,7 +595,7 @@ module BRAM2x18_SFIFO (
       assign in_reg2[17:WR_DATA_WIDTH]  = 0;
       assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
     end
-  endgenerate   
+  endgenerate     
   
  case (RD_DATA_WIDTH)
 	8, 9: begin
@@ -807,7 +810,10 @@ module BRAM2x18_AFIFO (
   assign Empty2 = fifo2_flags[7];
   
   generate
-    if (WR_DATA_WIDTH == 9) begin
+    if (WR_DATA_WIDTH == 18) begin
+      assign in_reg1[17:0] = DIN1[17:0];
+      assign in_reg2[17:0] = DIN2[17:0];
+    end else if (WR_DATA_WIDTH == 9) begin
       assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
       assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
     end else begin
@@ -816,7 +822,7 @@ module BRAM2x18_AFIFO (
       assign in_reg2[17:WR_DATA_WIDTH]  = 0;
       assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
     end
-  endgenerate   
+  endgenerate     
   
  case (RD_DATA_WIDTH)
 	8, 9: begin

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -244,7 +244,7 @@ module \$__QLF_FACTOR_BRAM18_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		.CFG_ENABLE_D(CFG_ENABLE_D),
 		.CLKPOL2(CLKPOL2),
 		.CLKPOL3(CLKPOL3),
-		.INIT0(INIT),
+		.INIT0(INIT)
 	) _TECHMAP_REPLACE_ (
 		.A1ADDR(A1ADDR),
 		.A1DATA(A1DATA),
@@ -307,7 +307,7 @@ module \$__QLF_FACTOR_BRAM18_SDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, CL
 		.CFG_ENABLE_B(CFG_ENABLE_B),
 		.CLKPOL2(CLKPOL2),
 		.CLKPOL3(CLKPOL3),
-		.INIT0(INIT),
+		.INIT0(INIT)
 	) _TECHMAP_REPLACE_ (
 		.A1ADDR(A1ADDR),
 		.A1DATA(A1DATA),
@@ -542,7 +542,7 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 	input RD_SRST;
 
 	input [RD_ADDR_WIDTH-1:0] RD_ADDR;
-	output [RD_DATA_WIDTH-1:0] RD_DATA;
+	output reg [RD_DATA_WIDTH-1:0] RD_DATA;
 	input RD_EN;
 
 	input [WR_ADDR_WIDTH-1:0] WR_ADDR;
@@ -551,7 +551,7 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 
 	wire [14:RD_ADDR_WIDTH] RD_ADDR_CMPL;
 	wire [14:WR_ADDR_WIDTH] WR_ADDR_CMPL;
-	wire [35:RD_DATA_WIDTH] RD_DATA_CMPL;
+	reg [35:RD_DATA_WIDTH] RD_DATA_CMPL;
 	wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
 
 	wire [14:0] RD_ADDR_TOTAL;
@@ -1017,5 +1017,1524 @@ module \$__QLF_FACTOR_BRAM36_SDP_ASYMMETRIC (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, 
 		.FLUSH1_i(FLUSH1),
 		.FLUSH2_i(FLUSH2)
 	);
+endmodule
+
+module SFIFO_36K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    CLK,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+
+  parameter WR_DATA_WIDTH = 36;
+  parameter RD_DATA_WIDTH = 36;
+  parameter UPAE_DBITS = 12'd10;
+  parameter UPAF_DBITS = 12'd10;
+
+  input wire CLK;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+  
+  wire [35:0] in_reg;
+  wire [35:0] out_reg;
+  wire [17:0] fifo_flags;
+  
+  wire [35:0] RD_DATA_CMPL;
+  wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
+  
+  wire Push_Clk, Pop_Clk;
+  
+  assign Push_Clk = CLK;
+  assign Pop_Clk = CLK;
+  
+  assign Overrun_Error = fifo_flags[0];
+  assign Full_Watermark = fifo_flags[1];
+  assign Almost_Full = fifo_flags[2];
+  assign Full = fifo_flags[3];
+  assign Underrun_Error = fifo_flags[4];
+  assign Empty_Watermark = fifo_flags[5];
+  assign Almost_Empty = fifo_flags[6];
+  assign Empty = fifo_flags[7];
+   
+  generate
+    if (WR_DATA_WIDTH == 36) begin
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end else if (WR_DATA_WIDTH > 18 && WR_DATA_WIDTH < 36) begin
+      assign in_reg[WR_DATA_WIDTH+1:18] = DIN[WR_DATA_WIDTH-1:16];
+      assign in_reg[17:0] = {2'b00,DIN[15:0]};
+    end else if (WR_DATA_WIDTH == 9) begin
+      assign in_reg[35:0] = {19'h0, DIN[8], 8'h0, DIN[7:0]};
+    end else begin
+      assign in_reg[35:WR_DATA_WIDTH]  = 0;
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate
+  
+  generate
+    if (RD_DATA_WIDTH == 36) begin
+      assign RD_DATA_CMPL = out_reg;
+    end else if (RD_DATA_WIDTH > 18 && RD_DATA_WIDTH < 36) begin
+      assign RD_DATA_CMPL  = {2'b00,out_reg[35:18],out_reg[15:0]};
+    end else if (RD_DATA_WIDTH == 9) begin
+      assign RD_DATA_CMPL = { 27'h0, out_reg[16], out_reg[7:0]};
+    end else begin
+      assign RD_DATA_CMPL = {18'h0, out_reg[17:0]};
+    end
+  endgenerate
+  
+  case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'b1
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1
+				};
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+		endcase
+	end
+	32, 36: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'b1
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b1
+				};
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b1
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b1
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b1
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b1
+				};
+			end
+		endcase
+	end
+ endcase
+ 
+  (* is_fifo = 1 *)
+  (* sync_fifo = 1 *)
+  (* rd_data_width = RD_DATA_WIDTH *) 
+  (* wr_data_width = WR_DATA_WIDTH *)
+ 	TDP36K U1 (
+		.RESET_ni(1'b1),
+		.WDATA_A1_i(in_reg[17:0]),
+		.WDATA_A2_i(in_reg[35:18]),
+		.RDATA_A1_o(fifo_flags),
+		.RDATA_A2_o(),
+		.ADDR_A1_i(14'h0),
+		.ADDR_A2_i(14'h0),
+		.CLK_A1_i(Push_Clk),
+		.CLK_A2_i(1'b0),
+		.REN_A1_i(1'b1),
+		.REN_A2_i(1'b0),
+		.WEN_A1_i(PUSH),
+		.WEN_A2_i(1'b0),
+		.BE_A1_i(2'b11),
+		.BE_A2_i(2'b11),
+
+		.WDATA_B1_i(18'h0),
+		.WDATA_B2_i(18'h0),
+		.RDATA_B1_o(out_reg[17:0]),
+		.RDATA_B2_o(out_reg[35:18]),
+		.ADDR_B1_i(14'h0),
+		.ADDR_B2_i(14'h0),
+		.CLK_B1_i(Pop_Clk),
+		.CLK_B2_i(1'b0),
+		.REN_B1_i(POP),
+		.REN_B2_i(1'b0),
+		.WEN_B1_i(1'b0),
+		.WEN_B2_i(1'b0),
+		.BE_B1_i(2'b11),
+		.BE_B2_i(2'b11),
+
+		.FLUSH1_i(Async_Flush),
+		.FLUSH2_i(1'b0)
+	);
+
+  assign DOUT[RD_DATA_WIDTH-1 : 0] = RD_DATA_CMPL[RD_DATA_WIDTH-1 : 0];
+
+endmodule 
+
+module AFIFO_36K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    Push_Clk,
+    Pop_Clk,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+
+  parameter WR_DATA_WIDTH = 36;
+  parameter RD_DATA_WIDTH = 36;
+  parameter UPAE_DBITS = 12'd10;
+  parameter UPAF_DBITS = 12'd10;
+
+  input wire Push_Clk, Pop_Clk;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+  
+  wire [35:0] in_reg;
+  wire [35:0] out_reg;
+  wire [17:0] fifo_flags;
+  
+  wire [35:0] RD_DATA_CMPL;
+  wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
+  
+  assign Overrun_Error = fifo_flags[0];
+  assign Full_Watermark = fifo_flags[1];
+  assign Almost_Full = fifo_flags[2];
+  assign Full = fifo_flags[3];
+  assign Underrun_Error = fifo_flags[4];
+  assign Empty_Watermark = fifo_flags[5];
+  assign Almost_Empty = fifo_flags[6];
+  assign Empty = fifo_flags[7];
+   
+  generate
+    if (WR_DATA_WIDTH == 36) begin
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end else if (WR_DATA_WIDTH > 18 && WR_DATA_WIDTH < 36) begin
+      assign in_reg[WR_DATA_WIDTH+1:18] = DIN[WR_DATA_WIDTH-1:16];
+      assign in_reg[17:0] = {2'b00,DIN[15:0]};
+    end else if (WR_DATA_WIDTH == 9) begin
+      assign in_reg[35:0] = {19'h0, DIN[8], 8'h0, DIN[7:0]};
+    end else begin
+      assign in_reg[35:WR_DATA_WIDTH]  = 0;
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate
+  
+  generate
+    if (RD_DATA_WIDTH == 36) begin
+      assign RD_DATA_CMPL = out_reg;
+    end else if (RD_DATA_WIDTH > 18 && RD_DATA_WIDTH < 36) begin
+      assign RD_DATA_CMPL  = {2'b00,out_reg[35:18],out_reg[15:0]};
+    end else if (RD_DATA_WIDTH == 9) begin
+      assign RD_DATA_CMPL = { 27'h0, out_reg[16], out_reg[7:0]};
+    end else begin
+      assign RD_DATA_CMPL = {18'h0, out_reg[17:0]};
+    end
+  endgenerate
+  
+  case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'b0
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0
+				};
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+		endcase
+	end
+	32, 36: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'b0
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b0
+				};
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'b0
+				};
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'b0
+				};
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b0
+				};
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'b0
+				};
+			end
+		endcase
+	end
+ endcase
+ 
+  (* is_fifo = 1 *)
+  (* sync_fifo = 0 *)
+  (* rd_data_width = RD_DATA_WIDTH *) 
+  (* wr_data_width = WR_DATA_WIDTH *)
+ 	TDP36K U1 (
+		.RESET_ni(1'b1),
+		.WDATA_A1_i(in_reg[17:0]),
+		.WDATA_A2_i(in_reg[35:18]),
+		.RDATA_A1_o(fifo_flags),
+		.RDATA_A2_o(),
+		.ADDR_A1_i(14'h0),
+		.ADDR_A2_i(14'h0),
+		.CLK_A1_i(Push_Clk),
+		.CLK_A2_i(1'b0),
+		.REN_A1_i(1'b1),
+		.REN_A2_i(1'b0),
+		.WEN_A1_i(PUSH),
+		.WEN_A2_i(1'b0),
+		.BE_A1_i(2'b11),
+		.BE_A2_i(2'b11),
+
+		.WDATA_B1_i(18'h0),
+		.WDATA_B2_i(18'h0),
+		.RDATA_B1_o(out_reg[17:0]),
+		.RDATA_B2_o(out_reg[35:18]),
+		.ADDR_B1_i(14'h0),
+		.ADDR_B2_i(14'h0),
+		.CLK_B1_i(Pop_Clk),
+		.CLK_B2_i(1'b0),
+		.REN_B1_i(POP),
+		.REN_B2_i(1'b0),
+		.WEN_B1_i(1'b0),
+		.WEN_B2_i(1'b0),
+		.BE_B1_i(2'b11),
+		.BE_B2_i(2'b11),
+
+		.FLUSH1_i(Async_Flush),
+		.FLUSH2_i(1'b0)
+	);
+
+  assign DOUT[RD_DATA_WIDTH-1 : 0] = RD_DATA_CMPL[RD_DATA_WIDTH-1 : 0];
+
+endmodule 
+
+module SFIFO_18K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    CLK,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+  
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+  parameter UPAE_DBITS = 11'd10;
+  parameter UPAF_DBITS = 11'd10;
+
+  input wire CLK;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+ 
+ 	BRAM2x18_SFIFO  #(
+      .WR_DATA_WIDTH(WR_DATA_WIDTH), 
+      .RD_DATA_WIDTH(RD_DATA_WIDTH),
+      .UPAE_DBITS1(UPAE_DBITS),
+      .UPAF_DBITS1(UPAF_DBITS),
+      .UPAE_DBITS2(),
+      .UPAF_DBITS2()   
+       ) U1
+      (
+      .DIN1(DIN),
+      .PUSH1(PUSH),
+      .POP1(POP),
+      .CLK1(CLK),
+      .Async_Flush1(Async_Flush),
+      .Overrun_Error1(Overrun_Error),
+      .Full_Watermark1(Full_Watermark),
+      .Almost_Full1(Almost_Full),
+      .Full1(Full),
+      .Underrun_Error1(Underrun_Error),
+      .Empty_Watermark1(Empty_Watermark),
+      .Almost_Empty1(Almost_Empty),
+      .Empty1(Empty),
+      .DOUT1(DOUT),
+      
+      .DIN2(),
+      .PUSH2(),
+      .POP2(),
+      .CLK2(),
+      .Async_Flush2(),
+      .Overrun_Error2(),
+      .Full_Watermark2(),
+      .Almost_Full2(),
+      .Full2(),
+      .Underrun_Error2(),
+      .Empty_Watermark2(),
+      .Almost_Empty2(),
+      .Empty2(),
+      .DOUT2()
+	);
+
+endmodule
+
+module AFIFO_18K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    Push_Clk,
+    Pop_Clk,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+  
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+  parameter UPAE_DBITS = 11'd10;
+  parameter UPAF_DBITS = 11'd10;
+
+  input wire Push_Clk, Pop_Clk;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+ 
+ 	BRAM2x18_AFIFO  #(
+      .WR_DATA_WIDTH(WR_DATA_WIDTH), 
+      .RD_DATA_WIDTH(RD_DATA_WIDTH),
+      .UPAE_DBITS1(UPAE_DBITS),
+      .UPAF_DBITS1(UPAF_DBITS),
+      .UPAE_DBITS2(),
+      .UPAF_DBITS2()
+       ) U1
+      (
+      .DIN1(DIN),
+      .PUSH1(PUSH),
+      .POP1(POP),
+      .Push_Clk1(Push_Clk),
+      .Pop_Clk1(Pop_Clk),
+      .Async_Flush1(Async_Flush),
+      .Overrun_Error1(Overrun_Error),
+      .Full_Watermark1(Full_Watermark),
+      .Almost_Full1(Almost_Full),
+      .Full1(Full),
+      .Underrun_Error1(Underrun_Error),
+      .Empty_Watermark1(Empty_Watermark),
+      .Almost_Empty1(Almost_Empty),
+      .Empty1(Empty),
+      .DOUT1(DOUT),
+      
+      .DIN2(),
+      .PUSH2(),
+      .POP2(),
+      .Push_Clk2(),
+      .Pop_Clk2(),
+      .Async_Flush2(),
+      .Overrun_Error2(),
+      .Full_Watermark2(),
+      .Almost_Full2(),
+      .Full2(),
+      .Underrun_Error2(),
+      .Empty_Watermark2(),
+      .Almost_Empty2(),
+      .Empty2(),
+      .DOUT2()
+	);
+
+endmodule
+
+module RAM_36K_BLK (
+    WEN_i,
+    REN_i,
+    WR_CLK_i,
+    RD_CLK_i,
+    WR_BE_i,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 36;
+parameter BE_WIDTH = 4;
+
+input wire WEN_i;
+input wire REN_i;
+input wire WR_CLK_i;
+input wire RD_CLK_i;
+input wire [BE_WIDTH-1:0] WR_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+wire [14:RD_ADDR_WIDTH] RD_ADDR_CMPL;
+wire [14:WR_ADDR_WIDTH] WR_ADDR_CMPL;
+wire [35:0] RD_DATA_CMPL;
+wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
+
+wire [14:0] RD_ADDR_TOTAL;
+wire [14:0] WR_ADDR_TOTAL;
+
+wire [14:0] RD_ADDR_SHIFTED;
+wire [14:0] WR_ADDR_SHIFTED;
+
+wire [3:0] WR_BE;
+
+wire FLUSH1;
+wire FLUSH2;
+
+generate
+  if (WR_ADDR_WIDTH == 15) begin
+    assign WR_ADDR_TOTAL = WR_ADDR_i;
+  end else begin
+    assign WR_ADDR_TOTAL[14:WR_ADDR_WIDTH] = 0;
+    assign WR_ADDR_TOTAL[WR_ADDR_WIDTH-1:0] = WR_ADDR_i;
+  end
+endgenerate
+
+generate
+  if (RD_ADDR_WIDTH == 15) begin
+    assign RD_ADDR_TOTAL = RD_ADDR_i;
+  end else begin
+    assign RD_ADDR_TOTAL[14:RD_ADDR_WIDTH] = 0;
+    assign RD_ADDR_TOTAL[RD_ADDR_WIDTH-1:0] = RD_ADDR_i;
+  end
+endgenerate
+
+// Assign parameters
+case (RD_DATA_WIDTH)
+	1: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	2: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_4, `MODE_2, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_4, `MODE_2, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_9, `MODE_2, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_9, `MODE_2, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_18, `MODE_2, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_18, `MODE_2, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_36, `MODE_2, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_36, `MODE_2, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_2, `MODE_1, `MODE_2, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	4: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_2, `MODE_4, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_2, `MODE_4, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_9, `MODE_4, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_9, `MODE_4, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_18, `MODE_4, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_18, `MODE_4, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_36, `MODE_4, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_36, `MODE_4, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_4, `MODE_1, `MODE_4, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_2, `MODE_9, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_2, `MODE_9, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_4, `MODE_9, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_4, `MODE_9, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_18, `MODE_9, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_36, `MODE_9, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_9, `MODE_1, `MODE_9, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_2, `MODE_18, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_2, `MODE_18, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_4, `MODE_18, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_4, `MODE_18, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_9, `MODE_18, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_36, `MODE_18, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_18, `MODE_1, `MODE_18, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	32, 36: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_2, `MODE_36, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_2, `MODE_36, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_4, `MODE_36, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_4, `MODE_36, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_9, `MODE_36, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_18, `MODE_36, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_36, `MODE_1, `MODE_36, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_2, `MODE_1, `MODE_2, 1'd0
+				};
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_4, `MODE_1, `MODE_4, 1'd0
+				};
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_9, `MODE_1, `MODE_9, 1'd0
+				};
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_18, `MODE_1, `MODE_18, 1'd0
+				};
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_36, `MODE_1, `MODE_36, 1'd0
+				};
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+				};
+			end
+		endcase
+	end
+endcase
+
+// Apply shift
+case (RD_DATA_WIDTH)
+	1: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL;
+	end
+	2: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 4;
+	end
+	32, 36: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 5;
+	end
+	default: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL;
+	end
+endcase
+
+case (WR_DATA_WIDTH)
+	1: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL;
+	end
+	2: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 4;
+	end
+	32, 36: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 5;
+	end
+	default: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL;
+	end
+endcase
+
+case (BE_WIDTH)
+	4: begin
+		assign WR_BE = WR_BE_i[BE_WIDTH-1 :0];
+	end
+	default: begin
+		assign WR_BE[3:BE_WIDTH] = 0;
+    assign WR_BE[BE_WIDTH-1 :0] = WR_BE_i[BE_WIDTH-1 :0];
+	end
+endcase
+
+assign FLUSH1 = 1'b0;
+assign FLUSH2 = 1'b0;
+
+// TODO configure per width
+wire [17:0] PORT_B1_RDATA;
+wire [17:0] PORT_B2_RDATA;
+wire [35:0] PORT_A_WDATA;
+
+generate
+  if (WR_DATA_WIDTH == 36) begin
+    assign PORT_A_WDATA[WR_DATA_WIDTH-1:0] = WDATA_i[WR_DATA_WIDTH-1:0];
+  end else if (WR_DATA_WIDTH > 18 && WR_DATA_WIDTH < 36) begin
+    assign PORT_A_WDATA[WR_DATA_WIDTH+1:18]  = WDATA_i[WR_DATA_WIDTH-1:16];
+    assign PORT_A_WDATA[17:0] = {2'b00,WDATA_i[15:0]};
+  end else if (WR_DATA_WIDTH == 9) begin
+    assign PORT_A_WDATA = {19'h0, WDATA_i[8], 8'h0, WDATA_i[7:0]};
+  end else begin
+    assign PORT_A_WDATA[35:WR_DATA_WIDTH] = 0;
+    assign PORT_A_WDATA[WR_DATA_WIDTH-1:0] = WDATA_i[WR_DATA_WIDTH-1:0];
+  end
+endgenerate
+
+generate
+  if (RD_DATA_WIDTH == 36) begin
+    assign RD_DATA_CMPL = {PORT_B2_RDATA, PORT_B1_RDATA};
+  end else if (RD_DATA_WIDTH > 18 && RD_DATA_WIDTH < 36) begin
+    assign RD_DATA_CMPL  = {2'b00,PORT_B2_RDATA[17:0],PORT_B1_RDATA[15:0]};
+  end else if (RD_DATA_WIDTH == 9) begin
+    assign RD_DATA_CMPL = { 27'h0, PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+  end else begin
+    assign RD_DATA_CMPL = {18'h0, PORT_B1_RDATA};
+  end
+endgenerate
+
+assign RDATA_o = RD_DATA_CMPL[RD_DATA_WIDTH-1:0];
+
+(* is_inferred = 1 *)
+(* rd_data_width = RD_DATA_WIDTH *)
+(* wr_data_width = WR_DATA_WIDTH *)
+TDP36K BRAM_BLK (
+	.RESET_ni(1'b1),
+
+	.WDATA_A1_i(PORT_A_WDATA[17:0]),
+	.RDATA_A1_o(),
+	.ADDR_A1_i(WR_ADDR_SHIFTED),
+	.CLK_A1_i(WR_CLK_i),
+	.REN_A1_i(1'b0),
+	.WEN_A1_i(WEN_i),
+	.BE_A1_i(WR_BE[1:0]),
+
+	.WDATA_B1_i(18'h0),
+	.RDATA_B1_o(PORT_B1_RDATA[17:0]),
+	.ADDR_B1_i(RD_ADDR_SHIFTED),
+	.CLK_B1_i(RD_CLK_i),
+	.REN_B1_i(REN_i),
+	.WEN_B1_i(1'b0),
+	.BE_B1_i({REN_i,REN_i}),
+
+	.WDATA_A2_i(PORT_A_WDATA[35:18]),
+	.RDATA_A2_o(),
+	.ADDR_A2_i(WR_ADDR_SHIFTED),
+	.CLK_A2_i(WR_CLK_i),
+	.REN_A2_i(1'b0),
+	.WEN_A2_i(WEN_i),
+	.BE_A2_i(WR_BE[3:2]),
+
+	.WDATA_B2_i(18'h0),
+	.RDATA_B2_o(PORT_B2_RDATA[17:0]),
+	.ADDR_B2_i(RD_ADDR_SHIFTED),
+	.CLK_B2_i(RD_CLK_i),
+	.REN_B2_i(REN_i),
+	.WEN_B2_i(1'b0),
+	.BE_B2_i({REN_i,REN_i}),
+
+	.FLUSH1_i(FLUSH1),
+	.FLUSH2_i(FLUSH2)
+);
+
+endmodule
+
+module RAM_18K_BLK (
+    WEN_i,
+    REN_i,
+    WR_CLK_i,
+    RD_CLK_i,
+    WR_BE_i,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire WR_CLK_i;
+input wire RD_CLK_i;
+input wire [BE_WIDTH-1:0] WR_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+  BRAM2x18_SP  #(
+      .WR_ADDR_WIDTH(WR_ADDR_WIDTH), 
+      .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+      .WR_DATA_WIDTH(WR_DATA_WIDTH), 
+      .RD_DATA_WIDTH(RD_DATA_WIDTH),
+      .BE1_WIDTH(BE_WIDTH),
+      .BE2_WIDTH()      
+       ) U1
+      (
+      .RESET_ni(1'b1),
+      
+      .WEN1_i(WEN_i),
+      .REN1_i(REN_i),
+      .WR1_CLK_i(WR_CLK_i),
+      .RD1_CLK_i(RD_CLK_i),
+      .WR1_BE_i(WR_BE_i),
+      .WR1_ADDR_i(WR_ADDR_i),
+      .RD1_ADDR_i(RD_ADDR_i),
+      .WDATA1_i(WDATA_i),
+      .RDATA1_o(RDATA_o),
+      
+      .WEN2_i(),
+      .REN2_i(),
+      .WR2_CLK_i(),
+      .RD2_CLK_i(),
+      .WR2_BE_i(),
+      .WR2_ADDR_i(),
+      .RD2_ADDR_i(),
+      .WDATA2_i(),
+      .RDATA2_o()
+      );
+    
+endmodule
+
+module DPRAM_36K_BLK (   
+    CLK1_i,
+    WEN1_i,
+    WR1_BE_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    CLK2_i,
+    WEN2_i,
+    WR2_BE_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 10;
+parameter DATA_WIDTH = 36;
+parameter BE1_WIDTH = 4;
+parameter BE2_WIDTH = 4;
+
+input wire CLK1_i;
+input wire WEN1_i;
+input wire [BE1_WIDTH-1 :0] WR1_BE_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire CLK2_i;
+input wire WEN2_i;
+input wire [BE2_WIDTH-1 :0] WR2_BE_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+wire FLUSH1;
+wire FLUSH2;
+
+wire [14:0] A1ADDR_TOTAL;
+wire [14:0] B1ADDR_TOTAL;
+wire [14:0] C1ADDR_TOTAL;
+wire [14:0] D1ADDR_TOTAL;
+
+generate
+  if (ADDR_WIDTH == 15) begin
+    assign A1ADDR_TOTAL = RD1_ADDR_i;
+    assign B1ADDR_TOTAL = WR1_ADDR_i;
+    assign C1ADDR_TOTAL = RD2_ADDR_i;
+    assign D1ADDR_TOTAL = WR2_ADDR_i;
+  end else begin
+    assign A1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign A1ADDR_TOTAL[ADDR_WIDTH-1:0] = RD1_ADDR_i;
+    assign B1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign B1ADDR_TOTAL[ADDR_WIDTH-1:0] = WR1_ADDR_i;
+    assign C1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign C1ADDR_TOTAL[ADDR_WIDTH-1:0] = RD2_ADDR_i;
+    assign D1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign D1ADDR_TOTAL[ADDR_WIDTH-1:0] = WR2_ADDR_i;
+  end
+endgenerate
+
+wire [35:DATA_WIDTH] A1DATA_CMPL;
+wire [35:DATA_WIDTH] B1DATA_CMPL;
+wire [35:DATA_WIDTH] C1DATA_CMPL;
+wire [35:DATA_WIDTH] D1DATA_CMPL;
+
+wire [35:0] A1DATA_TOTAL;
+wire [35:0] B1DATA_TOTAL;
+wire [35:0] C1DATA_TOTAL;
+wire [35:0] D1DATA_TOTAL;
+
+wire [14:0] PORT_A_ADDR;
+wire [14:0] PORT_B_ADDR;
+
+wire [3:0] WR1_BE;
+wire [3:0] WR2_BE;
+
+generate
+  if (BE1_WIDTH == 4) begin
+    assign WR1_BE = WR1_BE_i;
+  end else begin
+    assign WR1_BE[3:BE1_WIDTH] = 0;
+    assign WR1_BE[BE1_WIDTH-1:0] = WR1_BE_i[BE1_WIDTH-1:0];
+  end
+endgenerate
+
+generate
+  if (BE2_WIDTH == 4) begin
+    assign WR2_BE = WR2_BE_i;
+  end else begin
+    assign WR2_BE[3:BE2_WIDTH] = 0;
+    assign WR2_BE[BE2_WIDTH-1:0] = WR2_BE_i[BE2_WIDTH-1:0];
+  end
+endgenerate
+
+// Assign read/write data - handle special case for 9bit mode
+// parity bit for 9bit mode is placed in R/W port on bit #16
+case (DATA_WIDTH)
+	9: begin
+		assign RDATA1_o = {A1DATA_TOTAL[16], A1DATA_TOTAL[7:0]};
+		assign RDATA2_o = {C1DATA_TOTAL[16], C1DATA_TOTAL[7:0]};
+		assign B1DATA_TOTAL = {B1DATA_CMPL[35:17], WDATA1_i[8], B1DATA_CMPL[16:9], WDATA1_i[7:0]};
+		assign D1DATA_TOTAL = {D1DATA_CMPL[35:17], WDATA2_i[8], D1DATA_CMPL[16:9], WDATA2_i[7:0]};
+	end
+	default: begin
+		assign RDATA1_o = A1DATA_TOTAL[DATA_WIDTH-1:0];
+		assign RDATA2_o = C1DATA_TOTAL[DATA_WIDTH-1:0];
+		assign B1DATA_TOTAL = {B1DATA_CMPL, WDATA1_i};
+		assign D1DATA_TOTAL = {D1DATA_CMPL, WDATA2_i};
+	end
+endcase
+
+case (DATA_WIDTH)
+	1: begin
+		assign PORT_A_ADDR = REN1_i ? A1ADDR_TOTAL : (WEN1_i ? B1ADDR_TOTAL : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? C1ADDR_TOTAL : (WEN2_i ? D1ADDR_TOTAL : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_1, `MODE_1, `MODE_1, `MODE_1, 1'd0
+          };
+	end
+
+	2: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 1) : (WEN1_i ? (B1ADDR_TOTAL << 1) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 1) : (WEN2_i ? (D1ADDR_TOTAL << 1) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_2, `MODE_2, `MODE_2, `MODE_2, 1'd0
+          };
+	end
+
+	4: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 2) : (WEN1_i ? (B1ADDR_TOTAL << 2) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 2) : (WEN2_i ? (D1ADDR_TOTAL << 2) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_4, `MODE_4, `MODE_4, `MODE_4, 1'd0
+          };
+	end
+
+	8, 9: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 3) : (WEN1_i ? (B1ADDR_TOTAL << 3) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 3) : (WEN2_i ? (D1ADDR_TOTAL << 3) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_9, `MODE_9, `MODE_9, `MODE_9, 1'd0
+          };
+	end
+
+	16, 18: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 4) : (WEN1_i ? (B1ADDR_TOTAL << 4) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 4) : (WEN2_i ? (D1ADDR_TOTAL << 4) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_18, `MODE_18, `MODE_18, `MODE_18, 1'd0
+          };
+	end
+
+	32, 36: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 5) : (WEN1_i ? (B1ADDR_TOTAL << 5) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 5) : (WEN2_i ? (D1ADDR_TOTAL << 5) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0
+          };
+	end
+	default: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 5) : (WEN1_i ? (B1ADDR_TOTAL << 5) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 5) : (WEN2_i ? (D1ADDR_TOTAL << 5) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0,
+              12'd10, 12'd10, 4'd0, `MODE_36, `MODE_36, `MODE_36, `MODE_36, 1'd0
+          };
+	end
+endcase
+
+assign FLUSH1 = 1'b0;
+assign FLUSH2 = 1'b0;
+
+(* is_inferred = 1 *)
+(* rd_data_width = DATA_WIDTH *)
+(* wr_data_width = DATA_WIDTH *)
+TDP36K U1 (
+	.RESET_ni(1'b1),
+	.WDATA_A1_i(B1DATA_TOTAL[17:0]),
+	.WDATA_A2_i(B1DATA_TOTAL[35:18]),
+	.RDATA_A1_o(A1DATA_TOTAL[17:0]),
+	.RDATA_A2_o(A1DATA_TOTAL[35:18]),
+	.ADDR_A1_i(PORT_A_ADDR),
+	.ADDR_A2_i(PORT_A_ADDR),
+	.CLK_A1_i(CLK1_i),
+	.CLK_A2_i(CLK1_i),
+	.REN_A1_i(REN1_i),
+	.REN_A2_i(REN1_i),
+	.WEN_A1_i(WEN1_i),
+	.WEN_A2_i(WEN1_i),
+	.BE_A1_i(WR1_BE[1:0]),
+	.BE_A2_i(WR1_BE[3:0]),
+
+	.WDATA_B1_i(D1DATA_TOTAL[17:0]),
+	.WDATA_B2_i(D1DATA_TOTAL[35:18]),
+	.RDATA_B1_o(C1DATA_TOTAL[17:0]),
+	.RDATA_B2_o(C1DATA_TOTAL[35:18]),
+	.ADDR_B1_i(PORT_B_ADDR),
+	.ADDR_B2_i(PORT_B_ADDR),
+	.CLK_B1_i(CLK2_i),
+	.CLK_B2_i(CLK2_i),
+	.REN_B1_i(REN2_i),
+	.REN_B2_i(REN2_i),
+	.WEN_B1_i(WEN2_i),
+	.WEN_B2_i(WEN2_i),
+	.BE_B1_i(WR2_BE[1:0]),
+	.BE_B2_i(WR2_BE[3:0]),
+
+	.FLUSH1_i(FLUSH1),
+	.FLUSH2_i(FLUSH2)
+);
+endmodule
+
+module DPRAM_18K_BLK (   
+    CLK1_i,
+    WEN1_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    CLK2_i,
+    WEN2_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 10;
+parameter DATA_WIDTH = 18;
+parameter BE1_WIDTH = 2;
+parameter BE2_WIDTH = 2;
+
+input wire CLK1_i;
+input wire WEN1_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire CLK2_i;
+input wire WEN2_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+(* is_inferred = 1 *)
+BRAM2x18_DP #(
+	.CFG_ABITS(ADDR_WIDTH),
+	.CFG_DBITS(DATA_WIDTH),
+	.CFG_ENABLE_B(BE1_WIDTH),
+	.CFG_ENABLE_D(BE2_WIDTH)
+) bram2x18_inst (
+	.A1ADDR(RD1_ADDR_i),
+	.A1DATA(RDATA1_o),
+	.A1EN(REN1_i),
+	.B1ADDR(WR1_ADDR_i),
+	.B1DATA(WDATA1_i),
+	.B1EN({WEN1_i,WEN1_i}),
+	.CLK1(CLK1_i),
+
+	.C1ADDR(RD2_ADDR_i),
+	.C1DATA(RDATA2_o),
+	.C1EN(REN2_i),
+	.D1ADDR(WR2_ADDR_i),
+	.D1DATA(WDATA2_i),
+	.D1EN({WEN2_i,WEN2_i}),
+	.CLK2(CLK2_i),
+
+	.E1ADDR(),
+	.E1DATA(),
+	.E1EN(),
+	.F1ADDR(),
+	.F1DATA(),
+	.F1EN(),
+	.CLK3(),
+
+	.G1ADDR(),
+	.G1DATA(),
+	.G1EN(),
+	.H1ADDR(),
+	.H1DATA(),
+	.H1EN(),
+	.CLK4()
+);
 endmodule
 

--- a/ql-qlf-plugin/qlf_k6n10f/brams_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_sim.v
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+`timescale 1ns /10ps
 
 `default_nettype none
 
@@ -1270,12 +1271,12 @@ module \_$_mem_v2_asymmetric (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, RD_EN, RD_SRST,
     parameter WR_PRIORITY_MASK = 0;
     parameter WR_WIDE_CONTINUATION = 0;
 
-    localparam MODE_36  = 3'b111;   // 36 or 32-bit
-    localparam MODE_18  = 3'b110;   // 18 or 16-bit
-    localparam MODE_9   = 3'b101;   // 9 or 8-bit
-    localparam MODE_4   = 3'b100;   // 4-bit
-    localparam MODE_2   = 3'b010;   // 32-bit
-    localparam MODE_1   = 3'b001;   // 32-bit
+    localparam MODE_36 = 3'b011; // 36- or 32-bit
+    localparam MODE_18 = 3'b010; // 18- or 16-bit
+    localparam MODE_9 = 3'b001; // 9- or 8-bit
+    localparam MODE_4 = 3'b100; // 4-bit
+    localparam MODE_2 = 3'b110; // 2-bit
+    localparam MODE_1 = 3'b101; // 1-bit
 
     input  wire RD_CLK;
     input  wire WR_CLK;
@@ -1419,6 +1420,5601 @@ module \_$_mem_v2_asymmetric (RD_ADDR, RD_ARST, RD_CLK, RD_DATA, RD_EN, RD_SRST,
     );
 endmodule
 
+module BRAM2x18_SP (
+    RESET_ni,
+    
+    WEN1_i,
+    REN1_i,
+    WR1_CLK_i,
+    RD1_CLK_i,
+    WR1_BE_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    WEN2_i,
+    REN2_i,
+    WR2_CLK_i,
+    RD2_CLK_i,
+    WR2_BE_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter BE1_WIDTH = 2;
+parameter BE2_WIDTH = 2;
+
+localparam MODE_36 = 3'b011; // 36- or 32-bit
+localparam MODE_18 = 3'b010; // 18- or 16-bit
+localparam MODE_9 = 3'b001; // 9- or 8-bit
+localparam MODE_4 = 3'b100; // 4-bit
+localparam MODE_2 = 3'b110; // 2-bit
+localparam MODE_1 = 3'b101; // 1-bit
+
+input wire RESET_ni;
+
+input wire WEN1_i;
+input wire REN1_i;
+input wire WR1_CLK_i;
+input wire RD1_CLK_i;
+input wire [BE1_WIDTH-1:0] WR1_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA1_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire WEN2_i;
+input wire REN2_i;
+input wire WR2_CLK_i;
+input wire RD2_CLK_i;
+input wire [BE2_WIDTH-1:0] WR2_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA2_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA2_o;
+
+//localparam READ_DATA_BITS_TO_SKIP = 18 - RD_DATA_WIDTH;
+
+wire [14:RD_ADDR_WIDTH] RD1_ADDR_CMPL;
+wire [14:WR_ADDR_WIDTH] WR1_ADDR_CMPL;
+wire [17:RD_DATA_WIDTH] RD1_DATA_CMPL;
+wire [17:WR_DATA_WIDTH] WR1_DATA_CMPL;
+           
+wire [14:RD_ADDR_WIDTH] RD2_ADDR_CMPL;
+wire [14:WR_ADDR_WIDTH] WR2_ADDR_CMPL;
+wire [17:RD_DATA_WIDTH] RD2_DATA_CMPL;
+wire [17:WR_DATA_WIDTH] WR2_DATA_CMPL;
+
+wire [14:0] RD1_ADDR_TOTAL;
+wire [14:0] WR1_ADDR_TOTAL;
+
+wire [14:0] RD2_ADDR_TOTAL;
+wire [14:0] WR2_ADDR_TOTAL;
+
+wire [14:0] RD1_ADDR_SHIFTED;
+wire [14:0] WR1_ADDR_SHIFTED;
+
+wire [14:0] RD2_ADDR_SHIFTED;
+wire [14:0] WR2_ADDR_SHIFTED;
+
+wire [1:0] WR1_BE;
+wire [1:0] WR2_BE;
+
+wire FLUSH1;
+wire FLUSH2;
+
+generate
+  if (WR_ADDR_WIDTH == 15) begin
+    assign WR1_ADDR_TOTAL = WR1_ADDR_i;
+    assign WR2_ADDR_TOTAL = WR2_ADDR_i;
+  end else begin
+    assign WR1_ADDR_TOTAL[14:WR_ADDR_WIDTH] = 0;
+    assign WR1_ADDR_TOTAL[WR_ADDR_WIDTH-1:0] = WR1_ADDR_i;
+    assign WR2_ADDR_TOTAL[14:WR_ADDR_WIDTH] = 0;
+    assign WR2_ADDR_TOTAL[WR_ADDR_WIDTH-1:0] = WR2_ADDR_i;
+  end
+endgenerate
+
+generate
+  if (RD_ADDR_WIDTH == 15) begin
+    assign RD1_ADDR_TOTAL = RD1_ADDR_i;
+    assign RD2_ADDR_TOTAL = RD2_ADDR_i;
+  end else begin
+    assign RD1_ADDR_TOTAL[14:RD_ADDR_WIDTH] = 0;
+    assign RD1_ADDR_TOTAL[RD_ADDR_WIDTH-1:0] = RD1_ADDR_i;
+    assign RD2_ADDR_TOTAL[14:RD_ADDR_WIDTH] = 0;
+    assign RD2_ADDR_TOTAL[RD_ADDR_WIDTH-1:0] = RD2_ADDR_i;
+  end
+endgenerate
+
+// Apply shift
+case (RD_DATA_WIDTH)
+	1: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL;
+	end
+	2: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign RD1_ADDR_SHIFTED = RD1_ADDR_TOTAL;
+	end
+endcase
+
+case (WR_DATA_WIDTH)
+	1: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL;
+	end
+	2: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign WR1_ADDR_SHIFTED = WR1_ADDR_TOTAL;
+	end
+endcase
+
+case (RD_DATA_WIDTH)
+	1: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL;
+	end
+	2: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign RD2_ADDR_SHIFTED = RD2_ADDR_TOTAL;
+	end
+endcase
+
+case (WR_DATA_WIDTH)
+	1: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL;
+	end
+	2: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL << 4;
+	end
+	default: begin
+		assign WR2_ADDR_SHIFTED = WR2_ADDR_TOTAL;
+	end
+endcase
+
+case (BE1_WIDTH)
+	2: begin
+		assign WR1_BE = WR1_BE_i[BE1_WIDTH-1 :0];
+	end
+	default: begin
+		assign WR1_BE[1:BE1_WIDTH] = 0;
+    assign WR1_BE[BE1_WIDTH-1 :0] = WR1_BE_i[BE1_WIDTH-1 :0];
+	end
+endcase
+
+case (BE2_WIDTH)
+	2: begin
+		assign WR2_BE = WR2_BE_i[BE2_WIDTH-1 :0];
+	end
+	default: begin
+		assign WR2_BE[1:BE2_WIDTH] = 0;
+    assign WR2_BE[BE2_WIDTH-1 :0] = WR2_BE_i[BE2_WIDTH-1 :0];
+	end
+endcase
+
+assign FLUSH1 = 1'b0;
+assign FLUSH2 = 1'b0;
+
+// TODO configure per width
+wire [17:0] PORT_B1_RDATA;
+wire [17:0] PORT_B2_RDATA;
+wire [17:0] PORT_A1_WDATA;
+wire [17:0] PORT_A2_WDATA;
+
+generate
+  if (WR_DATA_WIDTH == 18) begin
+    assign PORT_A1_WDATA[WR_DATA_WIDTH-1:0] = WDATA1_i[WR_DATA_WIDTH-1:0];
+    assign PORT_A2_WDATA[WR_DATA_WIDTH-1:0] = WDATA2_i[WR_DATA_WIDTH-1:0];
+  end else if (WR_DATA_WIDTH == 9) begin
+    assign PORT_A1_WDATA = {19'h0, WDATA1_i[8], 8'h0, WDATA1_i[7:0]};
+    assign PORT_A2_WDATA = {19'h0, WDATA2_i[8], 8'h0, WDATA2_i[7:0]};
+  end else begin
+    assign PORT_A1_WDATA[17:WR_DATA_WIDTH] = 0;
+    assign PORT_A1_WDATA[WR_DATA_WIDTH-1:0] = WDATA1_i[WR_DATA_WIDTH-1:0];
+    assign PORT_A2_WDATA[17:WR_DATA_WIDTH] = 0;
+    assign PORT_A2_WDATA[WR_DATA_WIDTH-1:0] = WDATA2_i[WR_DATA_WIDTH-1:0];
+  end
+endgenerate
+
+case (RD_DATA_WIDTH)
+	9: begin
+		assign RDATA1_o = {PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+    assign RDATA2_o = {PORT_B2_RDATA[16], PORT_B2_RDATA[7:0]};
+	end
+	default: begin
+		assign RDATA1_o = PORT_B1_RDATA[RD_DATA_WIDTH-1:0];
+    assign RDATA2_o = PORT_B2_RDATA[RD_DATA_WIDTH-1:0];
+	end
+endcase
+
+// Assign parameters
+case (RD_DATA_WIDTH)
+	1: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	2: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_4, MODE_2, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_4, MODE_2, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_9, MODE_2, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_9, MODE_2, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_18, MODE_2, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_18, MODE_2, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	4: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_2, MODE_4, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_2, MODE_4, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_9, MODE_4, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_9, MODE_4, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );       
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_18, MODE_4, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_18, MODE_4, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_2, MODE_9, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_2, MODE_9, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_4, MODE_9, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_4, MODE_9, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_18, MODE_9, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_18, MODE_9, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_2, MODE_18, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_2, MODE_18, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_4, MODE_18, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_4, MODE_18, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_9, MODE_18, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_9, MODE_18, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b1,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(RESET_ni),
+        
+          .WDATA_A1_i(PORT_A1_WDATA),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR1_ADDR_SHIFTED),
+          .CLK_A1_i(WR1_CLK_i),
+          .REN_A1_i(),
+          .WEN_A1_i(WEN1_i),
+          .BE_A1_i(WR1_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA),
+          .ADDR_B1_i(RD1_ADDR_SHIFTED),
+          .CLK_B1_i(RD1_CLK_i),
+          .REN_B1_i(REN1_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN1_i,REN1_i}),
+        
+          .WDATA_A2_i(PORT_A2_WDATA),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR2_ADDR_SHIFTED),
+          .CLK_A2_i(WR2_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN2_i),
+          .BE_A2_i(WR2_BE[1:0]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA),
+          .ADDR_B2_i(RD2_ADDR_SHIFTED),
+          .CLK_B2_i(RD2_CLK_i),
+          .REN_B2_i(REN2_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN2_i,REN2_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+endcase
+
+endmodule
+
+module RAM_18K_BLK (
+    WEN_i,
+    REN_i,
+    WR_CLK_i,
+    RD_CLK_i,
+    WR_BE_i,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire WR_CLK_i;
+input wire RD_CLK_i;
+input wire [BE_WIDTH-1:0] WR_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+  BRAM2x18_SP  #(
+      .WR_ADDR_WIDTH(WR_ADDR_WIDTH), 
+      .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+      .WR_DATA_WIDTH(WR_DATA_WIDTH), 
+      .RD_DATA_WIDTH(RD_DATA_WIDTH),
+      .BE1_WIDTH(BE_WIDTH),
+      .BE2_WIDTH()      
+       ) U1
+      (
+      .RESET_ni(1'b1),
+      
+      .WEN1_i(WEN_i),
+      .REN1_i(REN_i),
+      .WR1_CLK_i(WR_CLK_i),
+      .RD1_CLK_i(RD_CLK_i),
+      .WR1_BE_i(WR_BE_i),
+      .WR1_ADDR_i(WR_ADDR_i),
+      .RD1_ADDR_i(RD_ADDR_i),
+      .WDATA1_i(WDATA_i),
+      .RDATA1_o(RDATA_o),
+      
+      .WEN2_i(),
+      .REN2_i(),
+      .WR2_CLK_i(),
+      .RD2_CLK_i(),
+      .WR2_BE_i(),
+      .WR2_ADDR_i(),
+      .RD2_ADDR_i(),
+      .WDATA2_i(),
+      .RDATA2_o()
+      );
+    
+endmodule
+
+module RAM_36K_BLK (
+    WEN_i,
+    REN_i,
+    WR_CLK_i,
+    RD_CLK_i,
+    WR_BE_i,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 36;
+parameter BE_WIDTH = 4;
+
+localparam MODE_36 = 3'b011; // 36- or 32-bit
+localparam MODE_18 = 3'b010; // 18- or 16-bit
+localparam MODE_9 = 3'b001; // 9- or 8-bit
+localparam MODE_4 = 3'b100; // 4-bit
+localparam MODE_2 = 3'b110; // 2-bit
+localparam MODE_1 = 3'b101; // 1-bit
+
+input wire WEN_i;
+input wire REN_i;
+input wire WR_CLK_i;
+input wire RD_CLK_i;
+input wire [BE_WIDTH-1:0] WR_BE_i;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+wire [14:RD_ADDR_WIDTH] RD_ADDR_CMPL;
+wire [14:WR_ADDR_WIDTH] WR_ADDR_CMPL;
+wire [35:0] RD_DATA_CMPL;
+wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
+
+wire [14:0] RD_ADDR_TOTAL;
+wire [14:0] WR_ADDR_TOTAL;
+
+wire [14:0] RD_ADDR_SHIFTED;
+wire [14:0] WR_ADDR_SHIFTED;
+
+wire [3:0] WR_BE;
+
+wire FLUSH1;
+wire FLUSH2;
+
+generate
+  if (WR_ADDR_WIDTH == 15) begin
+    assign WR_ADDR_TOTAL = WR_ADDR_i;
+  end else begin
+    assign WR_ADDR_TOTAL[14:WR_ADDR_WIDTH] = 0;
+    assign WR_ADDR_TOTAL[WR_ADDR_WIDTH-1:0] = WR_ADDR_i;
+  end
+endgenerate
+
+generate
+  if (RD_ADDR_WIDTH == 15) begin
+    assign RD_ADDR_TOTAL = RD_ADDR_i;
+  end else begin
+    assign RD_ADDR_TOTAL[14:RD_ADDR_WIDTH] = 0;
+    assign RD_ADDR_TOTAL[RD_ADDR_WIDTH-1:0] = RD_ADDR_i;
+  end
+endgenerate
+
+// Apply shift
+case (RD_DATA_WIDTH)
+	1: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL;
+	end
+	2: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 4;
+	end
+	32, 36: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL << 5;
+	end
+	default: begin
+		assign RD_ADDR_SHIFTED = RD_ADDR_TOTAL;
+	end
+endcase
+
+case (WR_DATA_WIDTH)
+	1: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL;
+	end
+	2: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 1;
+	end
+	4: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 2;
+	end
+	8, 9: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 3;
+	end
+	16, 18: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 4;
+	end
+	32, 36: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL << 5;
+	end
+	default: begin
+		assign WR_ADDR_SHIFTED = WR_ADDR_TOTAL;
+	end
+endcase
+
+case (BE_WIDTH)
+	4: begin
+		assign WR_BE = WR_BE_i[BE_WIDTH-1 :0];
+	end
+	default: begin
+		assign WR_BE[3:BE_WIDTH] = 0;
+    assign WR_BE[BE_WIDTH-1 :0] = WR_BE_i[BE_WIDTH-1 :0];
+	end
+endcase
+
+assign FLUSH1 = 1'b0;
+assign FLUSH2 = 1'b0;
+
+// TODO configure per width
+wire [17:0] PORT_B1_RDATA;
+wire [17:0] PORT_B2_RDATA;
+wire [35:0] PORT_A_WDATA;
+
+generate
+  if (WR_DATA_WIDTH == 36) begin
+    assign PORT_A_WDATA[WR_DATA_WIDTH-1:0] = WDATA_i[WR_DATA_WIDTH-1:0];
+  end else if (WR_DATA_WIDTH > 18 && WR_DATA_WIDTH < 36) begin
+    assign PORT_A_WDATA[WR_DATA_WIDTH+1:18]  = WDATA_i[WR_DATA_WIDTH-1:16];
+    assign PORT_A_WDATA[17:0] = {2'b00,WDATA_i[15:0]};
+  end else if (WR_DATA_WIDTH == 9) begin
+    assign PORT_A_WDATA = {19'h0, WDATA_i[8], 8'h0, WDATA_i[7:0]};
+  end else begin
+    assign PORT_A_WDATA[35:WR_DATA_WIDTH] = 0;
+    assign PORT_A_WDATA[WR_DATA_WIDTH-1:0] = WDATA_i[WR_DATA_WIDTH-1:0];
+  end
+endgenerate
+
+generate
+  if (RD_DATA_WIDTH == 36) begin
+    assign RD_DATA_CMPL = {PORT_B2_RDATA, PORT_B1_RDATA};
+  end else if (RD_DATA_WIDTH > 18 && RD_DATA_WIDTH < 36) begin
+    assign RD_DATA_CMPL  = {2'b00,PORT_B2_RDATA[17:0],PORT_B1_RDATA[15:0]};
+  end else if (RD_DATA_WIDTH == 9) begin
+    assign RD_DATA_CMPL = { 27'h0, PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+  end else begin
+    assign RD_DATA_CMPL = {18'h0, PORT_B1_RDATA};
+  end
+endgenerate
+
+assign RDATA_o = RD_DATA_CMPL[RD_DATA_WIDTH-1:0];
+
+// Assign parameters
+case (RD_DATA_WIDTH)
+	1: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );       
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_36, MODE_1, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_36, MODE_1, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );       
+			end
+		endcase
+	end
+	2: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_4, MODE_2, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_4, MODE_2, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_9, MODE_2, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_9, MODE_2, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_18, MODE_2, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_18, MODE_2, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_36, MODE_2, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_36, MODE_2, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_2, MODE_1, MODE_2, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	4: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_2, MODE_4, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_2, MODE_4, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_9, MODE_4, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_9, MODE_4, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_18, MODE_4, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_18, MODE_4, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_36, MODE_4, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_36, MODE_4, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_4, MODE_1, MODE_4, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_2, MODE_9, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_2, MODE_9, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_4, MODE_9, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_4, MODE_9, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_18, MODE_9, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_18, MODE_9, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_36, MODE_9, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_36, MODE_9, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_9, MODE_1, MODE_9, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_2, MODE_18, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_2, MODE_18, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_4, MODE_18, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_4, MODE_18, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_9, MODE_18, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_9, MODE_18, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_36, MODE_18, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_36, MODE_18, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_18, MODE_1, MODE_18, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	32, 36: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_1, MODE_36, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_1, MODE_36, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_2, MODE_36, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_2, MODE_36, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_4, MODE_36, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_4, MODE_36, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_9, MODE_36, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_9, MODE_36, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_18, MODE_36, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_18, MODE_36, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_1, MODE_36, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_36, MODE_1, MODE_36, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			1: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			2: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_2, MODE_1, MODE_2, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			4: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_4, MODE_1, MODE_4, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			8, 9: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_9, MODE_1, MODE_9, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );       
+			end
+			16, 18: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_18, MODE_1, MODE_18, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );       
+			end
+			32, 36: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_36, MODE_1, MODE_36, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_36, MODE_1, MODE_36, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+			default: begin
+				defparam BRAM_BLK.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+					12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+				};
+        (* is_inferred = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K BRAM_BLK (
+          .RESET_ni(1'b1),
+        
+          .WDATA_A1_i(PORT_A_WDATA[17:0]),
+          .RDATA_A1_o(),
+          .ADDR_A1_i(WR_ADDR_SHIFTED),
+          .CLK_A1_i(WR_CLK_i),
+          .REN_A1_i(1'b0),
+          .WEN_A1_i(WEN_i),
+          .BE_A1_i(WR_BE[1:0]),
+        
+          .WDATA_B1_i(18'h0),
+          .RDATA_B1_o(PORT_B1_RDATA[17:0]),
+          .ADDR_B1_i(RD_ADDR_SHIFTED),
+          .CLK_B1_i(RD_CLK_i),
+          .REN_B1_i(REN_i),
+          .WEN_B1_i(1'b0),
+          .BE_B1_i({REN_i,REN_i}),
+        
+          .WDATA_A2_i(PORT_A_WDATA[35:18]),
+          .RDATA_A2_o(),
+          .ADDR_A2_i(WR_ADDR_SHIFTED),
+          .CLK_A2_i(WR_CLK_i),
+          .REN_A2_i(1'b0),
+          .WEN_A2_i(WEN_i),
+          .BE_A2_i(WR_BE[3:2]),
+        
+          .WDATA_B2_i(18'h0),
+          .RDATA_B2_o(PORT_B2_RDATA[17:0]),
+          .ADDR_B2_i(RD_ADDR_SHIFTED),
+          .CLK_B2_i(RD_CLK_i),
+          .REN_B2_i(REN_i),
+          .WEN_B2_i(1'b0),
+          .BE_B2_i({REN_i,REN_i}),
+        
+          .FLUSH1_i(FLUSH1),
+          .FLUSH2_i(FLUSH2)
+        );        
+			end
+		endcase
+	end
+endcase
+
+endmodule
+
+module BRAM2x18_DP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, CLK3, CLK4, D1ADDR, D1DATA, D1EN, E1ADDR, E1DATA, E1EN, F1ADDR, F1DATA, F1EN, G1ADDR, G1DATA, G1EN, H1ADDR, H1DATA, H1EN);
+	parameter CFG_ABITS = 11;
+	parameter CFG_DBITS = 18;
+	parameter CFG_ENABLE_B = 4;
+	parameter CFG_ENABLE_D = 4;
+	parameter CFG_ENABLE_F = 4;
+	parameter CFG_ENABLE_H = 4;
+
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter [18431:0] INIT0 = 18432'bx;
+	parameter [18431:0] INIT1 = 18432'bx;
+  
+  localparam MODE_36 = 3'b011; // 36- or 32-bit
+  localparam MODE_18 = 3'b010; // 18- or 16-bit
+  localparam MODE_9 = 3'b001; // 9- or 8-bit
+  localparam MODE_4 = 3'b100; // 4-bit
+  localparam MODE_2 = 3'b110; // 2-bit
+  localparam MODE_1 = 3'b101; // 1-bit
+
+  input wire CLK1;
+  input wire CLK2;
+  input wire CLK3;
+  input wire CLK4;
+
+  input  wire [CFG_ABITS-1:0] A1ADDR;
+  output wire [CFG_DBITS-1:0] A1DATA;
+  input  wire A1EN;
+
+  input  wire [CFG_ABITS-1:0] B1ADDR;
+  input  wire [CFG_DBITS-1:0] B1DATA;
+  input  wire [CFG_ENABLE_B-1:0] B1EN;
+
+  input  wire [CFG_ABITS-1:0] C1ADDR;
+  output wire [CFG_DBITS-1:0] C1DATA;
+  input  wire C1EN;
+
+  input  wire [CFG_ABITS-1:0] D1ADDR;
+  input  wire [CFG_DBITS-1:0] D1DATA;
+  input  wire [CFG_ENABLE_D-1:0] D1EN;
+
+  input  wire [CFG_ABITS-1:0] E1ADDR;
+  output wire [CFG_DBITS-1:0] E1DATA;
+  input  wire E1EN;
+
+  input  wire [CFG_ABITS-1:0] F1ADDR;
+  input  wire [CFG_DBITS-1:0] F1DATA;
+  input  wire [CFG_ENABLE_F-1:0] F1EN;
+
+  input  wire [CFG_ABITS-1:0] G1ADDR;
+  output wire [CFG_DBITS-1:0] G1DATA;
+  input  wire G1EN;
+
+  input  wire [CFG_ABITS-1:0] H1ADDR;
+  input  wire [CFG_DBITS-1:0] H1DATA;
+  input  wire [CFG_ENABLE_H-1:0] H1EN;
+
+	wire FLUSH1;
+	wire FLUSH2;
+
+	wire [14:0] A1ADDR_TOTAL;
+	wire [14:0] B1ADDR_TOTAL;
+	wire [14:0] C1ADDR_TOTAL;
+	wire [14:0] D1ADDR_TOTAL;
+	wire [14:0] E1ADDR_TOTAL;
+	wire [14:0] F1ADDR_TOTAL;
+	wire [14:0] G1ADDR_TOTAL;
+	wire [14:0] H1ADDR_TOTAL;
+  
+  generate
+    if (CFG_ABITS == 15) begin
+      assign A1ADDR_TOTAL = A1ADDR;
+      assign B1ADDR_TOTAL = B1ADDR;
+      assign C1ADDR_TOTAL = C1ADDR;
+      assign D1ADDR_TOTAL = D1ADDR;
+      assign E1ADDR_TOTAL = E1ADDR;
+      assign F1ADDR_TOTAL = F1ADDR;
+      assign G1ADDR_TOTAL = G1ADDR;
+      assign H1ADDR_TOTAL = H1ADDR;
+    end else begin
+      assign A1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign A1ADDR_TOTAL[CFG_ABITS-1:0] = A1ADDR;
+      assign B1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign B1ADDR_TOTAL[CFG_ABITS-1:0] = B1ADDR;
+      assign C1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign C1ADDR_TOTAL[CFG_ABITS-1:0] = C1ADDR;
+      assign D1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign D1ADDR_TOTAL[CFG_ABITS-1:0] = D1ADDR;
+      assign E1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign E1ADDR_TOTAL[CFG_ABITS-1:0] = E1ADDR;
+      assign F1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign F1ADDR_TOTAL[CFG_ABITS-1:0] = F1ADDR;
+      assign G1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign G1ADDR_TOTAL[CFG_ABITS-1:0] = G1ADDR;
+      assign H1ADDR_TOTAL[14:CFG_ABITS] = 0;
+      assign H1ADDR_TOTAL[CFG_ABITS-1:0] = H1ADDR;
+    end
+  endgenerate
+
+	wire [17:CFG_DBITS] A1_RDATA_CMPL;
+	wire [17:CFG_DBITS] C1_RDATA_CMPL;
+	wire [17:CFG_DBITS] E1_RDATA_CMPL;
+	wire [17:CFG_DBITS] G1_RDATA_CMPL;
+
+	wire [17:CFG_DBITS] B1_WDATA_CMPL;
+	wire [17:CFG_DBITS] D1_WDATA_CMPL;
+	wire [17:CFG_DBITS] F1_WDATA_CMPL;
+	wire [17:CFG_DBITS] H1_WDATA_CMPL;
+
+	wire [14:0] PORT_A1_ADDR;
+	wire [14:0] PORT_A2_ADDR;
+	wire [14:0] PORT_B1_ADDR;
+	wire [14:0] PORT_B2_ADDR;
+
+	assign FLUSH1 = 1'b0;
+	assign FLUSH2 = 1'b0;
+
+	wire [17:0] PORT_A1_RDATA;
+	wire [17:0] PORT_B1_RDATA;
+	wire [17:0] PORT_A2_RDATA;
+	wire [17:0] PORT_B2_RDATA;
+
+	wire [17:0] PORT_A1_WDATA;
+	wire [17:0] PORT_B1_WDATA;
+	wire [17:0] PORT_A2_WDATA;
+	wire [17:0] PORT_B2_WDATA;
+
+	// Assign read/write data - handle special case for 9bit mode
+	// parity bit for 9bit mode is placed in R/W port on bit #16
+	case (CFG_DBITS)
+		9: begin
+			assign A1DATA = {PORT_A1_RDATA[16], PORT_A1_RDATA[7:0]};
+			assign C1DATA = {PORT_B1_RDATA[16], PORT_B1_RDATA[7:0]};
+			assign E1DATA = {PORT_A2_RDATA[16], PORT_A2_RDATA[7:0]};
+			assign G1DATA = {PORT_B2_RDATA[16], PORT_B2_RDATA[7:0]};
+			assign PORT_A1_WDATA = {B1_WDATA_CMPL[17], B1DATA[8], B1_WDATA_CMPL[16:9], B1DATA[7:0]};
+			assign PORT_B1_WDATA = {D1_WDATA_CMPL[17], D1DATA[8], D1_WDATA_CMPL[16:9], D1DATA[7:0]};
+			assign PORT_A2_WDATA = {F1_WDATA_CMPL[17], F1DATA[8], F1_WDATA_CMPL[16:9], F1DATA[7:0]};
+			assign PORT_B2_WDATA = {H1_WDATA_CMPL[17], H1DATA[8], H1_WDATA_CMPL[16:9], H1DATA[7:0]};
+		end
+		default: begin
+			assign A1DATA = PORT_A1_RDATA[CFG_DBITS-1:0];
+			assign C1DATA = PORT_B1_RDATA[CFG_DBITS-1:0];
+			assign E1DATA = PORT_A2_RDATA[CFG_DBITS-1:0];
+			assign G1DATA = PORT_B2_RDATA[CFG_DBITS-1:0];
+			assign PORT_A1_WDATA = {B1_WDATA_CMPL, B1DATA};
+			assign PORT_B1_WDATA = {D1_WDATA_CMPL, D1DATA};
+			assign PORT_A2_WDATA = {F1_WDATA_CMPL, F1DATA};
+			assign PORT_B2_WDATA = {H1_WDATA_CMPL, H1DATA};
+
+		end
+	endcase
+
+	wire PORT_A1_CLK = CLK1;
+	wire PORT_A2_CLK = CLK3;
+	wire PORT_B1_CLK = CLK2;
+	wire PORT_B2_CLK = CLK4;
+
+	wire PORT_A1_REN = A1EN;
+	wire PORT_A1_WEN = B1EN[0];
+	wire [CFG_ENABLE_B-1:0] PORT_A1_BE = {B1EN[1],B1EN[0]};
+
+	wire PORT_A2_REN = E1EN;
+	wire PORT_A2_WEN = F1EN[0];
+	wire [CFG_ENABLE_F-1:0] PORT_A2_BE = {F1EN[1],F1EN[0]};
+
+	wire PORT_B1_REN = C1EN;
+	wire PORT_B1_WEN = D1EN[0];
+	wire [CFG_ENABLE_D-1:0] PORT_B1_BE = {D1EN[1],D1EN[0]};
+
+	wire PORT_B2_REN = G1EN;
+	wire PORT_B2_WEN = H1EN[0];
+	wire [CFG_ENABLE_H-1:0] PORT_B2_BE = {H1EN[1],H1EN[0]};
+  
+  	case (CFG_DBITS)
+		1: begin
+			assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+			};
+      (* is_split = 1 *)
+      (* rd_data_width = CFG_DBITS *)
+      (* wr_data_width = CFG_DBITS *)
+      TDP36K  _TECHMAP_REPLACE_ (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+    
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+    
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+    
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+    
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+      );
+		end
+
+		2: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 1) : (B1EN ? (B1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 1) : (F1EN ? (F1ADDR_TOTAL << 1) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 1) : (H1EN ? (H1ADDR_TOTAL << 1) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+			};
+      (* is_split = 1 *)
+      (* rd_data_width = CFG_DBITS *)
+      (* wr_data_width = CFG_DBITS *)
+      TDP36K  _TECHMAP_REPLACE_ (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+    
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+    
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+    
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+    
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+      );
+		end
+
+		4: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 2) : (B1EN ? (B1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 2) : (D1EN ? (D1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 2) : (F1EN ? (F1ADDR_TOTAL << 2) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 2) : (H1EN ? (H1ADDR_TOTAL << 2) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+			};
+      (* is_split = 1 *)
+      (* rd_data_width = CFG_DBITS *)
+      (* wr_data_width = CFG_DBITS *)
+      TDP36K  _TECHMAP_REPLACE_ (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+    
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+    
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+    
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+    
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+      );
+		end
+
+		8, 9: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 3) : (B1EN ? (B1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 3) : (F1EN ? (F1ADDR_TOTAL << 3) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 3) : (H1EN ? (H1ADDR_TOTAL << 3) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+			};
+      (* is_split = 1 *)
+      (* rd_data_width = CFG_DBITS *)
+      (* wr_data_width = CFG_DBITS *)
+      TDP36K  _TECHMAP_REPLACE_ (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+    
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+    
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+    
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+    
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+      );
+		end
+
+		16, 18: begin
+			assign PORT_A1_ADDR = A1EN ? (A1ADDR_TOTAL << 4) : (B1EN ? (B1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? (E1ADDR_TOTAL << 4) : (F1EN ? (F1ADDR_TOTAL << 4) : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? (G1ADDR_TOTAL << 4) : (H1EN ? (H1ADDR_TOTAL << 4) : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+			};
+      (* is_split = 1 *)
+      (* rd_data_width = CFG_DBITS *)
+      (* wr_data_width = CFG_DBITS *)
+      TDP36K  _TECHMAP_REPLACE_ (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+    
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+    
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+    
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+    
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+      );
+		end
+
+		default: begin
+			assign PORT_A1_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 14'd0);
+			assign PORT_B1_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 14'd0);
+			assign PORT_A2_ADDR = E1EN ? E1ADDR_TOTAL : (F1EN ? F1ADDR_TOTAL : 14'd0);
+			assign PORT_B2_ADDR = G1EN ? G1ADDR_TOTAL : (H1EN ? H1ADDR_TOTAL : 14'd0);
+			defparam _TECHMAP_REPLACE_.MODE_BITS = { 1'b1,
+				11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+				12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+			};
+      (* is_split = 1 *)
+      (* rd_data_width = CFG_DBITS *)
+      (* wr_data_width = CFG_DBITS *)
+      TDP36K  _TECHMAP_REPLACE_ (
+        .WDATA_A1_i(PORT_A1_WDATA),
+        .RDATA_A1_o(PORT_A1_RDATA),
+        .ADDR_A1_i(PORT_A1_ADDR),
+        .CLK_A1_i(PORT_A1_CLK),
+        .REN_A1_i(PORT_A1_REN),
+        .WEN_A1_i(PORT_A1_WEN),
+        .BE_A1_i(PORT_A1_BE),
+    
+        .WDATA_A2_i(PORT_A2_WDATA),
+        .RDATA_A2_o(PORT_A2_RDATA),
+        .ADDR_A2_i(PORT_A2_ADDR),
+        .CLK_A2_i(PORT_A2_CLK),
+        .REN_A2_i(PORT_A2_REN),
+        .WEN_A2_i(PORT_A2_WEN),
+        .BE_A2_i(PORT_A2_BE),
+    
+        .WDATA_B1_i(PORT_B1_WDATA),
+        .RDATA_B1_o(PORT_B1_RDATA),
+        .ADDR_B1_i(PORT_B1_ADDR),
+        .CLK_B1_i(PORT_B1_CLK),
+        .REN_B1_i(PORT_B1_REN),
+        .WEN_B1_i(PORT_B1_WEN),
+        .BE_B1_i(PORT_B1_BE),
+    
+        .WDATA_B2_i(PORT_B2_WDATA),
+        .RDATA_B2_o(PORT_B2_RDATA),
+        .ADDR_B2_i(PORT_B2_ADDR),
+        .CLK_B2_i(PORT_B2_CLK),
+        .REN_B2_i(PORT_B2_REN),
+        .WEN_B2_i(PORT_B2_WEN),
+        .BE_B2_i(PORT_B2_BE),
+    
+        .FLUSH1_i(FLUSH1),
+        .FLUSH2_i(FLUSH2)
+      );
+		end
+	endcase
+
+endmodule
+
+module DPRAM_18K_BLK (   
+    CLK1_i,
+    WEN1_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    CLK2_i,
+    WEN2_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 10;
+parameter DATA_WIDTH = 18;
+parameter BE1_WIDTH = 2;
+parameter BE2_WIDTH = 2;
+
+input wire CLK1_i;
+input wire WEN1_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire CLK2_i;
+input wire WEN2_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+(* is_inferred = 1 *)
+BRAM2x18_DP #(
+	.CFG_ABITS(ADDR_WIDTH),
+	.CFG_DBITS(DATA_WIDTH),
+	.CFG_ENABLE_B(BE1_WIDTH),
+	.CFG_ENABLE_D(BE2_WIDTH)
+) bram2x18_inst (
+	.A1ADDR(RD1_ADDR_i),
+	.A1DATA(RDATA1_o),
+	.A1EN(REN1_i),
+	.B1ADDR(WR1_ADDR_i),
+	.B1DATA(WDATA1_i),
+	.B1EN({WEN1_i,WEN1_i}),
+	.CLK1(CLK1_i),
+
+	.C1ADDR(RD2_ADDR_i),
+	.C1DATA(RDATA2_o),
+	.C1EN(REN2_i),
+	.D1ADDR(WR2_ADDR_i),
+	.D1DATA(WDATA2_i),
+	.D1EN({WEN2_i,WEN2_i}),
+	.CLK2(CLK2_i),
+
+	.E1ADDR(),
+	.E1DATA(),
+	.E1EN(),
+	.F1ADDR(),
+	.F1DATA(),
+	.F1EN(),
+	.CLK3(),
+
+	.G1ADDR(),
+	.G1DATA(),
+	.G1EN(),
+	.H1ADDR(),
+	.H1DATA(),
+	.H1EN(),
+	.CLK4()
+);
+endmodule
+
+module DPRAM_36K_BLK (   
+    CLK1_i,
+    WEN1_i,
+    WR1_BE_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    CLK2_i,
+    WEN2_i,
+    WR2_BE_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 10;
+parameter DATA_WIDTH = 36;
+parameter BE1_WIDTH = 4;
+parameter BE2_WIDTH = 4;
+
+localparam MODE_36 = 3'b011; // 36- or 32-bit
+localparam MODE_18 = 3'b010; // 18- or 16-bit
+localparam MODE_9 = 3'b001; // 9- or 8-bit
+localparam MODE_4 = 3'b100; // 4-bit
+localparam MODE_2 = 3'b110; // 2-bit
+localparam MODE_1 = 3'b101; // 1-bit
+
+input wire CLK1_i;
+input wire WEN1_i;
+input wire [BE1_WIDTH-1 :0] WR1_BE_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire CLK2_i;
+input wire WEN2_i;
+input wire [BE2_WIDTH-1 :0] WR2_BE_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+wire FLUSH1;
+wire FLUSH2;
+
+wire [14:0] A1ADDR_TOTAL;
+wire [14:0] B1ADDR_TOTAL;
+wire [14:0] C1ADDR_TOTAL;
+wire [14:0] D1ADDR_TOTAL;
+
+generate
+  if (ADDR_WIDTH == 15) begin
+    assign A1ADDR_TOTAL = RD1_ADDR_i;
+    assign B1ADDR_TOTAL = WR1_ADDR_i;
+    assign C1ADDR_TOTAL = RD2_ADDR_i;
+    assign D1ADDR_TOTAL = WR2_ADDR_i;
+  end else begin
+    assign A1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign A1ADDR_TOTAL[ADDR_WIDTH-1:0] = RD1_ADDR_i;
+    assign B1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign B1ADDR_TOTAL[ADDR_WIDTH-1:0] = WR1_ADDR_i;
+    assign C1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign C1ADDR_TOTAL[ADDR_WIDTH-1:0] = RD2_ADDR_i;
+    assign D1ADDR_TOTAL[14:ADDR_WIDTH] = 0;
+    assign D1ADDR_TOTAL[ADDR_WIDTH-1:0] = WR2_ADDR_i;
+  end
+endgenerate
+
+wire [35:DATA_WIDTH] A1DATA_CMPL;
+wire [35:DATA_WIDTH] B1DATA_CMPL;
+wire [35:DATA_WIDTH] C1DATA_CMPL;
+wire [35:DATA_WIDTH] D1DATA_CMPL;
+
+wire [35:0] A1DATA_TOTAL;
+wire [35:0] B1DATA_TOTAL;
+wire [35:0] C1DATA_TOTAL;
+wire [35:0] D1DATA_TOTAL;
+
+wire [14:0] PORT_A_ADDR;
+wire [14:0] PORT_B_ADDR;
+
+wire [3:0] WR1_BE;
+wire [3:0] WR2_BE;
+
+generate
+  if (BE1_WIDTH == 4) begin
+    assign WR1_BE = WR1_BE_i;
+  end else begin
+    assign WR1_BE[3:BE1_WIDTH] = 0;
+    assign WR1_BE[BE1_WIDTH-1:0] = WR1_BE_i[BE1_WIDTH-1:0];
+  end
+endgenerate
+
+generate
+  if (BE2_WIDTH == 4) begin
+    assign WR2_BE = WR2_BE_i;
+  end else begin
+    assign WR2_BE[3:BE2_WIDTH] = 0;
+    assign WR2_BE[BE2_WIDTH-1:0] = WR2_BE_i[BE2_WIDTH-1:0];
+  end
+endgenerate
+
+// Assign read/write data - handle special case for 9bit mode
+// parity bit for 9bit mode is placed in R/W port on bit #16
+case (DATA_WIDTH)
+	9: begin
+		assign RDATA1_o = {A1DATA_TOTAL[16], A1DATA_TOTAL[7:0]};
+		assign RDATA2_o = {C1DATA_TOTAL[16], C1DATA_TOTAL[7:0]};
+		assign B1DATA_TOTAL = {B1DATA_CMPL[35:17], WDATA1_i[8], B1DATA_CMPL[16:9], WDATA1_i[7:0]};
+		assign D1DATA_TOTAL = {D1DATA_CMPL[35:17], WDATA2_i[8], D1DATA_CMPL[16:9], WDATA2_i[7:0]};
+	end
+	default: begin
+		assign RDATA1_o = A1DATA_TOTAL[DATA_WIDTH-1:0];
+		assign RDATA2_o = C1DATA_TOTAL[DATA_WIDTH-1:0];
+		assign B1DATA_TOTAL = {B1DATA_CMPL, WDATA1_i};
+		assign D1DATA_TOTAL = {D1DATA_CMPL, WDATA2_i};
+	end
+endcase
+
+assign FLUSH1 = 1'b0;
+assign FLUSH2 = 1'b0;
+
+case (DATA_WIDTH)
+	1: begin
+		assign PORT_A_ADDR = REN1_i ? A1ADDR_TOTAL : (WEN1_i ? B1ADDR_TOTAL : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? C1ADDR_TOTAL : (WEN2_i ? D1ADDR_TOTAL : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_1, MODE_1, MODE_1, MODE_1, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+
+	2: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 1) : (WEN1_i ? (B1ADDR_TOTAL << 1) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 1) : (WEN2_i ? (D1ADDR_TOTAL << 1) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_2, MODE_2, MODE_2, MODE_2, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+
+	4: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 2) : (WEN1_i ? (B1ADDR_TOTAL << 2) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 2) : (WEN2_i ? (D1ADDR_TOTAL << 2) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_4, MODE_4, MODE_4, MODE_4, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+
+	8, 9: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 3) : (WEN1_i ? (B1ADDR_TOTAL << 3) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 3) : (WEN2_i ? (D1ADDR_TOTAL << 3) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+
+	16, 18: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 4) : (WEN1_i ? (B1ADDR_TOTAL << 4) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 4) : (WEN2_i ? (D1ADDR_TOTAL << 4) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+
+	32, 36: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 5) : (WEN1_i ? (B1ADDR_TOTAL << 5) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 5) : (WEN2_i ? (D1ADDR_TOTAL << 5) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+	default: begin
+		assign PORT_A_ADDR = REN1_i ? (A1ADDR_TOTAL << 5) : (WEN1_i ? (B1ADDR_TOTAL << 5) : 15'd0);
+		assign PORT_B_ADDR = REN2_i ? (C1ADDR_TOTAL << 5) : (WEN2_i ? (D1ADDR_TOTAL << 5) : 15'd0);
+          defparam U1.MODE_BITS = { 1'b0,
+              11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+              12'd10, 12'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0
+          };
+          (* is_inferred = 1 *)
+          (* rd_data_width = DATA_WIDTH *)
+          (* wr_data_width = DATA_WIDTH *)
+          TDP36K U1 (
+            .RESET_ni(1'b1),
+            .WDATA_A1_i(B1DATA_TOTAL[17:0]),
+            .WDATA_A2_i(B1DATA_TOTAL[35:18]),
+            .RDATA_A1_o(A1DATA_TOTAL[17:0]),
+            .RDATA_A2_o(A1DATA_TOTAL[35:18]),
+            .ADDR_A1_i(PORT_A_ADDR),
+            .ADDR_A2_i(PORT_A_ADDR),
+            .CLK_A1_i(CLK1_i),
+            .CLK_A2_i(CLK1_i),
+            .REN_A1_i(REN1_i),
+            .REN_A2_i(REN1_i),
+            .WEN_A1_i(WEN1_i),
+            .WEN_A2_i(WEN1_i),
+            .BE_A1_i(WR1_BE[1:0]),
+            .BE_A2_i(WR1_BE[3:0]),
+          
+            .WDATA_B1_i(D1DATA_TOTAL[17:0]),
+            .WDATA_B2_i(D1DATA_TOTAL[35:18]),
+            .RDATA_B1_o(C1DATA_TOTAL[17:0]),
+            .RDATA_B2_o(C1DATA_TOTAL[35:18]),
+            .ADDR_B1_i(PORT_B_ADDR),
+            .ADDR_B2_i(PORT_B_ADDR),
+            .CLK_B1_i(CLK2_i),
+            .CLK_B2_i(CLK2_i),
+            .REN_B1_i(REN2_i),
+            .REN_B2_i(REN2_i),
+            .WEN_B1_i(WEN2_i),
+            .WEN_B2_i(WEN2_i),
+            .BE_B1_i(WR2_BE[1:0]),
+            .BE_B2_i(WR2_BE[3:0]),
+          
+            .FLUSH1_i(FLUSH1),
+            .FLUSH2_i(FLUSH2)
+          );          
+	end
+endcase
+
+endmodule
+
 // ============================================================================
 // TDP36K write width 1 functional modes
 
@@ -1492,6 +7088,45 @@ module TDP36K_BRAM_WR_X1_RD_X1_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X1_RD_X2_nonsplit (
@@ -1563,6 +7198,45 @@ module TDP36K_BRAM_WR_X1_RD_X2_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -1636,6 +7310,45 @@ module TDP36K_BRAM_WR_X1_RD_X4_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X1_RD_X9_nonsplit (
@@ -1707,6 +7420,45 @@ module TDP36K_BRAM_WR_X1_RD_X9_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -1780,6 +7532,45 @@ module TDP36K_BRAM_WR_X1_RD_X18_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X1_RD_X36_nonsplit (
@@ -1851,6 +7642,45 @@ module TDP36K_BRAM_WR_X1_RD_X36_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -1927,6 +7757,45 @@ module TDP36K_BRAM_WR_X2_RD_X1_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X2_RD_X2_nonsplit (
@@ -1998,6 +7867,45 @@ module TDP36K_BRAM_WR_X2_RD_X2_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2071,6 +7979,45 @@ module TDP36K_BRAM_WR_X2_RD_X4_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X2_RD_X9_nonsplit (
@@ -2142,6 +8089,45 @@ module TDP36K_BRAM_WR_X2_RD_X9_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2215,6 +8201,45 @@ module TDP36K_BRAM_WR_X2_RD_X18_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify  
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X2_RD_X36_nonsplit (
@@ -2286,6 +8311,45 @@ module TDP36K_BRAM_WR_X2_RD_X36_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2362,6 +8426,45 @@ module TDP36K_BRAM_WR_X4_RD_X1_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X4_RD_X2_nonsplit (
@@ -2433,6 +8536,45 @@ module TDP36K_BRAM_WR_X4_RD_X2_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2506,6 +8648,45 @@ module TDP36K_BRAM_WR_X4_RD_X4_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X4_RD_X9_nonsplit (
@@ -2577,6 +8758,45 @@ module TDP36K_BRAM_WR_X4_RD_X9_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2650,6 +8870,45 @@ module TDP36K_BRAM_WR_X4_RD_X18_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X4_RD_X36_nonsplit (
@@ -2721,6 +8980,45 @@ module TDP36K_BRAM_WR_X4_RD_X36_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2797,6 +9095,45 @@ module TDP36K_BRAM_WR_X9_RD_X1_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X9_RD_X2_nonsplit (
@@ -2868,6 +9205,45 @@ module TDP36K_BRAM_WR_X9_RD_X2_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -2941,6 +9317,45 @@ module TDP36K_BRAM_WR_X9_RD_X4_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X9_RD_X9_nonsplit (
@@ -3012,6 +9427,45 @@ module TDP36K_BRAM_WR_X9_RD_X9_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3085,6 +9539,45 @@ module TDP36K_BRAM_WR_X9_RD_X18_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X9_RD_X36_nonsplit (
@@ -3156,6 +9649,45 @@ module TDP36K_BRAM_WR_X9_RD_X36_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3232,6 +9764,45 @@ module TDP36K_BRAM_WR_X18_RD_X1_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X18_RD_X2_nonsplit (
@@ -3303,6 +9874,45 @@ module TDP36K_BRAM_WR_X18_RD_X2_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3376,6 +9986,45 @@ module TDP36K_BRAM_WR_X18_RD_X4_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X18_RD_X9_nonsplit (
@@ -3447,6 +10096,45 @@ module TDP36K_BRAM_WR_X18_RD_X9_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3520,6 +10208,45 @@ module TDP36K_BRAM_WR_X18_RD_X18_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X18_RD_X36_nonsplit (
@@ -3591,6 +10318,45 @@ module TDP36K_BRAM_WR_X18_RD_X36_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3667,6 +10433,45 @@ module TDP36K_BRAM_WR_X36_RD_X1_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X36_RD_X2_nonsplit (
@@ -3738,6 +10543,45 @@ module TDP36K_BRAM_WR_X36_RD_X2_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3811,6 +10655,45 @@ module TDP36K_BRAM_WR_X36_RD_X4_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X36_RD_X9_nonsplit (
@@ -3882,6 +10765,45 @@ module TDP36K_BRAM_WR_X36_RD_X9_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+	
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -3955,6 +10877,45 @@ module TDP36K_BRAM_WR_X36_RD_X18_nonsplit (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X36_RD_X36_nonsplit (
@@ -4026,6 +10987,45 @@ module TDP36K_BRAM_WR_X36_RD_X36_nonsplit (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -4102,6 +11102,45 @@ module TDP36K_BRAM_WR_X1_RD_X1_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X1_RD_X2_split (
@@ -4173,6 +11212,45 @@ module TDP36K_BRAM_WR_X1_RD_X2_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -4246,6 +11324,45 @@ module TDP36K_BRAM_WR_X1_RD_X4_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X1_RD_X9_split (
@@ -4318,6 +11435,45 @@ module TDP36K_BRAM_WR_X1_RD_X9_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X1_RD_X18_split (
@@ -4389,6 +11545,45 @@ module TDP36K_BRAM_WR_X1_RD_X18_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -4465,6 +11660,45 @@ module TDP36K_BRAM_WR_X2_RD_X1_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X2_RD_X2_split (
@@ -4536,6 +11770,45 @@ module TDP36K_BRAM_WR_X2_RD_X2_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -4609,6 +11882,45 @@ module TDP36K_BRAM_WR_X2_RD_X4_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X2_RD_X9_split (
@@ -4681,6 +11993,45 @@ module TDP36K_BRAM_WR_X2_RD_X9_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X2_RD_X18_split (
@@ -4752,6 +12103,45 @@ module TDP36K_BRAM_WR_X2_RD_X18_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -4828,6 +12218,45 @@ module TDP36K_BRAM_WR_X4_RD_X1_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X4_RD_X2_split (
@@ -4899,6 +12328,45 @@ module TDP36K_BRAM_WR_X4_RD_X2_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -4972,6 +12440,45 @@ module TDP36K_BRAM_WR_X4_RD_X4_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X4_RD_X9_split (
@@ -5044,6 +12551,45 @@ module TDP36K_BRAM_WR_X4_RD_X9_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X4_RD_X18_split (
@@ -5115,6 +12661,45 @@ module TDP36K_BRAM_WR_X4_RD_X18_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -5191,6 +12776,45 @@ module TDP36K_BRAM_WR_X9_RD_X1_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X9_RD_X2_split (
@@ -5262,6 +12886,45 @@ module TDP36K_BRAM_WR_X9_RD_X2_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -5335,6 +12998,45 @@ module TDP36K_BRAM_WR_X9_RD_X4_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X9_RD_X9_split (
@@ -5407,6 +13109,45 @@ module TDP36K_BRAM_WR_X9_RD_X9_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X9_RD_X18_split (
@@ -5478,6 +13219,45 @@ module TDP36K_BRAM_WR_X9_RD_X18_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -5554,6 +13334,45 @@ module TDP36K_BRAM_WR_X18_RD_X1_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X18_RD_X2_split (
@@ -5625,6 +13444,45 @@ module TDP36K_BRAM_WR_X18_RD_X2_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -5698,6 +13556,45 @@ module TDP36K_BRAM_WR_X18_RD_X4_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
 module TDP36K_BRAM_WR_X18_RD_X9_split (
@@ -5769,6 +13666,45 @@ module TDP36K_BRAM_WR_X18_RD_X9_split (
         .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
         .FLUSH2_i   (FLUSH2_i)
     );
+
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
 
 endmodule
 
@@ -5842,5 +13778,6292 @@ module TDP36K_BRAM_WR_X18_RD_X18_split (
         .FLUSH2_i   (FLUSH2_i)
     );
 
+`ifdef SDF_SIM
+	specify
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
 endmodule
 
+//=================================================================================
+
+module SFIFO_18K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    CLK,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+  
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+  parameter UPAE_DBITS = 11'd10;
+  parameter UPAF_DBITS = 11'd10;
+
+  input wire CLK;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+ 
+ 	BRAM2x18_SFIFO  #(
+      .WR_DATA_WIDTH(WR_DATA_WIDTH), 
+      .RD_DATA_WIDTH(RD_DATA_WIDTH),
+      .UPAE_DBITS1(UPAE_DBITS),
+      .UPAF_DBITS1(UPAF_DBITS),
+      .UPAE_DBITS2(),
+      .UPAF_DBITS2()     
+       ) U1
+      (
+      .DIN1(DIN),
+      .PUSH1(PUSH),
+      .POP1(POP),
+      .CLK1(CLK),
+      .Async_Flush1(Async_Flush),
+      .Overrun_Error1(Overrun_Error),
+      .Full_Watermark1(Full_Watermark),
+      .Almost_Full1(Almost_Full),
+      .Full1(Full),
+      .Underrun_Error1(Underrun_Error),
+      .Empty_Watermark1(Empty_Watermark),
+      .Almost_Empty1(Almost_Empty),
+      .Empty1(Empty),
+      .DOUT1(DOUT),
+      
+      .DIN2(),
+      .PUSH2(),
+      .POP2(),
+      .CLK2(),
+      .Async_Flush2(),
+      .Overrun_Error2(),
+      .Full_Watermark2(),
+      .Almost_Full2(),
+      .Full2(),
+      .Underrun_Error2(),
+      .Empty_Watermark2(),
+      .Almost_Empty2(),
+      .Empty2(),
+      .DOUT2()
+	);
+
+endmodule
+
+module AFIFO_18K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    Push_Clk,
+    Pop_Clk,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+  
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+  parameter UPAE_DBITS = 11'd10;
+  parameter UPAF_DBITS = 11'd10;
+
+  input wire Push_Clk, Pop_Clk;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+ 
+ 	BRAM2x18_AFIFO  #(
+      .WR_DATA_WIDTH(WR_DATA_WIDTH), 
+      .RD_DATA_WIDTH(RD_DATA_WIDTH),
+      .UPAE_DBITS1(UPAE_DBITS),
+      .UPAF_DBITS1(UPAF_DBITS),
+      .UPAE_DBITS2(),
+      .UPAF_DBITS2()       
+       ) U1
+      (
+      .DIN1(DIN),
+      .PUSH1(PUSH),
+      .POP1(POP),
+      .Push_Clk1(Push_Clk),
+      .Pop_Clk1(Pop_Clk),
+      .Async_Flush1(Async_Flush),
+      .Overrun_Error1(Overrun_Error),
+      .Full_Watermark1(Full_Watermark),
+      .Almost_Full1(Almost_Full),
+      .Full1(Full),
+      .Underrun_Error1(Underrun_Error),
+      .Empty_Watermark1(Empty_Watermark),
+      .Almost_Empty1(Almost_Empty),
+      .Empty1(Empty),
+      .DOUT1(DOUT),
+      
+      .DIN2(),
+      .PUSH2(),
+      .POP2(),
+      .Push_Clk2(),
+      .Pop_Clk2(),
+      .Async_Flush2(),
+      .Overrun_Error2(),
+      .Full_Watermark2(),
+      .Almost_Full2(),
+      .Full2(),
+      .Underrun_Error2(),
+      .Empty_Watermark2(),
+      .Almost_Empty2(),
+      .Empty2(),
+      .DOUT2()
+	);
+
+endmodule
+
+module BRAM2x18_SFIFO (
+    DIN1,
+    PUSH1,
+    POP1,
+    CLK1,
+    Async_Flush1,
+    Overrun_Error1,
+    Full_Watermark1,
+    Almost_Full1,
+    Full1,
+    Underrun_Error1,
+    Empty_Watermark1,
+    Almost_Empty1,
+    Empty1,
+    DOUT1,
+    
+    DIN2,
+    PUSH2,
+    POP2,
+    CLK2,
+    Async_Flush2,
+    Overrun_Error2,
+    Full_Watermark2,
+    Almost_Full2,
+    Full2,
+    Underrun_Error2,
+    Empty_Watermark2,
+    Almost_Empty2,
+    Empty2,
+    DOUT2
+);
+
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+
+  
+  parameter UPAE_DBITS1 = 11'd10;
+  parameter UPAF_DBITS1 = 11'd10;
+  
+  parameter UPAE_DBITS2 = 11'd10;
+  parameter UPAF_DBITS2 = 11'd10;
+  
+  localparam MODE_36 = 3'b011; // 36- or 32-bit
+  localparam MODE_18 = 3'b010; // 18- or 16-bit
+  localparam MODE_9 = 3'b001; // 9- or 8-bit
+  localparam MODE_4 = 3'b100; // 4-bit
+  localparam MODE_2 = 3'b110; // 2-bit
+  localparam MODE_1 = 3'b101; // 1-bit
+
+  input wire CLK1;
+  input wire PUSH1, POP1;
+  input wire [WR_DATA_WIDTH-1:0] DIN1;
+  input wire Async_Flush1;
+  output wire [RD_DATA_WIDTH-1:0] DOUT1;
+  output wire Almost_Full1, Almost_Empty1;
+  output wire Full1, Empty1;
+  output wire Full_Watermark1, Empty_Watermark1;
+  output wire Overrun_Error1, Underrun_Error1;
+  
+  input wire CLK2;
+  input wire PUSH2, POP2;
+  input wire [WR_DATA_WIDTH-1:0] DIN2;
+  input wire Async_Flush2;
+  output wire [RD_DATA_WIDTH-1:0] DOUT2;
+  output wire Almost_Full2, Almost_Empty2;
+  output wire Full2, Empty2;
+  output wire Full_Watermark2, Empty_Watermark2;
+  output wire Overrun_Error2, Underrun_Error2;
+  
+  wire [17:0] in_reg1;
+  wire [17:0] out_reg1;
+  wire [17:0] fifo1_flags;
+  
+  wire [17:0] in_reg2;
+  wire [17:0] out_reg2;
+  wire [17:0] fifo2_flags;
+  
+  wire Push_Clk1, Pop_Clk1;
+  wire Push_Clk2, Pop_Clk2;
+  assign Push_Clk1 = CLK1;
+  assign Pop_Clk1 = CLK1;
+  assign Push_Clk2 = CLK2;
+  assign Pop_Clk2 = CLK2;
+  
+  assign Overrun_Error1 = fifo1_flags[0];
+  assign Full_Watermark1 = fifo1_flags[1];
+  assign Almost_Full1 = fifo1_flags[2];
+  assign Full1 = fifo1_flags[3];
+  assign Underrun_Error1 = fifo1_flags[4];
+  assign Empty_Watermark1 = fifo1_flags[5];
+  assign Almost_Empty1 = fifo1_flags[6];
+  assign Empty1 = fifo1_flags[7];
+  
+  assign Overrun_Error2 = fifo2_flags[0];
+  assign Full_Watermark2 = fifo2_flags[1];
+  assign Almost_Full2 = fifo2_flags[2];
+  assign Full2 = fifo2_flags[3];
+  assign Underrun_Error2 = fifo2_flags[4];
+  assign Empty_Watermark2 = fifo2_flags[5];
+  assign Almost_Empty2 = fifo2_flags[6];
+  assign Empty2 = fifo2_flags[7];
+  
+  generate
+    if (WR_DATA_WIDTH == 9) begin
+      assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
+      assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
+    end else begin
+      assign in_reg1[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg1[WR_DATA_WIDTH-1:0] = DIN1[WR_DATA_WIDTH-1:0];
+      assign in_reg2[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate   
+  
+ case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_18, MODE_9, MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_18, MODE_9, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_9, MODE_18, MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_9, MODE_18, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 1 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );
+			end
+		endcase
+	end
+  endcase
+
+  generate
+    if (RD_DATA_WIDTH == 9) begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = {out_reg1[16], out_reg1[7:0]};
+      assign DOUT2[RD_DATA_WIDTH-1:0] = {out_reg2[16], out_reg2[7:0]};
+    end else begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = out_reg1[RD_DATA_WIDTH-1:0];
+      assign DOUT2[RD_DATA_WIDTH-1:0] = out_reg2[RD_DATA_WIDTH-1:0];
+    end
+  endgenerate 
+
+endmodule
+
+module BRAM2x18_AFIFO (
+    DIN1,
+    PUSH1,
+    POP1,
+    Push_Clk1,
+    Pop_Clk1,
+    Async_Flush1,
+    Overrun_Error1,
+    Full_Watermark1,
+    Almost_Full1,
+    Full1,
+    Underrun_Error1,
+    Empty_Watermark1,
+    Almost_Empty1,
+    Empty1,
+    DOUT1,
+    
+    DIN2,
+    PUSH2,
+    POP2,
+    Push_Clk2,
+    Pop_Clk2,
+    Async_Flush2,
+    Overrun_Error2,
+    Full_Watermark2,
+    Almost_Full2,
+    Full2,
+    Underrun_Error2,
+    Empty_Watermark2,
+    Almost_Empty2,
+    Empty2,
+    DOUT2
+);
+
+  parameter WR_DATA_WIDTH = 18;
+  parameter RD_DATA_WIDTH = 18;
+
+  
+  parameter UPAE_DBITS1 = 11'd10;
+  parameter UPAF_DBITS1 = 11'd10;
+  
+  parameter UPAE_DBITS2 = 11'd10;
+  parameter UPAF_DBITS2 = 11'd10;
+  
+  localparam MODE_36 = 3'b011; // 36- or 32-bit
+  localparam MODE_18 = 3'b010; // 18- or 16-bit
+  localparam MODE_9 = 3'b001; // 9- or 8-bit
+  localparam MODE_4 = 3'b100; // 4-bit
+  localparam MODE_2 = 3'b110; // 2-bit
+  localparam MODE_1 = 3'b101; // 1-bit
+
+  input wire Push_Clk1, Pop_Clk1;
+  input wire PUSH1, POP1;
+  input wire [WR_DATA_WIDTH-1:0] DIN1;
+  input wire Async_Flush1;
+  output wire [RD_DATA_WIDTH-1:0] DOUT1;
+  output wire Almost_Full1, Almost_Empty1;
+  output wire Full1, Empty1;
+  output wire Full_Watermark1, Empty_Watermark1;
+  output wire Overrun_Error1, Underrun_Error1;
+  
+  input wire Push_Clk2, Pop_Clk2;
+  input wire PUSH2, POP2;
+  input wire [WR_DATA_WIDTH-1:0] DIN2;
+  input wire Async_Flush2;
+  output wire [RD_DATA_WIDTH-1:0] DOUT2;
+  output wire Almost_Full2, Almost_Empty2;
+  output wire Full2, Empty2;
+  output wire Full_Watermark2, Empty_Watermark2;
+  output wire Overrun_Error2, Underrun_Error2;
+  
+  wire [17:0] in_reg1;
+  wire [17:0] out_reg1;
+  wire [17:0] fifo1_flags;
+  
+  wire [17:0] in_reg2;
+  wire [17:0] out_reg2;
+  wire [17:0] fifo2_flags;
+  
+  assign Overrun_Error1 = fifo1_flags[0];
+  assign Full_Watermark1 = fifo1_flags[1];
+  assign Almost_Full1 = fifo1_flags[2];
+  assign Full1 = fifo1_flags[3];
+  assign Underrun_Error1 = fifo1_flags[4];
+  assign Empty_Watermark1 = fifo1_flags[5];
+  assign Almost_Empty1 = fifo1_flags[6];
+  assign Empty1 = fifo1_flags[7];
+  
+  assign Overrun_Error2 = fifo2_flags[0];
+  assign Full_Watermark2 = fifo2_flags[1];
+  assign Almost_Full2 = fifo2_flags[2];
+  assign Full2 = fifo2_flags[3];
+  assign Underrun_Error2 = fifo2_flags[4];
+  assign Empty_Watermark2 = fifo2_flags[5];
+  assign Almost_Empty2 = fifo2_flags[6];
+  assign Empty2 = fifo2_flags[7];
+  
+  generate
+    if (WR_DATA_WIDTH == 9) begin
+      assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
+      assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
+    end else begin
+      assign in_reg1[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg1[WR_DATA_WIDTH-1:0] = DIN1[WR_DATA_WIDTH-1:0];
+      assign in_reg2[17:WR_DATA_WIDTH]  = 0;
+      assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate   
+  
+ case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_18, MODE_9, MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_18, MODE_9, MODE_18, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_9, MODE_18, MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_9, MODE_18, MODE_9, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );       
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b1,
+					UPAF_DBITS2, UPAE_DBITS2, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0,
+					1'b0, UPAF_DBITS1, 1'b0, UPAE_DBITS1, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        (* is_fifo = 1 *) 
+        (* sync_fifo = 0 *) 
+        (* is_split = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *)
+        (* wr_data_width = WR_DATA_WIDTH *) 
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg1[17:0]),
+          .WDATA_A2_i(in_reg2[17:0]),
+          .RDATA_A1_o(fifo1_flags),
+          .RDATA_A2_o(fifo2_flags),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk1),
+          .CLK_A2_i(Push_Clk2),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b1),
+          .WEN_A1_i(PUSH1),
+          .WEN_A2_i(PUSH2),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg1[17:0]),
+          .RDATA_B2_o(out_reg2[17:0]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk1),
+          .CLK_B2_i(Pop_Clk2),
+          .REN_B1_i(POP1),
+          .REN_B2_i(POP2),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush1),
+          .FLUSH2_i(Async_Flush2)
+        );
+			end
+		endcase
+	end
+  endcase
+
+  generate
+    if (RD_DATA_WIDTH == 9) begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = {out_reg1[16], out_reg1[7:0]};
+      assign DOUT2[RD_DATA_WIDTH-1:0] = {out_reg2[16], out_reg2[7:0]};
+    end else begin
+      assign DOUT1[RD_DATA_WIDTH-1:0] = out_reg1[RD_DATA_WIDTH-1:0];
+      assign DOUT2[RD_DATA_WIDTH-1:0] = out_reg2[RD_DATA_WIDTH-1:0];
+    end
+  endgenerate  
+
+endmodule
+
+module SFIFO_36K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    CLK,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+
+  parameter WR_DATA_WIDTH = 36;
+  parameter RD_DATA_WIDTH = 36;
+  parameter UPAE_DBITS = 12'd10;
+  parameter UPAF_DBITS = 12'd10;
+  
+  localparam MODE_36 = 3'b011; // 36- or 32-bit
+  localparam MODE_18 = 3'b010; // 18- or 16-bit
+  localparam MODE_9 = 3'b001; // 9- or 8-bit
+  localparam MODE_4 = 3'b100; // 4-bit
+  localparam MODE_2 = 3'b110; // 2-bit
+  localparam MODE_1 = 3'b101; // 1-bit
+
+  input wire CLK;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+  
+  wire [35:0] in_reg;
+  wire [35:0] out_reg;
+  wire [17:0] fifo_flags;
+  
+  wire [35:0] RD_DATA_CMPL;
+  wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
+  
+  wire Push_Clk, Pop_Clk;
+  
+  assign Push_Clk = CLK;
+  assign Pop_Clk = CLK;
+  
+  assign Overrun_Error = fifo_flags[0];
+  assign Full_Watermark = fifo_flags[1];
+  assign Almost_Full = fifo_flags[2];
+  assign Full = fifo_flags[3];
+  assign Underrun_Error = fifo_flags[4];
+  assign Empty_Watermark = fifo_flags[5];
+  assign Almost_Empty = fifo_flags[6];
+  assign Empty = fifo_flags[7];
+   
+  generate
+    if (WR_DATA_WIDTH == 36) begin
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end else if (WR_DATA_WIDTH > 18 && WR_DATA_WIDTH < 36) begin
+      assign in_reg[WR_DATA_WIDTH+1:18] = DIN[WR_DATA_WIDTH-1:16];
+      assign in_reg[17:0] = {2'b00,DIN[15:0]};
+    end else if (WR_DATA_WIDTH == 9) begin
+      assign in_reg[35:0] = {19'h0, DIN[8], 8'h0, DIN[7:0]};
+    end else begin
+      assign in_reg[35:WR_DATA_WIDTH]  = 0;
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate
+  
+  generate
+    if (RD_DATA_WIDTH == 36) begin
+      assign RD_DATA_CMPL = out_reg;
+    end else if (RD_DATA_WIDTH > 18 && RD_DATA_WIDTH < 36) begin
+      assign RD_DATA_CMPL  = {2'b00,out_reg[35:18],out_reg[15:0]};
+    end else if (RD_DATA_WIDTH == 9) begin
+      assign RD_DATA_CMPL = { 27'h0, out_reg[16], out_reg[7:0]};
+    end else begin
+      assign RD_DATA_CMPL = {18'h0, out_reg[17:0]};
+    end
+  endgenerate
+  
+  case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_18, MODE_9, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_18, MODE_9, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_36, MODE_9, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_36, MODE_9, MODE_36, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_9, MODE_18, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_9, MODE_18, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_36, MODE_18, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_36, MODE_18, MODE_36, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+		endcase
+	end
+	32, 36: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_9, MODE_36, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_9, MODE_36, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_18, MODE_36, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_18, MODE_36, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );        
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b1
+				};
+        (* is_fifo = 1 *)
+        (* sync_fifo = 1 *)
+        (* rd_data_width = RD_DATA_WIDTH *) 
+        (* wr_data_width = WR_DATA_WIDTH *)
+        TDP36K U1 (
+          .RESET_ni(1'b1),
+          .WDATA_A1_i(in_reg[17:0]),
+          .WDATA_A2_i(in_reg[35:18]),
+          .RDATA_A1_o(fifo_flags),
+          .RDATA_A2_o(),
+          .ADDR_A1_i(14'h0),
+          .ADDR_A2_i(14'h0),
+          .CLK_A1_i(Push_Clk),
+          .CLK_A2_i(1'b0),
+          .REN_A1_i(1'b1),
+          .REN_A2_i(1'b0),
+          .WEN_A1_i(PUSH),
+          .WEN_A2_i(1'b0),
+          .BE_A1_i(2'b11),
+          .BE_A2_i(2'b11),
+      
+          .WDATA_B1_i(18'h0),
+          .WDATA_B2_i(18'h0),
+          .RDATA_B1_o(out_reg[17:0]),
+          .RDATA_B2_o(out_reg[35:18]),
+          .ADDR_B1_i(14'h0),
+          .ADDR_B2_i(14'h0),
+          .CLK_B1_i(Pop_Clk),
+          .CLK_B2_i(1'b0),
+          .REN_B1_i(POP),
+          .REN_B2_i(1'b0),
+          .WEN_B1_i(1'b0),
+          .WEN_B2_i(1'b0),
+          .BE_B1_i(2'b11),
+          .BE_B2_i(2'b11),
+      
+          .FLUSH1_i(Async_Flush),
+          .FLUSH2_i(1'b0)
+        );
+			end
+		endcase
+	end
+ endcase
+
+  assign DOUT[RD_DATA_WIDTH-1 : 0] = RD_DATA_CMPL[RD_DATA_WIDTH-1 : 0];
+
+endmodule
+
+module AFIFO_36K_BLK (
+    DIN,
+    PUSH,
+    POP,
+    Push_Clk,
+    Pop_Clk,
+    Async_Flush,
+    Overrun_Error,
+    Full_Watermark,
+    Almost_Full,
+    Full,
+    Underrun_Error,
+    Empty_Watermark,
+    Almost_Empty,
+    Empty,
+    DOUT
+);
+
+  parameter WR_DATA_WIDTH = 36;
+  parameter RD_DATA_WIDTH = 36;
+  parameter UPAE_DBITS = 12'd10;
+  parameter UPAF_DBITS = 12'd10;
+
+  localparam MODE_36 = 3'b011; // 36- or 32-bit
+  localparam MODE_18 = 3'b010; // 18- or 16-bit
+  localparam MODE_9 = 3'b001; // 9- or 8-bit
+  localparam MODE_4 = 3'b100; // 4-bit
+  localparam MODE_2 = 3'b110; // 2-bit
+  localparam MODE_1 = 3'b101; // 1-bit
+
+  input wire Push_Clk, Pop_Clk;
+  input wire PUSH, POP;
+  input wire [WR_DATA_WIDTH-1:0] DIN;
+  input wire Async_Flush;
+  output wire [RD_DATA_WIDTH-1:0] DOUT;
+  output wire Almost_Full, Almost_Empty;
+  output wire Full, Empty;
+  output wire Full_Watermark, Empty_Watermark;
+  output wire Overrun_Error, Underrun_Error;
+  
+  wire [35:0] in_reg;
+  wire [35:0] out_reg;
+  wire [17:0] fifo_flags;
+  
+  wire [35:0] RD_DATA_CMPL;
+  wire [35:WR_DATA_WIDTH] WR_DATA_CMPL;
+  
+  assign Overrun_Error = fifo_flags[0];
+  assign Full_Watermark = fifo_flags[1];
+  assign Almost_Full = fifo_flags[2];
+  assign Full = fifo_flags[3];
+  assign Underrun_Error = fifo_flags[4];
+  assign Empty_Watermark = fifo_flags[5];
+  assign Almost_Empty = fifo_flags[6];
+  assign Empty = fifo_flags[7];
+   
+  generate
+    if (WR_DATA_WIDTH == 36) begin
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end else if (WR_DATA_WIDTH > 18 && WR_DATA_WIDTH < 36) begin
+      assign in_reg[WR_DATA_WIDTH+1:18] = DIN[WR_DATA_WIDTH-1:16];
+      assign in_reg[17:0] = {2'b00,DIN[15:0]};
+    end else if (WR_DATA_WIDTH == 9) begin
+      assign in_reg[35:0] = {19'h0, DIN[8], 8'h0, DIN[7:0]};
+    end else begin
+      assign in_reg[35:WR_DATA_WIDTH]  = 0;
+      assign in_reg[WR_DATA_WIDTH-1:0] = DIN[WR_DATA_WIDTH-1:0];
+    end
+  endgenerate
+  
+  generate
+    if (RD_DATA_WIDTH == 36) begin
+      assign RD_DATA_CMPL = out_reg;
+    end else if (RD_DATA_WIDTH > 18 && RD_DATA_WIDTH < 36) begin
+      assign RD_DATA_CMPL  = {2'b00,out_reg[35:18],out_reg[15:0]};
+    end else if (RD_DATA_WIDTH == 9) begin
+      assign RD_DATA_CMPL = { 27'h0, out_reg[16], out_reg[7:0]};
+    end else begin
+      assign RD_DATA_CMPL = {18'h0, out_reg[17:0]};
+    end
+  endgenerate
+  
+  case (RD_DATA_WIDTH)
+	8, 9: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_18, MODE_9, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_18, MODE_9, MODE_18, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_36, MODE_9, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_36, MODE_9, MODE_36, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+		endcase
+	end
+	16, 18: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_9, MODE_18, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_9, MODE_18, MODE_9, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_36, MODE_18, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_36, MODE_18, MODE_36, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+		endcase
+	end
+	32, 36: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_9, MODE_36, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_9, MODE_36, MODE_9, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_18, MODE_36, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_18, MODE_36, MODE_18, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+		endcase
+	end
+	default: begin
+		case (WR_DATA_WIDTH)
+			8, 9: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_9, MODE_9, MODE_9, MODE_9, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_9, MODE_9, MODE_9, MODE_9, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			16, 18: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_18, MODE_18, MODE_18, MODE_18, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_18, MODE_18, MODE_18, MODE_18, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			32, 36: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+			default: begin
+				defparam U1.MODE_BITS = { 1'b0,
+					11'd10, 11'd10, 4'd0, MODE_36, MODE_36, MODE_36, MODE_36, 1'd0,
+					UPAF_DBITS, UPAE_DBITS, 4'h1, MODE_36, MODE_36, MODE_36, MODE_36, 1'b0
+				};
+        
+            (* is_fifo = 1 *)
+            (* sync_fifo = 0 *)
+            (* rd_data_width = RD_DATA_WIDTH *) 
+            (* wr_data_width = WR_DATA_WIDTH *)
+            TDP36K U1 (
+              .RESET_ni(1'b1),
+              .WDATA_A1_i(in_reg[17:0]),
+              .WDATA_A2_i(in_reg[35:18]),
+              .RDATA_A1_o(fifo_flags),
+              .RDATA_A2_o(),
+              .ADDR_A1_i(14'h0),
+              .ADDR_A2_i(14'h0),
+              .CLK_A1_i(Push_Clk),
+              .CLK_A2_i(1'b0),
+              .REN_A1_i(1'b1),
+              .REN_A2_i(1'b0),
+              .WEN_A1_i(PUSH),
+              .WEN_A2_i(1'b0),
+              .BE_A1_i(2'b11),
+              .BE_A2_i(2'b11),
+          
+              .WDATA_B1_i(18'h0),
+              .WDATA_B2_i(18'h0),
+              .RDATA_B1_o(out_reg[17:0]),
+              .RDATA_B2_o(out_reg[35:18]),
+              .ADDR_B1_i(14'h0),
+              .ADDR_B2_i(14'h0),
+              .CLK_B1_i(Pop_Clk),
+              .CLK_B2_i(1'b0),
+              .REN_B1_i(POP),
+              .REN_B2_i(1'b0),
+              .WEN_B1_i(1'b0),
+              .WEN_B2_i(1'b0),
+              .BE_B1_i(2'b11),
+              .BE_B2_i(2'b11),
+          
+              .FLUSH1_i(Async_Flush),
+              .FLUSH2_i(1'b0)
+            );
+  
+			end
+		endcase
+	end
+ endcase
+
+  assign DOUT[RD_DATA_WIDTH-1 : 0] = RD_DATA_CMPL[RD_DATA_WIDTH-1 : 0];
+
+endmodule  
+
+//===============================================================================
+module TDP36K_FIFO_ASYNC_WR_X9_RD_X9_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X9_RD_X18_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+ 
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X9_RD_X36_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X18_RD_X9_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X18_RD_X18_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X18_RD_X36_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X36_RD_X9_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X36_RD_X18_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X36_RD_X36_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+
+module TDP36K_FIFO_ASYNC_WR_X9_RD_X9_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+   
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X9_RD_X18_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X18_RD_X9_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_ASYNC_WR_X18_RD_X18_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X9_RD_X9_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+    
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X9_RD_X18_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X9_RD_X36_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X18_RD_X9_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X18_RD_X18_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X18_RD_X36_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X36_RD_X9_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X36_RD_X18_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X36_RD_X36_nonsplit (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+
+module TDP36K_FIFO_SYNC_WR_X9_RD_X9_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X9_RD_X18_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X18_RD_X9_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule
+
+module TDP36K_FIFO_SYNC_WR_X18_RD_X18_split (
+    RESET_ni,
+    WEN_A1_i,   WEN_B1_i,
+    REN_A1_i,   REN_B1_i,
+    CLK_A1_i,   CLK_B1_i,
+    BE_A1_i,    BE_B1_i,
+    ADDR_A1_i,  ADDR_B1_i,
+    WDATA_A1_i, WDATA_B1_i,
+    RDATA_A1_o, RDATA_B1_o,
+    FLUSH1_i,
+    WEN_A2_i,   WEN_B2_i,
+    REN_A2_i,   REN_B2_i,
+    CLK_A2_i,   CLK_B2_i,
+    BE_A2_i,    BE_B2_i,
+    ADDR_A2_i,  ADDR_B2_i,
+    WDATA_A2_i, WDATA_B2_i,
+    RDATA_A2_o, RDATA_B2_o,
+    FLUSH2_i
+);
+    parameter [80:0] MODE_BITS = 81'd0;
+
+    input wire  RESET_ni;
+    input wire  WEN_A1_i, WEN_B1_i;
+    input wire  REN_A1_i, REN_B1_i;
+    input wire  WEN_A2_i, WEN_B2_i;
+    input wire  REN_A2_i, REN_B2_i;
+
+    (* clkbuf_sink *)
+    input wire  CLK_A1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B1_i;
+    (* clkbuf_sink *)
+    input wire  CLK_A2_i;
+    (* clkbuf_sink *)
+    input wire  CLK_B2_i;
+
+    input wire  [ 1:0] BE_A1_i,    BE_B1_i;
+    input wire  [14:0] ADDR_A1_i,  ADDR_B1_i;
+    input wire  [17:0] WDATA_A1_i, WDATA_B1_i;
+    output wire [17:0] RDATA_A1_o, RDATA_B1_o;
+
+    input wire  FLUSH1_i;
+
+    input wire  [ 1:0] BE_A2_i,    BE_B2_i;
+    input wire  [13:0] ADDR_A2_i,  ADDR_B2_i;
+    input wire  [17:0] WDATA_A2_i, WDATA_B2_i;
+    output wire [17:0] RDATA_A2_o, RDATA_B2_o;
+
+    input wire  FLUSH2_i;
+
+    TDP36K #(.MODE_BITS(MODE_BITS)) bram (
+        .RESET_ni   (RESET_ni),   
+        .WEN_A1_i   (WEN_A1_i),   .WEN_B1_i   (WEN_B1_i),
+        .REN_A1_i   (REN_A1_i),   .REN_B1_i   (REN_B1_i),
+        .CLK_A1_i   (CLK_A1_i),   .CLK_B1_i   (CLK_B1_i),
+        .BE_A1_i    (BE_A1_i),    .BE_B1_i    (BE_B1_i),
+        .ADDR_A1_i  (ADDR_A1_i),  .ADDR_B1_i  (ADDR_B1_i),
+        .WDATA_A1_i (WDATA_A1_i), .WDATA_B1_i (WDATA_B1_i),
+        .RDATA_A1_o (RDATA_A1_o), .RDATA_B1_o (RDATA_B1_o),
+        .FLUSH1_i   (FLUSH1_i),
+        .WEN_A2_i   (WEN_A2_i),   .WEN_B2_i   (WEN_B2_i),
+        .REN_A2_i   (REN_A2_i),   .REN_B2_i   (REN_B2_i),
+        .CLK_A2_i   (CLK_A2_i),   .CLK_B2_i   (CLK_B2_i),
+        .BE_A2_i    (BE_A2_i),    .BE_B2_i    (BE_B2_i),
+        .ADDR_A2_i  (ADDR_A2_i),  .ADDR_B2_i  (ADDR_B2_i),
+        .WDATA_A2_i (WDATA_A2_i), .WDATA_B2_i (WDATA_B2_i),
+        .RDATA_A2_o (RDATA_A2_o), .RDATA_B2_o (RDATA_B2_o),
+        .FLUSH2_i   (FLUSH2_i)
+    );
+
+`ifdef SDF_SIM
+	specify
+    (FLUSH1_i => RDATA_A1_o[0]) = 0;
+    (FLUSH1_i => RDATA_A1_o[1]) = 0;
+    (FLUSH1_i => RDATA_A1_o[2]) = 0;
+    (FLUSH1_i => RDATA_A1_o[3]) = 0;
+    (FLUSH1_i => RDATA_A1_o[4]) = 0;
+    (FLUSH1_i => RDATA_A1_o[5]) = 0;
+    (FLUSH1_i => RDATA_A1_o[6]) = 0;
+    (FLUSH1_i => RDATA_A1_o[7]) = 0;
+    (FLUSH2_i => RDATA_A2_o[0]) = 0;
+    (FLUSH2_i => RDATA_A2_o[1]) = 0;
+    (FLUSH2_i => RDATA_A2_o[2]) = 0;
+    (FLUSH2_i => RDATA_A2_o[3]) = 0;
+    (FLUSH2_i => RDATA_A2_o[4]) = 0;
+    (FLUSH2_i => RDATA_A2_o[5]) = 0;
+    (FLUSH2_i => RDATA_A2_o[6]) = 0;
+    (FLUSH2_i => RDATA_A2_o[7]) = 0;    
+		(negedge RESET_ni => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(negedge RESET_ni => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(negedge RESET_ni => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(negedge RESET_ni => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+		(posedge CLK_A1_i => (RDATA_A1_o +: WDATA_A1_i)) = 0;
+		(posedge CLK_B1_i => (RDATA_B1_o +: WDATA_B1_i)) = 0;
+		(posedge CLK_A2_i => (RDATA_A2_o +: WDATA_A2_i)) = 0;
+		(posedge CLK_B2_i => (RDATA_B2_o +: WDATA_B2_i)) = 0;
+    $setuphold(posedge CLK_A1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A1_i, FLUSH1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WEN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, REN_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, BE_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, ADDR_A1_i, 0, 0);
+		$setuphold(posedge CLK_A1_i, WDATA_A1_i, 0, 0);
+    $setuphold(posedge CLK_B1_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B1_i, WEN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, REN_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, BE_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, ADDR_B1_i, 0, 0);
+		$setuphold(posedge CLK_B1_i, WDATA_B1_i, 0, 0);
+    $setuphold(posedge CLK_A2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_A2_i, FLUSH2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WEN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, REN_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, BE_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, ADDR_A2_i, 0, 0);
+		$setuphold(posedge CLK_A2_i, WDATA_A2_i, 0, 0);
+    $setuphold(posedge CLK_B2_i, RESET_ni, 0, 0);
+		$setuphold(posedge CLK_B2_i, WEN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, REN_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, BE_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, ADDR_B2_i, 0, 0);
+		$setuphold(posedge CLK_B2_i, WDATA_B2_i, 0, 0);
+	endspecify
+`endif
+
+endmodule

--- a/ql-qlf-plugin/qlf_k6n10f/brams_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_sim.v
@@ -14075,7 +14075,10 @@ module BRAM2x18_SFIFO (
   assign Empty2 = fifo2_flags[7];
   
   generate
-    if (WR_DATA_WIDTH == 9) begin
+    if (WR_DATA_WIDTH == 18) begin
+      assign in_reg1[17:0] = DIN1[17:0];
+      assign in_reg2[17:0] = DIN2[17:0];
+    end else if (WR_DATA_WIDTH == 9) begin
       assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
       assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
     end else begin
@@ -14084,7 +14087,7 @@ module BRAM2x18_SFIFO (
       assign in_reg2[17:WR_DATA_WIDTH]  = 0;
       assign in_reg2[WR_DATA_WIDTH-1:0] = DIN2[WR_DATA_WIDTH-1:0];
     end
-  endgenerate   
+  endgenerate     
   
  case (RD_DATA_WIDTH)
 	8, 9: begin
@@ -14625,7 +14628,10 @@ module BRAM2x18_AFIFO (
   assign Empty2 = fifo2_flags[7];
   
   generate
-    if (WR_DATA_WIDTH == 9) begin
+    if (WR_DATA_WIDTH == 18) begin
+      assign in_reg1[17:0] = DIN1[17:0];
+      assign in_reg2[17:0] = DIN2[17:0];
+    end else if (WR_DATA_WIDTH == 9) begin
       assign in_reg1[17:0] = {1'b0, DIN1[8], 8'h0, DIN1[7:0]};
       assign in_reg2[17:0] = {1'b0, DIN2[8], 8'h0, DIN2[7:0]};
     end else begin

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+`timescale 1ps/1ps
+
 `default_nettype none
 
 (* abc9_flop, lib_whitebox *)

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -394,15 +394,17 @@ struct SynthQuickLogicPass : public ScriptPass {
                                   ww.second, rw.second, ww.first, rw.first);
                         run(cmd);
 
-                        auto cmd1 = stringf("chtype -set TDP36K_FIFO_ASYNC_WR_X%d_RD_X%d_split t:TDP36K a:is_fifo=1 %%i a:sync_fifo=0 %%i a:is_split=1 %%i a:wr_data_width=%d "
-                                       "%%i a:rd_data_width=%d %%i",
-                                       ww.second, rw.second, ww.first, rw.first);
+                        auto cmd1 = stringf("chtype -set TDP36K_FIFO_ASYNC_WR_X%d_RD_X%d_split t:TDP36K a:is_fifo=1 %%i a:sync_fifo=0 %%i "
+                                            "a:is_split=1 %%i a:wr_data_width=%d "
+                                            "%%i a:rd_data_width=%d %%i",
+                                            ww.second, rw.second, ww.first, rw.first);
                         run(cmd1);
-                    
-                        auto cmd2 = stringf("chtype -set TDP36K_FIFO_SYNC_WR_X%d_RD_X%d_split t:TDP36K a:is_fifo=1 %%i a:sync_fifo=1 %%i a:is_split=1 %%i a:wr_data_width=%d "
-                                       "%%i a:rd_data_width=%d %%i",
-                                       ww.second, rw.second, ww.first, rw.first);
-                        run(cmd2);                    
+
+                        auto cmd2 = stringf("chtype -set TDP36K_FIFO_SYNC_WR_X%d_RD_X%d_split t:TDP36K a:is_fifo=1 %%i a:sync_fifo=1 %%i "
+                                            "a:is_split=1 %%i a:wr_data_width=%d "
+                                            "%%i a:rd_data_width=%d %%i",
+                                            ww.second, rw.second, ww.first, rw.first);
+                        run(cmd2);
                     }
                 }
 
@@ -412,16 +414,16 @@ struct SynthQuickLogicPass : public ScriptPass {
                           "chtype -set TDP36K_BRAM_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_inferred=1 %%i a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
                           ww.second, rw.second, ww.first, rw.first);
                         run(cmd);
-                        
-                        auto cmd1 = stringf(
-                          "chtype -set TDP36K_FIFO_ASYNC_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_fifo=1 %%i a:sync_fifo=0 %%i a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
-                          ww.second, rw.second, ww.first, rw.first);
+
+                        auto cmd1 = stringf("chtype -set TDP36K_FIFO_ASYNC_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_fifo=1 %%i a:sync_fifo=0 %%i "
+                                            "a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
+                                            ww.second, rw.second, ww.first, rw.first);
                         run(cmd1);
-                    
-                        auto cmd2 = stringf(
-                          "chtype -set TDP36K_FIFO_SYNC_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_fifo=1 %%i a:sync_fifo=1 %%i a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
-                          ww.second, rw.second, ww.first, rw.first);
-                          run(cmd2);
+
+                        auto cmd2 = stringf("chtype -set TDP36K_FIFO_SYNC_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_fifo=1 %%i a:sync_fifo=1 %%i "
+                                            "a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
+                                            ww.second, rw.second, ww.first, rw.first);
+                        run(cmd2);
                     }
                 }
             }

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -393,6 +393,16 @@ struct SynthQuickLogicPass : public ScriptPass {
                                   "%%i a:rd_data_width=%d %%i",
                                   ww.second, rw.second, ww.first, rw.first);
                         run(cmd);
+
+                        auto cmd1 = stringf("chtype -set TDP36K_FIFO_ASYNC_WR_X%d_RD_X%d_split t:TDP36K a:is_fifo=1 %%i a:sync_fifo=0 %%i a:is_split=1 %%i a:wr_data_width=%d "
+                                       "%%i a:rd_data_width=%d %%i",
+                                       ww.second, rw.second, ww.first, rw.first);
+                        run(cmd1);
+                    
+                        auto cmd2 = stringf("chtype -set TDP36K_FIFO_SYNC_WR_X%d_RD_X%d_split t:TDP36K a:is_fifo=1 %%i a:sync_fifo=1 %%i a:is_split=1 %%i a:wr_data_width=%d "
+                                       "%%i a:rd_data_width=%d %%i",
+                                       ww.second, rw.second, ww.first, rw.first);
+                        run(cmd2);                    
                     }
                 }
 
@@ -402,6 +412,16 @@ struct SynthQuickLogicPass : public ScriptPass {
                           "chtype -set TDP36K_BRAM_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_inferred=1 %%i a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
                           ww.second, rw.second, ww.first, rw.first);
                         run(cmd);
+                        
+                        auto cmd1 = stringf(
+                          "chtype -set TDP36K_FIFO_ASYNC_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_fifo=1 %%i a:sync_fifo=0 %%i a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
+                          ww.second, rw.second, ww.first, rw.first);
+                        run(cmd1);
+                    
+                        auto cmd2 = stringf(
+                          "chtype -set TDP36K_FIFO_SYNC_WR_X%d_RD_X%d_nonsplit t:TDP36K a:is_fifo=1 %%i a:sync_fifo=1 %%i a:wr_data_width=%d %%i a:rd_data_width=%d %%i",
+                          ww.second, rw.second, ww.first, rw.first);
+                          run(cmd2);
                     }
                 }
             }

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -37,26 +37,39 @@ TESTS = \
 #	qlf_k6n10_bram \
 
 SIM_TESTS = \
-    qlf_k6n10f/sim_dsp_mult_cfg_ports \
-    qlf_k6n10f/sim_dsp_mult_cfg_params \
-    qlf_k6n10f/sim_dsp_mult_r_cfg_ports \
-    qlf_k6n10f/sim_dsp_mult_r_cfg_params \
-    qlf_k6n10f/sim_dsp_fir_cfg_ports \
-    qlf_k6n10f/sim_dsp_fir_cfg_params \
-    qlf_k6n10f/sim_dsp_simd_cfg_ports \
-    qlf_k6n10f/sim_dsp_simd_cfg_params \
-    qlf_k6n10f/sim_tc36fifo
+     qlf_k6n10f/sim_dsp_mult_cfg_ports \
+     qlf_k6n10f/sim_dsp_mult_cfg_ports \
+     qlf_k6n10f/sim_dsp_mult_cfg_params \
+     qlf_k6n10f/sim_dsp_mult_r_cfg_ports \
+     qlf_k6n10f/sim_dsp_mult_r_cfg_params \
+     qlf_k6n10f/sim_dsp_fir_cfg_ports \
+     qlf_k6n10f/sim_dsp_fir_cfg_params \
+     qlf_k6n10f/sim_dsp_simd_cfg_ports \
+     qlf_k6n10f/sim_dsp_simd_cfg_params \
+     qlf_k6n10f/sim_tc36fifo
 
 # Those tests perform synthesis and simulation of synthesis results
 POST_SYNTH_SIM_TESTS = \
-    qlf_k6n10f/bram_tdp \
-    qlf_k6n10f/bram_sdp \
-    qlf_k6n10f/bram_tdp_split \
-    qlf_k6n10f/bram_sdp_split \
-    qlf_k6n10f/dsp_mult_post_synth_sim \
-    qlf_k6n10f/dsp_simd_post_synth_sim \
-    qlf_k6n10f/bram_asymmetric_wider_write \
-    qlf_k6n10f/bram_asymmetric_wider_read
+     qlf_k6n10f/asymmetric_bram36k_sfifo \
+     qlf_k6n10f/asymmetric_bram36k_afifo \
+     qlf_k6n10f/bram36k_sfifo \
+     qlf_k6n10f/bram36k_afifo \
+     qlf_k6n10f/bram18k_afifo \
+     qlf_k6n10f/bram18k_sfifo \
+     qlf_k6n10f/bram18k_tdp \
+     qlf_k6n10f/bram36k_tdp \
+     qlf_k6n10f/bram18k_sdp \
+     qlf_k6n10f/bram36k_sdp \
+     qlf_k6n10f/asymmetric_bram36k_sdp \
+     qlf_k6n10f/asymmetric_bram18k_sdp \
+     qlf_k6n10f/bram_tdp \
+     qlf_k6n10f/bram_sdp \
+     qlf_k6n10f/bram_tdp_split \
+     qlf_k6n10f/bram_sdp_split \
+     qlf_k6n10f/dsp_mult_post_synth_sim \
+     qlf_k6n10f/dsp_simd_post_synth_sim \
+     qlf_k6n10f/bram_asymmetric_wider_write \
+     qlf_k6n10f/bram_asymmetric_wider_read
 
 include $(shell pwd)/../../Makefile_test.common
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.tcl
@@ -1,0 +1,27 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save asymmetric_bram18k_sdp
+
+select spram_9x2048_18x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_9x2048_18x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_9x2048_18x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X18_split
+
+select -clear
+design -load asymmetric_bram18k_sdp
+select spram_18x1024_9x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_18x1024_9x2048 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_18x1024_9x2048_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X9_split

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.v
@@ -1,0 +1,93 @@
+module spram_9x2048_18x1024 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 11;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 18;
+parameter BE_WIDTH = 1;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x18_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(1'b1),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_18x1024_9x2048 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 11;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 9;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x18_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module spram_9x2048_18x1024 (
     WEN_i,
     REN_i,

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/Makefile
@@ -1,0 +1,39 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = asymmetric_bram18k_sdp_tb.v
+POST_SYNTH = spram_9x2048_18x1024_post_synth spram_18x1024_9x2048_post_synth
+ADDR_WIDTH0 = 11 10
+DATA_WIDTH0 = 9 18
+ADDR_WIDTH1 = 10 11
+DATA_WIDTH1 = 18 9
+TOP = spram_9x2048_18x1024 spram_18x1024_9x2048
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/Makefile
@@ -1,10 +1,18 @@
-# Copyright (C) 2019-2022 The SymbiFlow Authors
+# Copyright 2020-2022 F4PGA Authors
 #
-# Use of this source code is governed by a ISC-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/ISC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# SPDX-License-Identifier: ISC
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = asymmetric_bram18k_sdp_tb.v
 POST_SYNTH = spram_9x2048_18x1024_post_synth spram_18x1024_9x2048_post_synth

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-#FIXME: $(call simulate_post_synth,3)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/asymmetric_bram18k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/asymmetric_bram18k_sdp_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk_0;
-  reg clk_1;
+	reg clk_1;
 	reg rce;
 	reg [`ADDR_WIDTH1-1:0] ra;
 	wire [`DATA_WIDTH1-1:0] rq;
@@ -34,12 +34,11 @@ module TB;
 	initial clk_0 = 0;
 	initial clk_1 = 0;
 	initial ra = 0;
-  initial wa = 0;
-  initial wd = 0;
+	initial wa = 0;
+	initial wd = 0;
 	initial rce = 0;
-  initial wce = 0;
+	initial wce = 0;
 	initial forever #(PERIOD / 2.0) clk_0 = ~clk_0;
-  //initial forever #(PERIOD / 2.0) clk_1 = ~clk_1;
 	initial begin
 		#(PERIOD / 4.0);
 		forever #(PERIOD / 2.0) clk_1 = ~clk_1;
@@ -72,76 +71,76 @@ module TB;
 			error_0_cnt <= error_0_cnt + 1'b1;
 	end
 
-case (`STRINGIFY(`TOP))
-"spram_9x2048_18x1024": begin
-	initial #(1) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk_0) begin
-				wa = a[`ADDR_WIDTH0-1:0];
-				wd = a[9:1];
-				wce = 1;
-			end
-			@(posedge clk_0) begin
-				#(PERIOD/10) wce = 0;
-			end
-		end
-		// Read data
-		read_test_0 = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(negedge clk_1) begin
-				ra = a;
-				rce = 1;
-			end
-			@(posedge clk_1) begin
-        expected_0 <= {a[8],a[8],a[7:0],a[7:0]};
-				#(PERIOD/10) rce = 0;
-				if ( rq !== expected_0) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+	case (`STRINGIFY(`TOP))
+	"spram_9x2048_18x1024": begin
+		initial #(1) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk_0) begin
+					wa = a[`ADDR_WIDTH0-1:0];
+					wd = a[9:1];
+					wce = 1;
+				end
+				@(posedge clk_0) begin
+					#(PERIOD/10) wce = 0;
 				end
 			end
-		end
-		done_0 = 1'b1;
-    a = 0;
-	end
-end
-"spram_18x1024_9x2048": begin
-	initial #(1) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk_0) begin
-				wa = a[`ADDR_WIDTH0-1:0];
-				wd = {a[8],a[8],a[7:0],a[7:0]};
-				wce = 1;
-			end
-			@(posedge clk_0) begin
-				#(PERIOD/10) wce = 0;
-			end
-		end
-		// Read data
-		read_test_0 = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(negedge clk_1) begin
-				ra = a;
-				rce = 1;
-			end
-			@(posedge clk_1) begin
-        expected_0 <= {a[9:1]};
-				#(PERIOD/10) rce = 0;
-				if ( rq !== expected_0) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+			// Read data
+			read_test_0 = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(negedge clk_1) begin
+					ra = a;
+					rce = 1;
+				end
+				@(posedge clk_1) begin
+					expected_0 <= {a[8],a[8],a[7:0],a[7:0]};				
+					#(PERIOD/10) rce = 0;
+					if ( rq !== expected_0) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end
 				end
 			end
+			done_0 = 1'b1;
+			a = 0;		
 		end
-		done_0 = 1'b1;
-    a = 0;
 	end
-end  
-endcase
+	"spram_18x1024_9x2048": begin
+		initial #(1) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk_0) begin
+					wa = a[`ADDR_WIDTH0-1:0];
+					wd = {a[8],a[8],a[7:0],a[7:0]};
+					wce = 1;
+				end
+				@(posedge clk_0) begin
+					#(PERIOD/10) wce = 0;
+				end
+			end
+			// Read data
+			read_test_0 = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(negedge clk_1) begin
+					ra = a;
+					rce = 1;
+				end
+				@(posedge clk_1) begin				
+					expected_0 <= {a[9:1]};
+					#(PERIOD/10) rce = 0;
+					if ( rq !== expected_0) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end
+				end
+			end
+			done_0 = 1'b1;
+			a = 0;		
+		end
+	end	 
+	endcase
 
 	// Scan for simulation finish
 	always @(posedge clk_1) begin
@@ -153,7 +152,7 @@ endcase
 		"spram_9x2048_18x1024": begin
 			spram_9x2048_18x1024 #() bram (
 				.clock0(clk_0),
-        .clock1(clk_1),        
+				.clock1(clk_1),			
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -165,7 +164,7 @@ endcase
 		"spram_18x1024_9x2048": begin
 			spram_18x1024_9x2048 #() bram (
 				.clock0(clk_0),
-        .clock1(clk_1),        
+				.clock1(clk_1),			
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/asymmetric_bram18k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/asymmetric_bram18k_sdp_tb.v
@@ -1,0 +1,170 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_0;
+  reg clk_1;
+	reg rce;
+	reg [`ADDR_WIDTH1-1:0] ra;
+	wire [`DATA_WIDTH1-1:0] rq;
+	reg wce;
+	reg [`ADDR_WIDTH0-1:0] wa;
+	reg [`DATA_WIDTH0-1:0] wd;
+
+	initial clk_0 = 0;
+	initial clk_1 = 0;
+	initial ra = 0;
+  initial wa = 0;
+  initial wd = 0;
+	initial rce = 0;
+  initial wce = 0;
+	initial forever #(PERIOD / 2.0) clk_0 = ~clk_0;
+  //initial forever #(PERIOD / 2.0) clk_1 = ~clk_1;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_1 = ~clk_1;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_0;
+	initial done_0 = 1'b0;
+	wire done_sim = done_0;
+
+	reg [`DATA_WIDTH1-1:0] expected_0;
+
+	reg read_test_0;
+	initial read_test_0 = 0;
+
+
+	wire error_0 = (read_test_0) ? (rq !== expected_0) : 0;
+
+	integer error_0_cnt = 0;
+
+	always @ (posedge clk_1)
+	begin
+		if (error_0)
+			error_0_cnt <= error_0_cnt + 1'b1;
+	end
+
+case (`STRINGIFY(`TOP))
+"spram_9x2048_18x1024": begin
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa = a[`ADDR_WIDTH0-1:0];
+				wd = a[9:1];
+				wce = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk_1) begin
+        expected_0 <= {a[8],a[8],a[7:0],a[7:0]};
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+	end
+end
+"spram_18x1024_9x2048": begin
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa = a[`ADDR_WIDTH0-1:0];
+				wd = {a[8],a[8],a[7:0],a[7:0]};
+				wce = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk_1) begin
+        expected_0 <= {a[9:1]};
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+	end
+end  
+endcase
+
+	// Scan for simulation finish
+	always @(posedge clk_1) begin
+		if (done_sim)
+			$finish_and_return( (error_0_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"spram_9x2048_18x1024": begin
+			spram_9x2048_18x1024 #() bram (
+				.clock0(clk_0),
+        .clock1(clk_1),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_18x1024_9x2048": begin
+			spram_18x1024_9x2048 #() bram (
+				.clock0(clk_0),
+        .clock1(clk_1),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/asymmetric_bram18k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/sim/asymmetric_bram18k_sdp_tb.v
@@ -1,10 +1,18 @@
-// Copyright (C) 2019-2022 The SymbiFlow Authors
+// Copyright 2020-2022 F4PGA Authors
 //
-// Use of this source code is governed by a ISC-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/ISC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: ISC
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 `timescale 1ns/1ps
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.tcl
@@ -1,0 +1,49 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save asymmetric_bram36k_afifo
+
+select af4096x9_1024x36
+select *
+synth_quicklogic -family qlf_k6n10f -top af4096x9_1024x36 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af4096x9_1024x36_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X9_RD_X36_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_afifo
+select af2048x18_1024x36
+select *
+synth_quicklogic -family qlf_k6n10f -top af2048x18_1024x36 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af2048x18_1024x36_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X18_RD_X36_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_afifo
+select af2048x18_4098x9
+select *
+synth_quicklogic -family qlf_k6n10f -top af2048x18_4098x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af2048x18_4098x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X18_RD_X9_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_afifo
+select af1024x36_4098x9
+select *
+synth_quicklogic -family qlf_k6n10f -top af1024x36_4098x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af1024x36_4098x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X36_RD_X9_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module af4096x9_1024x36 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
 
 parameter WR_DATA_WIDTH = 9;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.v
@@ -33,7 +33,7 @@ output Overrun_Error, Underrun_Error;
 
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                 )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -53,8 +53,7 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af2048x18_1024x36 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -75,7 +74,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -95,8 +94,7 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af2048x18_4098x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -117,7 +115,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -137,8 +135,7 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af1024x36_4098x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -159,7 +156,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -179,6 +176,5 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.v
@@ -1,0 +1,168 @@
+module af4096x9_1024x36 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 36;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af2048x18_1024x36 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 36;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af2048x18_4098x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af1024x36_4098x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-#FIXME: $(call simulate_post_synth,3)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/Makefile
@@ -1,0 +1,43 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = asymmetric_bram36k_afifo_tb.v
+POST_SYNTH = af4096x9_1024x36_post_synth af2048x18_1024x36_post_synth af2048x18_4098x9_post_synth af1024x36_4098x9_post_synth
+ADDR_WIDTH0 = 12 11 11 10
+DATA_WIDTH0 = 9 18 18 36
+ADDR_WIDTH1 = 10 10 12 12
+DATA_WIDTH1 = 36 36 9 9
+TOP = af4096x9_1024x36 af2048x18_1024x36 af2048x18_4098x9 af1024x36_4098x9
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)
+	$(call simulate_post_synth,4)
+	$(call clean_post_synth_sim,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/Makefile
@@ -1,10 +1,18 @@
-# Copyright (C) 2019-2022 The SymbiFlow Authors
+# Copyright 2020-2022 F4PGA Authors
 #
-# Use of this source code is governed by a ISC-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/ISC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# SPDX-License-Identifier: ISC
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = asymmetric_bram36k_afifo_tb.v
 POST_SYNTH = af4096x9_1024x36_post_synth af2048x18_1024x36_post_synth af2048x18_4098x9_post_synth af1024x36_4098x9_post_synth

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/asymmetric_bram36k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/asymmetric_bram36k_afifo_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,32 +23,32 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk0;
-  reg clk1;
-  reg flush;
+	reg clk1;
+	reg flush;
 	reg pop;
 	wire [`DATA_WIDTH1-1:0] dout;
 	reg push;
-	reg [`DATA_WIDTH0-1:0] din;
-  wire almost_full,almost_empty;
-  wire full, empty;
-  wire full_watermark, empty_watermark;
-  wire overrun_error, underrun_error;
+	reg [`DATA_WIDTH0-1:0] din;	 
+	wire almost_full,almost_empty;
+	wire full, empty;
+	wire full_watermark, empty_watermark;
+	wire overrun_error, underrun_error;
 
-  initial 
-  begin
-    clk0 = 0;
-    clk1 = 0;
-    pop = 0;
-    push = 0;
-    flush = 1;
-    din = 0;
-    #40
-    flush = 0;
-  end
-  
+	initial 
+	begin
+		clk0 = 0;
+		clk1 = 0;
+		pop = 0;
+		push = 0;
+		flush = 1;
+		din = 0;
+		#40
+		flush = 0;
+	end
+	
 	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
-  initial forever #(PERIOD / 2.0) clk1 = ~clk1;
-  
+	initial forever #(PERIOD / 2.0) clk1 = ~clk1;
+	
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -58,12 +58,12 @@ module TB;
 
 	reg done;
 	initial done = 1'b0;
-  
-  reg read_test;
+	
+	reg read_test;
 	initial read_test = 0;
 
 	reg [`DATA_WIDTH1-1:0] expected;
-  initial expected = 0;
+	initial expected = 0;
 
 	wire error = (read_test) ? dout !== expected : 0;
 
@@ -74,136 +74,136 @@ module TB;
 			error_cnt <= error_cnt + 1'b1; 
 	end
 
-case (`STRINGIFY(`TOP))
-"af4096x9_1024x36": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = a[10:2];
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk1) begin
-        expected <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+	case (`STRINGIFY(`TOP))
+	"af4096x9_1024x36": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = a[10:2];
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
 				end
 			end
-      @(negedge clk1) begin
-				pop = 1;
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk1) begin
+					expected <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk1) begin
+					pop = 1;
+				end
 			end
+			done = 1'b1;
+			a = 0;
 		end
-		done = 1'b1;
-    a = 0;
 	end
-end
-"af2048x18_1024x36": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = a[18:1];
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk1) begin
-        expected <= {a[17:0],a[17:0]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+	"af2048x18_1024x36": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = a[18:1];
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
 				end
 			end
-      @(negedge clk1) begin
-				pop = 1;
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk1) begin
+					expected <= {a[17:0],a[17:0]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk1) begin
+					pop = 1;
+				end
 			end
+			done = 1'b1;
+			a = 0;
 		end
-		done = 1'b1;
-    a = 0;
+	end	 
+	"af2048x18_4098x9": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = {a[8],a[8],a[7:0],a[7:0]};
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
+				end
+			end
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk1) begin
+					expected <= {a[9:1]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk1) begin
+					pop = 1;
+				end
+			end
+			done = 1'b1;
+			a = 0;
+		end
 	end
-end  
-"af2048x18_4098x9": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = {a[8],a[8],a[7:0],a[7:0]};
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk1) begin
-        expected <= {a[9:1]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+	"af1024x36_4098x9": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
 				end
 			end
-      @(negedge clk1) begin
-				pop = 1;
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk1) begin
+					expected <= {a[10:2]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk1) begin
+					pop = 1;
+				end
 			end
+			done = 1'b1;
+			a = 0;
 		end
-		done = 1'b1;
-    a = 0;
 	end
-end
-"af1024x36_4098x9": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk1) begin
-        expected <= {a[10:2]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
-				end
-			end
-      @(negedge clk1) begin
-				pop = 1;
-			end
-		end
-		done = 1'b1;
-    a = 0;
-  end
-end
-endcase
+	endcase
 
 	// Scan for simulation finish
 	always @(posedge clk1) begin
@@ -214,78 +214,78 @@ endcase
 	case (`STRINGIFY(`TOP))
 		"af4096x9_1024x36": begin
 			af4096x9_1024x36 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af2048x18_1024x36": begin
 			af2048x18_1024x36 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af2048x18_4098x9": begin
 			af2048x18_4098x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af1024x36_4098x9": begin
 			af1024x36_4098x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 	endcase

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/asymmetric_bram36k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/asymmetric_bram36k_afifo_tb.v
@@ -1,10 +1,18 @@
-// Copyright (C) 2019-2022 The SymbiFlow Authors
+// Copyright 2020-2022 F4PGA Authors
 //
-// Use of this source code is governed by a ISC-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/ISC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: ISC
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 `timescale 1ns/1ps
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/asymmetric_bram36k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/sim/asymmetric_bram36k_afifo_tb.v
@@ -1,0 +1,284 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 30;
+	localparam ADDR_INCR = 1;
+
+	reg clk0;
+  reg clk1;
+  reg flush;
+	reg pop;
+	wire [`DATA_WIDTH1-1:0] dout;
+	reg push;
+	reg [`DATA_WIDTH0-1:0] din;
+  wire almost_full,almost_empty;
+  wire full, empty;
+  wire full_watermark, empty_watermark;
+  wire overrun_error, underrun_error;
+
+  initial 
+  begin
+    clk0 = 0;
+    clk1 = 0;
+    pop = 0;
+    push = 0;
+    flush = 1;
+    din = 0;
+    #40
+    flush = 0;
+  end
+  
+	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
+  initial forever #(PERIOD / 2.0) clk1 = ~clk1;
+  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+  
+  reg read_test;
+	initial read_test = 0;
+
+	reg [`DATA_WIDTH1-1:0] expected;
+  initial expected = 0;
+
+	wire error = (read_test) ? dout !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk1)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1; 
+	end
+
+case (`STRINGIFY(`TOP))
+"af4096x9_1024x36": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = a[10:2];
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk1) begin
+        expected <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk1) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+	end
+end
+"af2048x18_1024x36": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = a[18:1];
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk1) begin
+        expected <= {a[17:0],a[17:0]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk1) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+	end
+end  
+"af2048x18_4098x9": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = {a[8],a[8],a[7:0],a[7:0]};
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk1) begin
+        expected <= {a[9:1]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk1) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+	end
+end
+"af1024x36_4098x9": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk1) begin
+        expected <= {a[10:2]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk1) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+  end
+end
+endcase
+
+	// Scan for simulation finish
+	always @(posedge clk1) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"af4096x9_1024x36": begin
+			af4096x9_1024x36 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af2048x18_1024x36": begin
+			af2048x18_1024x36 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af2048x18_4098x9": begin
+			af2048x18_4098x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af1024x36_4098x9": begin
+			af1024x36_4098x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.tcl
@@ -1,0 +1,49 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save asymmetric_bram36k_sdp
+
+select spram_9x4096_36x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_9x4096_36x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_9x4096_36x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X36_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_sdp
+select spram_18x2048_36x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_18x2048_36x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_18x2048_36x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X36_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_sdp
+select spram_18x2048_9x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_18x2048_9x4096 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_18x2048_9x4096_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X9_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_sdp
+select spram_36x1024_18x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_36x1024_18x2048 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_36x1024_18x2048_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X36_RD_X18_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.v
@@ -1,0 +1,187 @@
+module spram_9x4096_36x1024 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 12;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 36;
+parameter BE_WIDTH = 1;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(1'b1),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_18x2048_36x1024 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 11;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 36;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule   
+
+module spram_18x2048_9x4096 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 11;
+parameter RD_ADDR_WIDTH = 12;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 9;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_36x1024_18x2048 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 11;
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 18;
+parameter BE_WIDTH = 4;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(4'b1111),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule     

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module spram_9x4096_36x1024 (
     WEN_i,
     REN_i,

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/Makefile
@@ -1,10 +1,18 @@
-# Copyright (C) 2019-2022 The SymbiFlow Authors
+# Copyright 2020-2022 F4PGA Authors
 #
-# Use of this source code is governed by a ISC-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/ISC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# SPDX-License-Identifier: ISC
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = asymmetric_bram36k_sdp_tb.v
 POST_SYNTH = spram_9x4096_36x1024_post_synth spram_18x2048_36x1024_post_synth spram_18x2048_9x4096_post_synth spram_36x1024_18x2048_post_synth
@@ -31,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-#FIXME: $(call simulate_post_synth,3)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/Makefile
@@ -1,0 +1,43 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = asymmetric_bram36k_sdp_tb.v
+POST_SYNTH = spram_9x4096_36x1024_post_synth spram_18x2048_36x1024_post_synth spram_18x2048_9x4096_post_synth spram_36x1024_18x2048_post_synth
+ADDR_WIDTH0 = 12 11 11 10
+DATA_WIDTH0 = 9 18 18 36
+ADDR_WIDTH1 = 10 10 12 11
+DATA_WIDTH1 = 36 36 9 18
+TOP = spram_9x4096_36x1024 spram_18x2048_36x1024 spram_18x2048_9x4096 spram_36x1024_18x2048
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)
+	$(call simulate_post_synth,4)
+	$(call clean_post_synth_sim,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/asymmetric_bram36k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/asymmetric_bram36k_sdp_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk_0;
-  reg clk_1;
+	reg clk_1;
 	reg rce;
 	reg [`ADDR_WIDTH1-1:0] ra;
 	wire [`DATA_WIDTH1-1:0] rq;
@@ -34,12 +34,11 @@ module TB;
 	initial clk_0 = 0;
 	initial clk_1 = 0;
 	initial ra = 0;
-  initial wa = 0;
-  initial wd = 0;
+	initial wa = 0;
+	initial wd = 0;
 	initial rce = 0;
-  initial wce = 0;
+	initial wce = 0;
 	initial forever #(PERIOD / 2.0) clk_0 = ~clk_0;
-  //initial forever #(PERIOD / 2.0) clk_1 = ~clk_1;
 	initial begin
 		#(PERIOD / 4.0);
 		forever #(PERIOD / 2.0) clk_1 = ~clk_1;
@@ -72,144 +71,144 @@ module TB;
 			error_0_cnt <= error_0_cnt + 1'b1;
 	end
 
-case (`STRINGIFY(`TOP))
-"spram_9x4096_36x1024": begin
-	initial #(1) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk_0) begin
-				wa = a[`ADDR_WIDTH0-1:0];
-				wd = a[10:2];
-				wce = 1;
-			end
-			@(posedge clk_0) begin
-				#(PERIOD/10) wce = 0;
-			end
-		end
-		// Read data
-		read_test_0 = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(negedge clk_1) begin
-				ra = a;
-				rce = 1;
-			end
-			@(posedge clk_1) begin
-        expected_0 <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
-				#(PERIOD/10) rce = 0;
-				if ( rq !== expected_0) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+	case (`STRINGIFY(`TOP))
+	"spram_9x4096_36x1024": begin
+		initial #(1) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk_0) begin
+					wa = a[`ADDR_WIDTH0-1:0];
+					wd = a[10:2];
+					wce = 1;
+				end
+				@(posedge clk_0) begin
+					#(PERIOD/10) wce = 0;
 				end
 			end
+			// Read data
+			read_test_0 = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(negedge clk_1) begin
+					ra = a;
+					rce = 1;
+				end
+				@(posedge clk_1) begin
+					expected_0 <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+					#(PERIOD/10) rce = 0;
+					if ( rq !== expected_0) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end
+				end
+			end
+			done_0 = 1'b1;
+			a = 0;
 		end
-		done_0 = 1'b1;
-    a = 0;
 	end
-end
-"spram_18x2048_36x1024": begin
-	initial #(1) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk_0) begin
-				wa = a[`ADDR_WIDTH0-1:0];
-				wd = a[18:1];
-				wce = 1;
-			end
-			@(posedge clk_0) begin
-				#(PERIOD/10) wce = 0;
-			end
-		end
-		// Read data
-		read_test_0 = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(negedge clk_1) begin
-				ra = a;
-				rce = 1;
-			end
-			@(posedge clk_1) begin
-        expected_0 <= {a[17:0],a[17:0]};
-				#(PERIOD/10) rce = 0;
-				if ( rq !== expected_0) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+	"spram_18x2048_36x1024": begin
+		initial #(1) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk_0) begin
+					wa = a[`ADDR_WIDTH0-1:0];
+					wd = a[18:1];
+					wce = 1;
+				end
+				@(posedge clk_0) begin
+					#(PERIOD/10) wce = 0;
 				end
 			end
+			// Read data
+			read_test_0 = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(negedge clk_1) begin
+					ra = a;
+					rce = 1;
+				end
+				@(posedge clk_1) begin
+					expected_0 <= {a[17:0],a[17:0]};
+					#(PERIOD/10) rce = 0;
+					if ( rq !== expected_0) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end
+				end
+			end
+			done_0 = 1'b1;
+			a = 0;
 		end
-		done_0 = 1'b1;
-    a = 0;
+	end	 
+	"spram_18x2048_9x4096": begin
+		initial #(1) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk_0) begin
+					wa = a[`ADDR_WIDTH0-1:0];
+					wd = {a[8],a[8],a[7:0],a[7:0]};
+					wce = 1;
+				end
+				@(posedge clk_0) begin
+					#(PERIOD/10) wce = 0;
+				end
+			end
+			// Read data
+			read_test_0 = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(negedge clk_1) begin
+					ra = a;
+					rce = 1;
+				end
+				@(posedge clk_1) begin
+					expected_0 <= {a[9:1]};
+					#(PERIOD/10) rce = 0;
+					if ( rq !== expected_0) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end
+				end
+			end
+			done_0 = 1'b1;
+			a = 0;
+		end
 	end
-end  
-"spram_18x2048_9x4096": begin
-	initial #(1) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk_0) begin
-				wa = a[`ADDR_WIDTH0-1:0];
-				wd = {a[8],a[8],a[7:0],a[7:0]};
-				wce = 1;
-			end
-			@(posedge clk_0) begin
-				#(PERIOD/10) wce = 0;
-			end
-		end
-		// Read data
-		read_test_0 = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(negedge clk_1) begin
-				ra = a;
-				rce = 1;
-			end
-			@(posedge clk_1) begin
-        expected_0 <= {a[9:1]};
-				#(PERIOD/10) rce = 0;
-				if ( rq !== expected_0) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+	"spram_36x1024_18x2048": begin
+		initial #(1) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk_0) begin
+					wa = a[`ADDR_WIDTH0-1:0];
+					wd = {a[17:0],a[17:0]};
+					wce = 1;
+				end
+				@(posedge clk_0) begin
+					#(PERIOD/10) wce = 0;
 				end
 			end
+			// Read data
+			read_test_0 = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(negedge clk_1) begin
+					ra = a;
+					rce = 1;
+				end
+				@(posedge clk_1) begin
+					expected_0 <= {a[18:1]};
+					#(PERIOD/10) rce = 0;
+					if ( rq !== expected_0) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+					end
+				end
+			end
+			done_0 = 1'b1;
+			a = 0;
 		end
-		done_0 = 1'b1;
-    a = 0;
 	end
-end
-"spram_36x1024_18x2048": begin
-	initial #(1) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk_0) begin
-				wa = a[`ADDR_WIDTH0-1:0];
-				wd = {a[17:0],a[17:0]};
-				wce = 1;
-			end
-			@(posedge clk_0) begin
-				#(PERIOD/10) wce = 0;
-			end
-		end
-		// Read data
-		read_test_0 = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(negedge clk_1) begin
-				ra = a;
-				rce = 1;
-			end
-			@(posedge clk_1) begin
-        expected_0 <= {a[18:1]};
-				#(PERIOD/10) rce = 0;
-				if ( rq !== expected_0) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
-				end
-			end
-		end
-		done_0 = 1'b1;
-    a = 0;
-  end
-end
-endcase
+	endcase
 
 	// Scan for simulation finish
 	always @(posedge clk_1) begin
@@ -221,7 +220,7 @@ endcase
 		"spram_9x4096_36x1024": begin
 			spram_9x4096_36x1024 #() bram (
 				.clock0(clk_0),
-        .clock1(clk_1),        
+				.clock1(clk_1),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -233,7 +232,7 @@ endcase
 		"spram_18x2048_36x1024": begin
 			spram_18x2048_36x1024 #() bram (
 				.clock0(clk_0),
-        .clock1(clk_1),        
+				.clock1(clk_1),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -245,7 +244,7 @@ endcase
 		"spram_18x2048_9x4096": begin
 			spram_18x2048_9x4096 #() bram (
 				.clock0(clk_0),
-        .clock1(clk_1),        
+				.clock1(clk_1),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -257,7 +256,7 @@ endcase
 		"spram_36x1024_18x2048": begin
 			spram_36x1024_18x2048 #() bram (
 				.clock0(clk_0),
-        .clock1(clk_1),        
+				.clock1(clk_1),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/asymmetric_bram36k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/asymmetric_bram36k_sdp_tb.v
@@ -1,10 +1,18 @@
-// Copyright (C) 2019-2022 The SymbiFlow Authors
+// Copyright 2020-2022 F4PGA Authors
 //
-// Use of this source code is governed by a ISC-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/ISC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: ISC
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 `timescale 1ns/1ps
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/asymmetric_bram36k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/sim/asymmetric_bram36k_sdp_tb.v
@@ -1,0 +1,262 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_0;
+  reg clk_1;
+	reg rce;
+	reg [`ADDR_WIDTH1-1:0] ra;
+	wire [`DATA_WIDTH1-1:0] rq;
+	reg wce;
+	reg [`ADDR_WIDTH0-1:0] wa;
+	reg [`DATA_WIDTH0-1:0] wd;
+
+	initial clk_0 = 0;
+	initial clk_1 = 0;
+	initial ra = 0;
+  initial wa = 0;
+  initial wd = 0;
+	initial rce = 0;
+  initial wce = 0;
+	initial forever #(PERIOD / 2.0) clk_0 = ~clk_0;
+  //initial forever #(PERIOD / 2.0) clk_1 = ~clk_1;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_1 = ~clk_1;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_0;
+	initial done_0 = 1'b0;
+	wire done_sim = done_0;
+
+	reg [`DATA_WIDTH1-1:0] expected_0;
+
+	reg read_test_0;
+	initial read_test_0 = 0;
+
+
+	wire error_0 = (read_test_0) ? (rq !== expected_0) : 0;
+
+	integer error_0_cnt = 0;
+
+	always @ (posedge clk_1)
+	begin
+		if (error_0)
+			error_0_cnt <= error_0_cnt + 1'b1;
+	end
+
+case (`STRINGIFY(`TOP))
+"spram_9x4096_36x1024": begin
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa = a[`ADDR_WIDTH0-1:0];
+				wd = a[10:2];
+				wce = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk_1) begin
+        expected_0 <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+	end
+end
+"spram_18x2048_36x1024": begin
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa = a[`ADDR_WIDTH0-1:0];
+				wd = a[18:1];
+				wce = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk_1) begin
+        expected_0 <= {a[17:0],a[17:0]};
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+	end
+end  
+"spram_18x2048_9x4096": begin
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa = a[`ADDR_WIDTH0-1:0];
+				wd = {a[8],a[8],a[7:0],a[7:0]};
+				wce = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk_1) begin
+        expected_0 <= {a[9:1]};
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+	end
+end
+"spram_36x1024_18x2048": begin
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa = a[`ADDR_WIDTH0-1:0];
+				wd = {a[17:0],a[17:0]};
+				wce = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk_1) begin
+        expected_0 <= {a[18:1]};
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+  end
+end
+endcase
+
+	// Scan for simulation finish
+	always @(posedge clk_1) begin
+		if (done_sim)
+			$finish_and_return( (error_0_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"spram_9x4096_36x1024": begin
+			spram_9x4096_36x1024 #() bram (
+				.clock0(clk_0),
+        .clock1(clk_1),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_18x2048_36x1024": begin
+			spram_18x2048_36x1024 #() bram (
+				.clock0(clk_0),
+        .clock1(clk_1),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_18x2048_9x4096": begin
+			spram_18x2048_9x4096 #() bram (
+				.clock0(clk_0),
+        .clock1(clk_1),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_36x1024_18x2048": begin
+			spram_36x1024_18x2048 #() bram (
+				.clock0(clk_0),
+        .clock1(clk_1),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.tcl
@@ -1,0 +1,49 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save asymmetric_bram36k_sfifo
+
+select f4096x9_1024x36
+select *
+synth_quicklogic -family qlf_k6n10f -top f4096x9_1024x36 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f4096x9_1024x36_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X9_RD_X36_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_sfifo
+select f2048x18_1024x36
+select *
+synth_quicklogic -family qlf_k6n10f -top f2048x18_1024x36 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f2048x18_1024x36_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X18_RD_X36_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_sfifo
+select f2048x18_4098x9
+select *
+synth_quicklogic -family qlf_k6n10f -top f2048x18_4098x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f2048x18_4098x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X18_RD_X9_nonsplit
+
+select -clear
+design -load asymmetric_bram36k_sfifo
+select f1024x36_2048x18
+select *
+synth_quicklogic -family qlf_k6n10f -top f1024x36_2048x18 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f1024x36_2048x18_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X36_RD_X18_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module f4096x9_1024x36 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
 
 parameter WR_DATA_WIDTH = 9;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.v
@@ -32,7 +32,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -51,8 +51,7 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f2048x18_1024x36 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -73,7 +72,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -92,8 +91,7 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f2048x18_4098x9 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -114,7 +112,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -133,8 +131,7 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f1024x36_2048x18 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -155,7 +152,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -174,6 +171,5 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.v
@@ -1,0 +1,163 @@
+module f4096x9_1024x36 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 36;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f2048x18_1024x36 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 36;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f2048x18_4098x9 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f1024x36_2048x18 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 18;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/Makefile
@@ -1,0 +1,43 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = asymmetric_bram36k_sfifo_tb.v
+POST_SYNTH = f4096x9_1024x36_post_synth f2048x18_1024x36_post_synth f2048x18_4098x9_post_synth f1024x36_2048x18_post_synth
+ADDR_WIDTH0 = 12 11 11 10
+DATA_WIDTH0 = 9 18 18 36
+ADDR_WIDTH1 = 10 10 12 11
+DATA_WIDTH1 = 36 36 9 18
+TOP = f4096x9_1024x36 f2048x18_1024x36 f2048x18_4098x9 f1024x36_2048x18
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)
+	$(call simulate_post_synth,4)
+	$(call clean_post_synth_sim,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-#FIXME: $(call simulate_post_synth,3)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/Makefile
@@ -1,10 +1,18 @@
-# Copyright (C) 2019-2022 The SymbiFlow Authors
+# Copyright 2020-2022 F4PGA Authors
 #
-# Use of this source code is governed by a ISC-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/ISC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# SPDX-License-Identifier: ISC
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = asymmetric_bram36k_sfifo_tb.v
 POST_SYNTH = f4096x9_1024x36_post_synth f2048x18_1024x36_post_synth f2048x18_4098x9_post_synth f1024x36_2048x18_post_synth

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/asymmetric_bram36k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/asymmetric_bram36k_sfifo_tb.v
@@ -1,10 +1,18 @@
-// Copyright (C) 2019-2022 The SymbiFlow Authors
+// Copyright 2020-2022 F4PGA Authors
 //
-// Use of this source code is governed by a ISC-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/ISC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: ISC
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 `timescale 1ns/1ps
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/asymmetric_bram36k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/asymmetric_bram36k_sfifo_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,29 +23,29 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk0;
-  reg flush;
+	reg flush;
 	reg pop;
 	wire [`DATA_WIDTH1-1:0] dout;
 	reg push;
 	reg [`DATA_WIDTH0-1:0] din;
-  wire almost_full,almost_empty;
-  wire full, empty;
-  wire full_watermark, empty_watermark;
-  wire overrun_error, underrun_error;
+	wire almost_full,almost_empty;
+	wire full, empty;
+	wire full_watermark, empty_watermark;
+	wire overrun_error, underrun_error;
 
-  initial 
-  begin
-    clk0 = 0;
-    pop = 0;
-    push = 0;
-    flush = 1;
-    din = 0;
-    #40
-    flush = 0;
-  end
-  
+	initial 
+	begin
+		clk0 = 0;
+		pop = 0;
+		push = 0;
+		flush = 1;
+		din = 0;
+		#40
+		flush = 0;
+	end
+	
 	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
-  
+	
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -55,12 +55,12 @@ module TB;
 
 	reg done;
 	initial done = 1'b0;
-  
-  reg read_test;
+	
+	reg read_test;
 	initial read_test = 0;
 
 	reg [`DATA_WIDTH1-1:0] expected;
-  initial expected = 0;
+	initial expected = 0;
 
 	wire error = (read_test) ? dout !== expected : 0;
 
@@ -71,136 +71,136 @@ module TB;
 			error_cnt <= error_cnt + 1'b1; 
 	end
 
-case (`STRINGIFY(`TOP))
-"f4096x9_1024x36": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = a[10:2];
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk0) begin
-        expected <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+	case (`STRINGIFY(`TOP))
+	"f4096x9_1024x36": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = a[10:2];
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
 				end
 			end
-      @(negedge clk0) begin
-				pop = 1;
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk0) begin
+					expected <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk0) begin
+					pop = 1;
+				end
 			end
+			done = 1'b1;
+			a = 0;
 		end
-		done = 1'b1;
-    a = 0;
 	end
-end
-"f2048x18_1024x36": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = a[18:1];
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk0) begin
-        expected <= {a[17:0],a[17:0]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+	"f2048x18_1024x36": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = a[18:1];
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
 				end
 			end
-      @(negedge clk0) begin
-				pop = 1;
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk0) begin
+					expected <= {a[17:0],a[17:0]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk0) begin
+					pop = 1;
+				end
 			end
+			done = 1'b1;
+			a = 0;
 		end
-		done = 1'b1;
-    a = 0;
+	end	 
+	"f2048x18_4098x9": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = {a[8],a[8],a[7:0],a[7:0]};
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
+				end
+			end
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk0) begin
+					expected <= {a[9:1]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk0) begin
+					pop = 1;
+				end
+			end
+			done = 1'b1;
+			a = 0;
+		end
 	end
-end  
-"f2048x18_4098x9": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = {a[8],a[8],a[7:0],a[7:0]};
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk0) begin
-        expected <= {a[9:1]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+	"f1024x36_2048x18": begin
+		initial #(50) begin
+			// Write data
+			for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+				@(negedge clk0) begin
+					din = {a[17:0],a[17:0]};
+					push = 1;
+				end
+				@(posedge clk0) begin
+					#(PERIOD/10) push = 0;
 				end
 			end
-      @(negedge clk0) begin
-				pop = 1;
+			// Read data
+			read_test = 1;
+			for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+				@(posedge clk0) begin
+					expected <= {a[18:1]};
+					#(PERIOD/10) pop = 0;
+					if ( dout !== expected) begin
+						$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+					end else begin
+						$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+					end
+				end
+				@(negedge clk0) begin
+					pop = 1;
+				end
 			end
+			done = 1'b1;
+			a = 0;
 		end
-		done = 1'b1;
-    a = 0;
 	end
-end
-"f1024x36_2048x18": begin
-	initial #(50) begin
-		// Write data
-		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
-			@(negedge clk0) begin
-				din = {a[17:0],a[17:0]};
-				push = 1;
-			end
-			@(posedge clk0) begin
-				#(PERIOD/10) push = 0;
-			end
-		end
-		// Read data
-		read_test = 1;
-		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
-			@(posedge clk0) begin
-        expected <= {a[18:1]};
-				#(PERIOD/10) pop = 0;
-				if ( dout !== expected) begin
-					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
-				end else begin
-					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
-				end
-			end
-      @(negedge clk0) begin
-				pop = 1;
-			end
-		end
-		done = 1'b1;
-    a = 0;
-  end
-end
-endcase
+	endcase
 
 	// Scan for simulation finish
 	always @(posedge clk0) begin
@@ -211,74 +211,74 @@ endcase
 	case (`STRINGIFY(`TOP))
 		"f4096x9_1024x36": begin
 			f4096x9_1024x36 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f2048x18_1024x36": begin
 			f2048x18_1024x36 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f2048x18_4098x9": begin
 			f2048x18_4098x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f1024x36_2048x18": begin
 			f1024x36_2048x18 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 	endcase

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/asymmetric_bram36k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/sim/asymmetric_bram36k_sfifo_tb.v
@@ -1,0 +1,277 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 30;
+	localparam ADDR_INCR = 1;
+
+	reg clk0;
+  reg flush;
+	reg pop;
+	wire [`DATA_WIDTH1-1:0] dout;
+	reg push;
+	reg [`DATA_WIDTH0-1:0] din;
+  wire almost_full,almost_empty;
+  wire full, empty;
+  wire full_watermark, empty_watermark;
+  wire overrun_error, underrun_error;
+
+  initial 
+  begin
+    clk0 = 0;
+    pop = 0;
+    push = 0;
+    flush = 1;
+    din = 0;
+    #40
+    flush = 0;
+  end
+  
+	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
+  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+  
+  reg read_test;
+	initial read_test = 0;
+
+	reg [`DATA_WIDTH1-1:0] expected;
+  initial expected = 0;
+
+	wire error = (read_test) ? dout !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk0)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1; 
+	end
+
+case (`STRINGIFY(`TOP))
+"f4096x9_1024x36": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = a[10:2];
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk0) begin
+        expected <= {a[8],a[8],a[7:0],a[7:0],a[8],a[8],a[7:0],a[7:0]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk0) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+	end
+end
+"f2048x18_1024x36": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = a[18:1];
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk0) begin
+        expected <= {a[17:0],a[17:0]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk0) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+	end
+end  
+"f2048x18_4098x9": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = {a[8],a[8],a[7:0],a[7:0]};
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk0) begin
+        expected <= {a[9:1]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk0) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+	end
+end
+"f1024x36_2048x18": begin
+	initial #(50) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) ; a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = {a[17:0],a[17:0]};
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk0) begin
+        expected <= {a[18:1]};
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+      @(negedge clk0) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+    a = 0;
+  end
+end
+endcase
+
+	// Scan for simulation finish
+	always @(posedge clk0) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"f4096x9_1024x36": begin
+			f4096x9_1024x36 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f2048x18_1024x36": begin
+			f2048x18_1024x36 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f2048x18_4098x9": begin
+			f2048x18_4098x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f1024x36_2048x18": begin
+			f1024x36_2048x18 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.tcl
@@ -1,0 +1,49 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram18k_afifo
+
+select af1024x18_1024x18
+select *
+synth_quicklogic -family qlf_k6n10f -top af1024x18_1024x18 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af1024x18_1024x18_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X18_RD_X18_split
+
+select -clear
+design -load bram18k_afifo
+select af1024x16_1024x16
+select *
+synth_quicklogic -family qlf_k6n10f -top af1024x16_1024x16 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af1024x16_1024x16_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X18_RD_X18_split
+
+select -clear
+design -load bram18k_afifo
+select af2048x9_2048x9
+select *
+synth_quicklogic -family qlf_k6n10f -top af2048x9_2048x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af2048x9_2048x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X9_RD_X9_split
+
+select -clear
+design -load bram18k_afifo
+select af2048x8_2048x8
+select *
+synth_quicklogic -family qlf_k6n10f -top af2048x8_2048x8 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af2048x8_2048x8_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X9_RD_X9_split

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.v
@@ -32,7 +32,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -52,8 +52,7 @@ AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af1024x16_1024x16 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -74,7 +73,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -94,8 +93,7 @@ AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af2048x9_2048x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -116,7 +114,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -136,8 +134,7 @@ AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af2048x8_2048x8 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -158,7 +155,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -178,6 +175,5 @@ AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module af1024x18_1024x18 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
 
 parameter WR_DATA_WIDTH = 18;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.v
@@ -1,0 +1,167 @@
+module af1024x18_1024x18 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af1024x16_1024x16 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 16;
+parameter RD_DATA_WIDTH = 16;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af2048x9_2048x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af2048x8_2048x8 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 8;
+parameter RD_DATA_WIDTH = 8;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram18k_afifo_tb.v
+POST_SYNTH = af1024x18_1024x18_post_synth af1024x16_1024x16_post_synth af2048x9_2048x9_post_synth af2048x8_2048x8_post_synth
+ADDR_WIDTH0 = 10 10 11 11
+DATA_WIDTH0 = 18 16 9 8
+ADDR_WIDTH1 = 10 10 11 11
+DATA_WIDTH1 = 18 16 9 8
+TOP = af1024x18_1024x18 af1024x16_1024x16 af2048x9_2048x9 af2048x8_2048x8
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+# FIXME: $(call simulate_post_synth,5)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)
+	$(call simulate_post_synth,4)
+	$(call clean_post_synth_sim,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/bram18k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/bram18k_afifo_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,32 +23,32 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk0;
-  reg clk1;
-  reg flush;
+	reg clk1;
+	reg flush;
 	reg pop;
 	wire [`DATA_WIDTH1-1:0] dout;
 	reg push;
 	reg [`DATA_WIDTH0-1:0] din;
-  wire almost_full,almost_empty;
-  wire full, empty;
-  wire full_watermark, empty_watermark;
-  wire overrun_error, underrun_error;
+	wire almost_full,almost_empty;
+	wire full, empty;
+	wire full_watermark, empty_watermark;
+	wire overrun_error, underrun_error;
 
-  initial 
-  begin
-    clk0 = 0;
-    clk1 = 0;
-    pop = 0;
-    push = 0;
-    flush = 1;
-    din = 0;
-    #40
-    flush = 0;
-  end
-  
+	initial 
+	begin
+		clk0 = 0;
+		clk1 = 0;
+		pop = 0;
+		push = 0;
+		flush = 1;
+		din = 0;
+		#40
+		flush = 0;
+	end
+	
 	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
-  initial forever #(PERIOD / 2.0) clk1 = ~clk1;
-  
+	initial forever #(PERIOD / 2.0) clk1 = ~clk1;
+	
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -63,7 +63,7 @@ module TB;
 	initial read_test = 0;
 
 	reg [`DATA_WIDTH1-1:0] expected;
-  initial expected = 0;
+	initial expected = 0;
 
 	always @(posedge clk1) begin
 		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
@@ -79,7 +79,7 @@ module TB;
 	end
 
 	initial #(50) begin
-    @(posedge clk0)
+		@(posedge clk0)
 		// Write data
 		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
 			@(negedge clk0) begin
@@ -117,78 +117,78 @@ module TB;
 	case (`STRINGIFY(`TOP))
 		"af1024x18_1024x18": begin
 			af1024x18_1024x18 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af1024x16_1024x16": begin
 			af1024x16_1024x16 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af2048x9_2048x9": begin
 			af2048x9_2048x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end		
 		"af2048x8_2048x8": begin
 			af2048x8_2048x8 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end	
 	endcase

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/bram18k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/sim/bram18k_afifo_tb.v
@@ -1,0 +1,195 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 30;
+	localparam ADDR_INCR = 1;
+
+	reg clk0;
+  reg clk1;
+  reg flush;
+	reg pop;
+	wire [`DATA_WIDTH1-1:0] dout;
+	reg push;
+	reg [`DATA_WIDTH0-1:0] din;
+  wire almost_full,almost_empty;
+  wire full, empty;
+  wire full_watermark, empty_watermark;
+  wire overrun_error, underrun_error;
+
+  initial 
+  begin
+    clk0 = 0;
+    clk1 = 0;
+    pop = 0;
+    push = 0;
+    flush = 1;
+    din = 0;
+    #40
+    flush = 0;
+  end
+  
+	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
+  initial forever #(PERIOD / 2.0) clk1 = ~clk1;
+  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+ 
+	reg read_test;
+	initial read_test = 0;
+
+	reg [`DATA_WIDTH1-1:0] expected;
+  initial expected = 0;
+
+	always @(posedge clk1) begin
+		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+
+	wire error = ((a != 0) && read_test) ? dout !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk1)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1; 
+	end
+
+	initial #(50) begin
+    @(posedge clk0)
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = a | (a << 20) | 20'h55000;
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk1) begin
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+			@(negedge clk1) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk1) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"af1024x18_1024x18": begin
+			af1024x18_1024x18 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af1024x16_1024x16": begin
+			af1024x16_1024x16 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af2048x9_2048x9": begin
+			af2048x9_2048x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end		
+		"af2048x8_2048x8": begin
+			af2048x8_2048x8 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end	
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.tcl
@@ -1,0 +1,39 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram18k_sdp
+
+select spram_18x1024_2x
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_18x1024_2x -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_18x1024_2x_post_synth.v
+select -assert-count 2 t:TDP36K_BRAM_WR_X18_RD_X18_split
+
+select -clear
+design -load bram18k_sdp
+select spram_9x2048_x2
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_9x2048_x2 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_9x2048_x2_post_synth.v
+select -assert-count 2 t:TDP36K_BRAM_WR_X9_RD_X9_split
+
+select -clear
+design -load bram18k_sdp
+select spram_9x2048_18x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_9x2048_18x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_9x2048_18x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X9_split
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X18_split

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module spram_18x1024_2x (   
     WEN0_i,
     REN0_i,

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.v
@@ -1,0 +1,260 @@
+module spram_18x1024_2x (   
+    WEN0_i,
+    REN0_i,
+    clock0,
+    WR_ADDR0_i,
+    RD_ADDR0_i,
+    WDATA0_i,
+    RDATA0_o,
+    
+    WEN1_i,
+    REN1_i,
+    clock1,
+    WR_ADDR1_i,
+    RD_ADDR1_i,
+    WDATA1_i,
+    RDATA1_o
+);
+
+parameter WR_ADDR_WIDTH0 = 10;
+parameter RD_ADDR_WIDTH0 = 10;
+parameter WR_DATA_WIDTH0 = 18;
+parameter RD_DATA_WIDTH0 = 18;
+parameter BE_WIDTH0 = 2;
+
+parameter WR_ADDR_WIDTH1 = 10;
+parameter RD_ADDR_WIDTH1 = 10;
+parameter WR_DATA_WIDTH1 = 18;
+parameter RD_DATA_WIDTH1 = 18;
+parameter BE_WIDTH1 = 2;
+
+input wire WEN0_i;
+input wire REN0_i;
+input wire clock0;
+input wire [WR_ADDR_WIDTH0-1 :0] WR_ADDR0_i;
+input wire [RD_ADDR_WIDTH0-1 :0] RD_ADDR0_i;
+input wire [WR_DATA_WIDTH0-1 :0] WDATA0_i;
+output wire [RD_DATA_WIDTH0-1 :0] RDATA0_o;
+
+input wire WEN1_i;
+input wire REN1_i;
+input wire clock1;
+input wire [WR_ADDR_WIDTH0-1 :0] WR_ADDR1_i;
+input wire [RD_ADDR_WIDTH0-1 :0] RD_ADDR1_i;
+input wire [WR_DATA_WIDTH0-1 :0] WDATA1_i;
+output wire [RD_DATA_WIDTH0-1 :0] RDATA1_o;
+
+
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH0),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH0),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH0),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH0),
+              .BE_WIDTH(BE_WIDTH0)
+              ) spram_x18_inst1 (
+              
+              .WEN_i(WEN0_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN0_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock0),
+              .WR_ADDR_i(WR_ADDR0_i),
+              .RD_ADDR_i(RD_ADDR0_i),
+              .WDATA_i(WDATA0_i),
+              .RDATA_o(RDATA0_o)
+              );
+              
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH1),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH1),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH1),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH1),
+              .BE_WIDTH(BE_WIDTH1)
+              ) spram_x18_inst2 (
+              
+              .WEN_i(WEN1_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN1_i),              
+              .WR_CLK_i(clock1),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR1_i),
+              .RD_ADDR_i(RD_ADDR1_i),
+              .WDATA_i(WDATA1_i),
+              .RDATA_o(RDATA1_o)
+              );
+              
+endmodule    
+
+module spram_9x2048_x2 (
+    WEN0_i,
+    REN0_i,
+    clock0,
+    WR_ADDR0_i,
+    RD_ADDR0_i,
+    WDATA0_i,
+    RDATA0_o,
+    
+    WEN1_i,
+    REN1_i,
+    clock1,
+    WR_ADDR1_i,
+    RD_ADDR1_i,
+    WDATA1_i,
+    RDATA1_o
+);
+
+parameter WR_ADDR_WIDTH0 = 11;
+parameter RD_ADDR_WIDTH0 = 11;
+parameter WR_DATA_WIDTH0 = 9;
+parameter RD_DATA_WIDTH0 = 9;
+parameter BE_WIDTH0 = 1;
+
+parameter WR_ADDR_WIDTH1 = 11;
+parameter RD_ADDR_WIDTH1 = 11;
+parameter WR_DATA_WIDTH1 = 9;
+parameter RD_DATA_WIDTH1 = 9;
+parameter BE_WIDTH1 = 1;
+
+input wire WEN0_i;
+input wire REN0_i;
+input wire clock0;
+input wire [WR_ADDR_WIDTH0-1 :0] WR_ADDR0_i;
+input wire [RD_ADDR_WIDTH0-1 :0] RD_ADDR0_i;
+input wire [WR_DATA_WIDTH0-1 :0] WDATA0_i;
+output wire [RD_DATA_WIDTH0-1 :0] RDATA0_o;
+
+input wire WEN1_i;
+input wire REN1_i;
+input wire clock1;
+input wire [WR_ADDR_WIDTH1-1 :0] WR_ADDR1_i;
+input wire [RD_ADDR_WIDTH1-1 :0] RD_ADDR1_i;
+input wire [WR_DATA_WIDTH1-1 :0] WDATA1_i;
+output wire [RD_DATA_WIDTH1-1 :0] RDATA1_o;
+
+
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH0),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH0),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH0),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH0),
+              .BE_WIDTH(BE_WIDTH0)
+              ) spram_x18_inst1 (
+              
+              .WEN_i(WEN0_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN0_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock0),
+              .WR_ADDR_i(WR_ADDR0_i),
+              .RD_ADDR_i(RD_ADDR0_i),
+              .WDATA_i(WDATA0_i),
+              .RDATA_o(RDATA0_o)
+              );
+              
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH1),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH1),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH1),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH1),
+              .BE_WIDTH(BE_WIDTH1)
+              ) spram_x18_inst2 (
+              
+              .WEN_i(WEN1_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN1_i),              
+              .WR_CLK_i(clock1),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR1_i),
+              .RD_ADDR_i(RD_ADDR1_i),
+              .WDATA_i(WDATA1_i),
+              .RDATA_o(RDATA1_o)
+              );
+              
+endmodule    
+
+module spram_9x2048_18x1024 (
+    WEN0_i,
+    REN0_i,
+    clock0,
+    WR_ADDR0_i,
+    RD_ADDR0_i,
+    WDATA0_i,
+    RDATA0_o,
+    
+    WEN1_i,
+    REN1_i,
+    clock1,
+    WR_ADDR1_i,
+    RD_ADDR1_i,
+    WDATA1_i,
+    RDATA1_o
+);
+
+parameter WR_ADDR_WIDTH0 = 11;
+parameter RD_ADDR_WIDTH0 = 11;
+parameter WR_DATA_WIDTH0 = 9;
+parameter RD_DATA_WIDTH0 = 9;
+parameter BE_WIDTH0 = 1;
+
+parameter WR_ADDR_WIDTH1 = 10;
+parameter RD_ADDR_WIDTH1 = 10;
+parameter WR_DATA_WIDTH1 = 18;
+parameter RD_DATA_WIDTH1 = 18;
+parameter BE_WIDTH1 = 2;
+
+input wire WEN0_i;
+input wire REN0_i;
+input wire clock0;
+input wire [WR_ADDR_WIDTH0-1 :0] WR_ADDR0_i;
+input wire [RD_ADDR_WIDTH0-1 :0] RD_ADDR0_i;
+input wire [WR_DATA_WIDTH0-1 :0] WDATA0_i;
+output wire [RD_DATA_WIDTH0-1 :0] RDATA0_o;
+
+input wire WEN1_i;
+input wire REN1_i;
+input wire clock1;
+input wire [WR_ADDR_WIDTH1-1 :0] WR_ADDR1_i;
+input wire [RD_ADDR_WIDTH1-1 :0] RD_ADDR1_i;
+input wire [WR_DATA_WIDTH1-1 :0] WDATA1_i;
+output wire [RD_DATA_WIDTH1-1 :0] RDATA1_o;
+
+
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH0),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH0),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH0),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH0),
+              .BE_WIDTH(BE_WIDTH0)
+              ) spram_x18_inst1 (
+              
+              .WEN_i(WEN0_i),
+              .WR_BE_i(1'b1),
+              .REN_i(REN0_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock0),
+              .WR_ADDR_i(WR_ADDR0_i),
+              .RD_ADDR_i(RD_ADDR0_i),
+              .WDATA_i(WDATA0_i),
+              .RDATA_o(RDATA0_o)
+              );
+              
+RAM_18K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH1),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH1),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH1),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH1),
+              .BE_WIDTH(BE_WIDTH1)
+              ) spram_x18_inst2 (
+              
+              .WEN_i(WEN1_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN1_i),              
+              .WR_CLK_i(clock1),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR1_i),
+              .RD_ADDR_i(RD_ADDR1_i),
+              .WDATA_i(WDATA1_i),
+              .RDATA_o(RDATA1_o)
+              );
+              
+endmodule    

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/Makefile
@@ -1,10 +1,18 @@
-# Copyright (C) 2019-2022 The SymbiFlow Authors
+# Copyright 2020-2022 F4PGA Authors
 #
-# Use of this source code is governed by a ISC-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/ISC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# SPDX-License-Identifier: ISC
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = bram18k_sdp_tb.v
 POST_SYNTH = spram_18x1024_2x_post_synth spram_9x2048_x2_post_synth spram_9x2048_18x1024_post_synth

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-#FIXME: $(call simulate_post_synth,3)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/Makefile
@@ -1,0 +1,41 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = bram18k_sdp_tb.v
+POST_SYNTH = spram_18x1024_2x_post_synth spram_9x2048_x2_post_synth spram_9x2048_18x1024_post_synth
+ADDR_WIDTH0 = 10 11 11
+DATA_WIDTH0 = 18 9 9
+ADDR_WIDTH1 = 10 11 10
+DATA_WIDTH1 = 18 9 18
+TOP = spram_18x1024_2x spram_9x2048_x2 spram_9x2048_18x1024
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/bram18k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/bram18k_sdp_tb.v
@@ -1,10 +1,18 @@
-// Copyright (C) 2019-2022 The SymbiFlow Authors
+// Copyright 2020-2022 F4PGA Authors
 //
-// Use of this source code is governed by a ISC-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/ISC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: ISC
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 `timescale 1ns/1ps
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/bram18k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/bram18k_sdp_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -126,7 +126,7 @@ module TB;
 			end
 		end
 		done_0 = 1'b1;
-    a = 0;
+		a = 0;
 	end
 
 	// PART 1
@@ -159,7 +159,7 @@ module TB;
 			end
 		end
 		done_1 = 1'b1;
-    b = (1<<`ADDR_WIDTH1) / 2;
+		b = (1<<`ADDR_WIDTH1) / 2;
 	end
 
 	// Scan for simulation finish

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/bram18k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/sim/bram18k_sdp_tb.v
@@ -1,0 +1,222 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_0;
+	reg rce_0;
+	reg [`ADDR_WIDTH0-1:0] ra_0;
+	wire [`DATA_WIDTH0-1:0] rq_0;
+	reg wce_0;
+	reg [`ADDR_WIDTH0-1:0] wa_0;
+	reg [`DATA_WIDTH0-1:0] wd_0;
+
+	reg clk_1;
+	reg rce_1;
+	reg [`ADDR_WIDTH1-1:0] ra_1;
+	wire [`DATA_WIDTH1-1:0] rq_1;
+	reg wce_1;
+	reg [`ADDR_WIDTH1-1:0] wa_1;
+	reg [`DATA_WIDTH1-1:0] wd_1;
+
+
+	initial clk_0 = 0;
+	initial clk_1 = 0;
+	initial ra_0 = 0;
+	initial ra_1 = 0;
+	initial rce_0 = 0;
+	initial rce_1 = 0;
+	initial forever #(PERIOD / 2.0) clk_0 = ~clk_0;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_1 = ~clk_1;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_0;
+	reg done_1;
+	initial done_0 = 1'b0;
+	initial done_1 = 1'b0;
+	wire done_sim = done_0 & done_1;
+
+	reg [`DATA_WIDTH0-1:0] expected_0;
+	reg [`DATA_WIDTH1-1:0] expected_1;
+
+	reg read_test_0;
+	reg read_test_1;
+	initial read_test_0 = 0;
+	initial read_test_1 = 0;
+
+	always @(posedge clk_0) begin
+		expected_0 <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
+	end
+	always @(posedge clk_1) begin
+		expected_1 <= ((b+1) | ((b+1) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+
+	wire error_0 = ((a != 0) && read_test_0) ? (rq_0 !== expected_0) : 0;
+	wire error_1 = ((b != (1<<`ADDR_WIDTH1) / 2) && read_test_1) ? (rq_1 !== expected_1) : 0;
+
+	integer error_0_cnt = 0;
+	integer error_1_cnt = 0;
+
+	always @ (posedge clk_0)
+	begin
+		if (error_0)
+			error_0_cnt <= error_0_cnt + 1'b1;
+	end
+	always @ (posedge clk_1)
+	begin
+		if (error_1)
+			error_1_cnt <= error_1_cnt + 1'b1;
+	end
+
+	// PART 0
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				wa_0 = a;
+				wd_0 = a | (a << 20) | 20'h55000;
+				wce_0 = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) wce_0 = 0;
+			end
+		end
+		// Read data
+		read_test_0 = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH0) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_0) begin
+				ra_0 = a;
+				rce_0 = 1;
+			end
+			@(posedge clk_0) begin
+				#(PERIOD/10) rce_0 = 0;
+				if ( rq_0 !== expected_0) begin
+					$display("%d: PORT 0: FAIL: mismatch act=%x exp=%x at %x", $time, rq_0, expected_0, a);
+				end else begin
+					$display("%d: PORT 0: OK: act=%x exp=%x at %x", $time, rq_0, expected_0, a);
+				end
+			end
+		end
+		done_0 = 1'b1;
+    a = 0;
+	end
+
+	// PART 1
+	initial #(1) begin
+		// Write data
+		for (b = (1<<`ADDR_WIDTH1) / 2; b < (1<<`ADDR_WIDTH1); b = b + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				wa_1 = b;
+				wd_1 = (b+1) | ((b+1) << 20) | 20'h55000;
+				wce_1 = 1;
+			end
+			@(posedge clk_1) begin
+				#(PERIOD/10) wce_1 = 0;
+			end
+		end
+		// Read data
+		read_test_1 = 1;
+		for (b = (1<<`ADDR_WIDTH1) / 2; b < (1<<`ADDR_WIDTH1); b = b + ADDR_INCR) begin
+			@(negedge clk_1) begin
+				ra_1 = b;
+				rce_1 = 1;
+			end
+			@(posedge clk_1) begin
+				#(PERIOD/10) rce_1 = 0;
+				if ( rq_1 !== expected_1) begin
+					$display("%d: PORT 1: FAIL: mismatch act=%x exp=%x at %x", $time, rq_1, expected_1, b);
+				end else begin
+					$display("%d: PORT 1: OK: act=%x exp=%x at %x", $time, rq_1, expected_1, b);
+				end
+			end
+		end
+		done_1 = 1'b1;
+    b = (1<<`ADDR_WIDTH1) / 2;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk_0, posedge clk_1) begin
+		if (done_sim)
+			$finish_and_return( (error_0_cnt == 0 & error_1_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"spram_18x1024_2x": begin
+			spram_18x1024_2x #() bram (
+				.clock0(clk_0),
+				.REN0_i(rce_0),
+				.RD_ADDR0_i(ra_0),
+				.RDATA0_o(rq_0),
+				.WEN0_i(wce_0),
+				.WR_ADDR0_i(wa_0),
+				.WDATA0_i(wd_0),
+
+				.clock1(clk_1),
+				.REN1_i(rce_1),
+				.RD_ADDR1_i(ra_1),
+				.RDATA1_o(rq_1),
+				.WEN1_i(wce_1),
+				.WR_ADDR1_i(wa_1),
+				.WDATA1_i(wd_1)
+			);
+		end
+		"spram_9x2048_x2": begin
+			spram_9x2048_x2 #() bram (
+				.clock0(clk_0),
+				.REN0_i(rce_0),
+				.RD_ADDR0_i(ra_0),
+				.RDATA0_o(rq_0),
+				.WEN0_i(wce_0),
+				.WR_ADDR0_i(wa_0),
+				.WDATA0_i(wd_0),
+
+				.clock1(clk_1),
+				.REN1_i(rce_1),
+				.RD_ADDR1_i(ra_1),
+				.RDATA1_o(rq_1),
+				.WEN1_i(wce_1),
+				.WR_ADDR1_i(wa_1),
+				.WDATA1_i(wd_1)
+			);
+		end
+		"spram_9x2048_18x1024": begin
+			spram_9x2048_18x1024 #() bram (
+				.clock0(clk_0),
+				.REN0_i(rce_0),
+				.RD_ADDR0_i(ra_0),
+				.RDATA0_o(rq_0),
+				.WEN0_i(wce_0),
+				.WR_ADDR0_i(wa_0),
+				.WDATA0_i(wd_0),
+
+				.clock1(clk_1),
+				.REN1_i(rce_1),
+				.RD_ADDR1_i(ra_1),
+				.RDATA1_o(rq_1),
+				.WEN1_i(wce_1),
+				.WR_ADDR1_i(wa_1),
+				.WDATA1_i(wd_1)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.tcl
@@ -1,0 +1,49 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram18k_sfifo
+
+select f1024x18_1024x18
+select *
+synth_quicklogic -family qlf_k6n10f -top f1024x18_1024x18 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f1024x18_1024x18_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X18_RD_X18_split
+
+select -clear
+design -load bram18k_sfifo
+select f1024x16_1024x16
+select *
+synth_quicklogic -family qlf_k6n10f -top f1024x16_1024x16 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f1024x16_1024x16_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X18_RD_X18_split
+
+select -clear
+design -load bram18k_sfifo
+select f2048x9_2048x9
+select *
+synth_quicklogic -family qlf_k6n10f -top f2048x9_2048x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f2048x9_2048x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X9_RD_X9_split
+
+select -clear
+design -load bram18k_sfifo
+select f2048x8_2048x8
+select *
+synth_quicklogic -family qlf_k6n10f -top f2048x8_2048x8 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f2048x8_2048x8_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X9_RD_X9_split

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module f1024x18_1024x18 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
 
 parameter WR_DATA_WIDTH = 18;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.v
@@ -1,0 +1,163 @@
+module f1024x18_1024x18 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f1024x16_1024x16 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 16;
+parameter RD_DATA_WIDTH = 16;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f2048x9_2048x9 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f2048x8_2048x8 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 8;
+parameter RD_DATA_WIDTH = 8;
+parameter UPAE_DBITS = 11'd10;
+parameter UPAF_DBITS = 11'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.v
@@ -32,7 +32,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -51,8 +51,7 @@ SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f1024x16_1024x16 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -73,7 +72,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -92,8 +91,7 @@ SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f2048x9_2048x9 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -114,7 +112,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -133,8 +131,7 @@ SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f2048x8_2048x8 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -155,7 +152,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -174,6 +171,5 @@ SFIFO_18K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram18k_sfifo_tb.v
+POST_SYNTH = f1024x18_1024x18_post_synth f1024x16_1024x16_post_synth f2048x9_2048x9_post_synth f2048x8_2048x8_post_synth
+ADDR_WIDTH0 = 10 10 11 11
+DATA_WIDTH0 = 18 16 9 8
+ADDR_WIDTH1 = 10 10 11 11
+DATA_WIDTH1 = 18 16 9 8
+TOP = f1024x18_1024x18 f1024x16_1024x16 f2048x9_2048x9 f2048x8_2048x8
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+# FIXME: $(call simulate_post_synth,5)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)
+	$(call simulate_post_synth,4)
+	$(call clean_post_synth_sim,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/bram18k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/bram18k_sfifo_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,29 +23,29 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk;
-  reg flush;
+	reg flush;
 	reg pop;
 	wire [`DATA_WIDTH1-1:0] dout;
 	reg push;
 	reg [`DATA_WIDTH0-1:0] din;
-  wire almost_full,almost_empty;
-  wire full, empty;
-  wire full_watermark, empty_watermark;
-  wire overrun_error, underrun_error;
+	wire almost_full,almost_empty;
+	wire full, empty;
+	wire full_watermark, empty_watermark;
+	wire overrun_error, underrun_error;
 
-  initial 
-  begin
-    clk = 0;
-    pop = 0;
-    push = 0;
-    flush = 1;
-    din = 0;
-    #40
-    flush = 0;
-  end
-  
+	initial 
+	begin
+		clk = 0;
+		pop = 0;
+		push = 0;
+		flush = 1;
+		din = 0;
+		#40
+		flush = 0;
+	end
+	
 	initial forever #(PERIOD / 3.0) clk = ~clk;
-  
+	
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -55,12 +55,12 @@ module TB;
 
 	reg done;
 	initial done = 1'b0;
-  
+	
 	reg read_test;
 	initial read_test = 0;
 
 	reg [`DATA_WIDTH1-1:0] expected;
-  initial expected = 0;
+	initial expected = 0;
 
 	always @(posedge clk) begin
 		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
@@ -76,7 +76,7 @@ module TB;
 	end
 
 	initial #(50) begin
-    @(posedge clk)
+		@(posedge clk)
 		// Write data
 		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
 			@(negedge clk) begin
@@ -114,75 +114,75 @@ module TB;
 	case (`STRINGIFY(`TOP))
 		"f1024x18_1024x18": begin
 			f1024x18_1024x18 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f1024x16_1024x16": begin
 			f1024x16_1024x16 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f2048x9_2048x9": begin
 			f2048x9_2048x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end	
 		"f2048x8_2048x8": begin
 			f2048x8_2048x8 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
-		end	    
+		end			
 	endcase
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/bram18k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/sim/bram18k_sfifo_tb.v
@@ -1,0 +1,188 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 30;
+	localparam ADDR_INCR = 1;
+
+	reg clk;
+  reg flush;
+	reg pop;
+	wire [`DATA_WIDTH1-1:0] dout;
+	reg push;
+	reg [`DATA_WIDTH0-1:0] din;
+  wire almost_full,almost_empty;
+  wire full, empty;
+  wire full_watermark, empty_watermark;
+  wire overrun_error, underrun_error;
+
+  initial 
+  begin
+    clk = 0;
+    pop = 0;
+    push = 0;
+    flush = 1;
+    din = 0;
+    #40
+    flush = 0;
+  end
+  
+	initial forever #(PERIOD / 3.0) clk = ~clk;
+  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+  
+	reg read_test;
+	initial read_test = 0;
+
+	reg [`DATA_WIDTH1-1:0] expected;
+  initial expected = 0;
+
+	always @(posedge clk) begin
+		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+
+	wire error = ((a != 0) && read_test) ? dout !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1; 
+	end
+
+	initial #(50) begin
+    @(posedge clk)
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				din = a | (a << 20) | 20'h55000;
+				push = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk) begin
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+			@(negedge clk) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"f1024x18_1024x18": begin
+			f1024x18_1024x18 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f1024x16_1024x16": begin
+			f1024x16_1024x16 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f2048x9_2048x9": begin
+			f2048x9_2048x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end	
+		"f2048x8_2048x8": begin
+			f2048x8_2048x8 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end	    
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.tcl
@@ -1,0 +1,39 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram18k_tdp
+
+select dpram_18x1024_x2
+select *
+synth_quicklogic -family qlf_k6n10f -top dpram_18x1024_x2 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/dpram_18x1024_x2_post_synth.v
+select -assert-count 2 t:TDP36K_BRAM_WR_X18_RD_X18_split
+
+select -clear
+design -load bram18k_tdp
+select dpram_9x2048_x2
+select *
+synth_quicklogic -family qlf_k6n10f -top dpram_9x2048_x2 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/dpram_9x2048_x2_post_synth.v
+select -assert-count 2 t:TDP36K_BRAM_WR_X9_RD_X9_split
+
+select -clear
+design -load bram18k_tdp
+select dpram_18x1024_9x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top dpram_18x1024_9x2048 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/dpram_18x1024_9x2048_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X18_split
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X9_split

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.v
@@ -1,0 +1,380 @@
+module dpram_18x1024_x2 (   
+    clk_a_0,
+    WEN_a_0,
+    REN_a_0,
+    WR_ADDR_a_0,
+    RD_ADDR_a_0,
+    WDATA_a_0,
+    RDATA_a_0,
+    
+    clk_b_0,
+    WEN_b_0,
+    REN_b_0,
+    WR_ADDR_b_0,
+    RD_ADDR_b_0,
+    WDATA_b_0,
+    RDATA_b_0,
+    
+    clk_a_1,
+    WEN_a_1,
+    REN_a_1,
+    WR_ADDR_a_1,
+    RD_ADDR_a_1,
+    WDATA_a_1,
+    RDATA_a_1,
+    
+    clk_b_1,
+    WEN_b_1,
+    REN_b_1,
+    WR_ADDR_b_1,
+    RD_ADDR_b_1,
+    WDATA_b_1,
+    RDATA_b_1
+);
+
+parameter ADDR_WIDTH0 = 10;
+parameter DATA_WIDTH0 = 18;
+parameter BE1_WIDTH0 = 2;
+parameter BE2_WIDTH0 = 2;
+
+parameter ADDR_WIDTH1 = 10;
+parameter DATA_WIDTH1 = 18;
+parameter BE1_WIDTH1 = 2;
+parameter BE2_WIDTH1 = 2;
+
+input wire clk_a_0;
+input wire WEN_a_0;
+input wire REN_a_0;
+input wire [ADDR_WIDTH0-1 :0] WR_ADDR_a_0;
+input wire [ADDR_WIDTH0-1 :0] RD_ADDR_a_0;
+input wire [DATA_WIDTH0-1 :0] WDATA_a_0;
+output wire [DATA_WIDTH0-1 :0] RDATA_a_0;
+
+input wire clk_b_0;
+input wire WEN_b_0;
+input wire REN_b_0;
+input wire [ADDR_WIDTH0-1 :0] WR_ADDR_b_0;
+input wire [ADDR_WIDTH0-1 :0] RD_ADDR_b_0;
+input wire [DATA_WIDTH0-1 :0] WDATA_b_0;
+output wire [DATA_WIDTH0-1 :0] RDATA_b_0;
+
+input wire clk_a_1;
+input wire WEN_a_1;
+input wire REN_a_1;
+input wire [ADDR_WIDTH1-1 :0] WR_ADDR_a_1;
+input wire [ADDR_WIDTH1-1 :0] RD_ADDR_a_1;
+input wire [DATA_WIDTH1-1 :0] WDATA_a_1;
+output wire [DATA_WIDTH1-1 :0] RDATA_a_1;
+
+input wire clk_b_1;
+input wire WEN_b_1;
+input wire REN_b_1;
+input wire [ADDR_WIDTH1-1 :0] WR_ADDR_b_1;
+input wire [ADDR_WIDTH1-1 :0] RD_ADDR_b_1;
+input wire [DATA_WIDTH1-1 :0] WDATA_b_1;
+output wire [DATA_WIDTH1-1 :0] RDATA_b_1;
+ 
+DPRAM_18K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH0),
+              .DATA_WIDTH(DATA_WIDTH0),
+              .BE1_WIDTH(BE1_WIDTH0),
+              .BE2_WIDTH(BE2_WIDTH0)
+              ) dpram_x18_inst0 ( 
+              
+              .CLK1_i(clk_a_0),
+              .WEN1_i(WEN_a_0),
+              .REN1_i(REN_a_0),
+              .WR1_ADDR_i(WR_ADDR_a_0),
+              .RD1_ADDR_i(RD_ADDR_a_0),
+              .WDATA1_i(WDATA_a_0),
+              .RDATA1_o(RDATA_a_0),
+              
+              .CLK2_i(clk_b_0),
+              .WEN2_i(WEN_b_0),
+              .REN2_i(REN_b_0),
+              .WR2_ADDR_i(WR_ADDR_b_0),
+              .RD2_ADDR_i(RD_ADDR_b_0),
+              .WDATA2_i(WDATA_b_0),
+              .RDATA2_o(RDATA_b_0)
+              );
+              
+ 
+DPRAM_18K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH1),
+              .DATA_WIDTH(DATA_WIDTH1),
+              .BE1_WIDTH(BE1_WIDTH1),
+              .BE2_WIDTH(BE2_WIDTH1)
+              ) dpram_x18_inst1 ( 
+              
+              .CLK1_i(clk_a_1),
+              .WEN1_i(WEN_a_1),
+              .REN1_i(REN_a_1),
+              .WR1_ADDR_i(WR_ADDR_a_1),
+              .RD1_ADDR_i(RD_ADDR_a_1),
+              .WDATA1_i(WDATA_a_1),
+              .RDATA1_o(RDATA_a_1),
+              
+              .CLK2_i(clk_b_1),
+              .WEN2_i(WEN_b_1),
+              .REN2_i(REN_b_1),
+              .WR2_ADDR_i(WR_ADDR_b_1),
+              .RD2_ADDR_i(RD_ADDR_b_1),
+              .WDATA2_i(WDATA_b_1),
+              .RDATA2_o(RDATA_b_1)
+              );
+              
+endmodule    
+
+module dpram_9x2048_x2 (   
+    clk_a_0,
+    WEN_a_0,
+    REN_a_0,
+    WR_ADDR_a_0,
+    RD_ADDR_a_0,
+    WDATA_a_0,
+    RDATA_a_0,
+    
+    clk_b_0,
+    WEN_b_0,
+    REN_b_0,
+    WR_ADDR_b_0,
+    RD_ADDR_b_0,
+    WDATA_b_0,
+    RDATA_b_0,
+    
+    clk_a_1,
+    WEN_a_1,
+    REN_a_1,
+    WR_ADDR_a_1,
+    RD_ADDR_a_1,
+    WDATA_a_1,
+    RDATA_a_1,
+    
+    clk_b_1,
+    WEN_b_1,
+    REN_b_1,
+    WR_ADDR_b_1,
+    RD_ADDR_b_1,
+    WDATA_b_1,
+    RDATA_b_1
+);
+
+parameter ADDR_WIDTH0 = 11;
+parameter DATA_WIDTH0 = 9;
+parameter BE1_WIDTH0 = 1;
+parameter BE2_WIDTH0 = 1;
+
+parameter ADDR_WIDTH1 = 11;
+parameter DATA_WIDTH1 = 9;
+parameter BE1_WIDTH1 = 1;
+parameter BE2_WIDTH1 = 1;
+
+input wire clk_a_0;
+input wire WEN_a_0;
+input wire REN_a_0;
+input wire [ADDR_WIDTH0-1 :0] WR_ADDR_a_0;
+input wire [ADDR_WIDTH0-1 :0] RD_ADDR_a_0;
+input wire [DATA_WIDTH0-1 :0] WDATA_a_0;
+output wire [DATA_WIDTH0-1 :0] RDATA_a_0;
+
+input wire clk_b_0;
+input wire WEN_b_0;
+input wire REN_b_0;
+input wire [ADDR_WIDTH0-1 :0] WR_ADDR_b_0;
+input wire [ADDR_WIDTH0-1 :0] RD_ADDR_b_0;
+input wire [DATA_WIDTH0-1 :0] WDATA_b_0;
+output wire [DATA_WIDTH0-1 :0] RDATA_b_0;
+
+input wire clk_a_1;
+input wire WEN_a_1;
+input wire REN_a_1;
+input wire [ADDR_WIDTH1-1 :0] WR_ADDR_a_1;
+input wire [ADDR_WIDTH1-1 :0] RD_ADDR_a_1;
+input wire [DATA_WIDTH1-1 :0] WDATA_a_1;
+output wire [DATA_WIDTH1-1 :0] RDATA_a_1;
+
+input wire clk_b_1;
+input wire WEN_b_1;
+input wire REN_b_1;
+input wire [ADDR_WIDTH1-1 :0] WR_ADDR_b_1;
+input wire [ADDR_WIDTH1-1 :0] RD_ADDR_b_1;
+input wire [DATA_WIDTH1-1 :0] WDATA_b_1;
+output wire [DATA_WIDTH1-1 :0] RDATA_b_1;
+ 
+DPRAM_18K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH0),
+              .DATA_WIDTH(DATA_WIDTH0),
+              .BE1_WIDTH(BE1_WIDTH0),
+              .BE2_WIDTH(BE2_WIDTH0)
+              ) dpram_x18_inst0 ( 
+              
+              .CLK1_i(clk_a_0),
+              .WEN1_i(WEN_a_0),
+              .REN1_i(REN_a_0),
+              .WR1_ADDR_i(WR_ADDR_a_0),
+              .RD1_ADDR_i(RD_ADDR_a_0),
+              .WDATA1_i(WDATA_a_0),
+              .RDATA1_o(RDATA_a_0),
+              
+              .CLK2_i(clk_b_0),
+              .WEN2_i(WEN_b_0),
+              .REN2_i(REN_b_0),
+              .WR2_ADDR_i(WR_ADDR_b_0),
+              .RD2_ADDR_i(RD_ADDR_b_0),
+              .WDATA2_i(WDATA_b_0),
+              .RDATA2_o(RDATA_b_0)
+              );
+              
+ 
+DPRAM_18K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH1),
+              .DATA_WIDTH(DATA_WIDTH1),
+              .BE1_WIDTH(BE1_WIDTH1),
+              .BE2_WIDTH(BE2_WIDTH1)
+              ) dpram_x18_inst1 ( 
+              
+              .CLK1_i(clk_a_1),
+              .WEN1_i(WEN_a_1),
+              .REN1_i(REN_a_1),
+              .WR1_ADDR_i(WR_ADDR_a_1),
+              .RD1_ADDR_i(RD_ADDR_a_1),
+              .WDATA1_i(WDATA_a_1),
+              .RDATA1_o(RDATA_a_1),
+              
+              .CLK2_i(clk_b_1),
+              .WEN2_i(WEN_b_1),
+              .REN2_i(REN_b_1),
+              .WR2_ADDR_i(WR_ADDR_b_1),
+              .RD2_ADDR_i(RD_ADDR_b_1),
+              .WDATA2_i(WDATA_b_1),
+              .RDATA2_o(RDATA_b_1)
+              );
+              
+endmodule    
+
+module dpram_18x1024_9x2048 (   
+    clk_a_0,
+    WEN_a_0,
+    REN_a_0,
+    WR_ADDR_a_0,
+    RD_ADDR_a_0,
+    WDATA_a_0,
+    RDATA_a_0,
+    
+    clk_b_0,
+    WEN_b_0,
+    REN_b_0,
+    WR_ADDR_b_0,
+    RD_ADDR_b_0,
+    WDATA_b_0,
+    RDATA_b_0,
+    
+    clk_a_1,
+    WEN_a_1,
+    REN_a_1,
+    WR_ADDR_a_1,
+    RD_ADDR_a_1,
+    WDATA_a_1,
+    RDATA_a_1,
+    
+    clk_b_1,
+    WEN_b_1,
+    REN_b_1,
+    WR_ADDR_b_1,
+    RD_ADDR_b_1,
+    WDATA_b_1,
+    RDATA_b_1
+);
+
+parameter ADDR_WIDTH0 = 10;
+parameter DATA_WIDTH0 = 18;
+parameter BE1_WIDTH0 = 2;
+parameter BE2_WIDTH0 = 2;
+
+parameter ADDR_WIDTH1 = 11;
+parameter DATA_WIDTH1 = 9;
+parameter BE1_WIDTH1 = 1;
+parameter BE2_WIDTH1 = 1;
+
+input wire clk_a_0;
+input wire WEN_a_0;
+input wire REN_a_0;
+input wire [ADDR_WIDTH0-1 :0] WR_ADDR_a_0;
+input wire [ADDR_WIDTH0-1 :0] RD_ADDR_a_0;
+input wire [DATA_WIDTH0-1 :0] WDATA_a_0;
+output wire [DATA_WIDTH0-1 :0] RDATA_a_0;
+
+input wire clk_b_0;
+input wire WEN_b_0;
+input wire REN_b_0;
+input wire [ADDR_WIDTH0-1 :0] WR_ADDR_b_0;
+input wire [ADDR_WIDTH0-1 :0] RD_ADDR_b_0;
+input wire [DATA_WIDTH0-1 :0] WDATA_b_0;
+output wire [DATA_WIDTH0-1 :0] RDATA_b_0;
+
+input wire clk_a_1;
+input wire WEN_a_1;
+input wire REN_a_1;
+input wire [ADDR_WIDTH1-1 :0] WR_ADDR_a_1;
+input wire [ADDR_WIDTH1-1 :0] RD_ADDR_a_1;
+input wire [DATA_WIDTH1-1 :0] WDATA_a_1;
+output wire [DATA_WIDTH1-1 :0] RDATA_a_1;
+
+input wire clk_b_1;
+input wire WEN_b_1;
+input wire REN_b_1;
+input wire [ADDR_WIDTH1-1 :0] WR_ADDR_b_1;
+input wire [ADDR_WIDTH1-1 :0] RD_ADDR_b_1;
+input wire [DATA_WIDTH1-1 :0] WDATA_b_1;
+output wire [DATA_WIDTH1-1 :0] RDATA_b_1;
+ 
+DPRAM_18K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH0),
+              .DATA_WIDTH(DATA_WIDTH0),
+              .BE1_WIDTH(BE1_WIDTH0),
+              .BE2_WIDTH(BE2_WIDTH0)
+              ) dpram_x18_inst0 ( 
+              
+              .CLK1_i(clk_a_0),
+              .WEN1_i(WEN_a_0),
+              .REN1_i(REN_a_0),
+              .WR1_ADDR_i(WR_ADDR_a_0),
+              .RD1_ADDR_i(RD_ADDR_a_0),
+              .WDATA1_i(WDATA_a_0),
+              .RDATA1_o(RDATA_a_0),
+              
+              .CLK2_i(clk_b_0),
+              .WEN2_i(WEN_b_0),
+              .REN2_i(REN_b_0),
+              .WR2_ADDR_i(WR_ADDR_b_0),
+              .RD2_ADDR_i(RD_ADDR_b_0),
+              .WDATA2_i(WDATA_b_0),
+              .RDATA2_o(RDATA_b_0)
+              );
+              
+ 
+DPRAM_18K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH1),
+              .DATA_WIDTH(DATA_WIDTH1),
+              .BE1_WIDTH(BE1_WIDTH1),
+              .BE2_WIDTH(BE2_WIDTH1)
+              ) dpram_x18_inst1 ( 
+              
+              .CLK1_i(clk_a_1),
+              .WEN1_i(WEN_a_1),
+              .REN1_i(REN_a_1),
+              .WR1_ADDR_i(WR_ADDR_a_1),
+              .RD1_ADDR_i(RD_ADDR_a_1),
+              .WDATA1_i(WDATA_a_1),
+              .RDATA1_o(RDATA_a_1),
+              
+              .CLK2_i(clk_b_1),
+              .WEN2_i(WEN_b_1),
+              .REN2_i(REN_b_1),
+              .WR2_ADDR_i(WR_ADDR_b_1),
+              .RD2_ADDR_i(RD_ADDR_b_1),
+              .WDATA2_i(WDATA_b_1),
+              .RDATA2_o(RDATA_b_1)
+              );
+              
+endmodule    

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module dpram_18x1024_x2 (   
     clk_a_0,
     WEN_a_0,

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-#FIXME: $(call simulate_post_synth,3)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/Makefile
@@ -1,0 +1,41 @@
+# Copyright (C) 2019-2022 The SymbiFlow Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+TESTBENCH = bram18k_tdp_tb.v
+POST_SYNTH = dpram_18x1024_9x2048_post_synth dpram_9x2048_x2_post_synth dpram_18x1024_x2_post_synth   
+ADDR_WIDTH0 = 10 11 10
+DATA_WIDTH0 = 18 9 18
+ADDR_WIDTH1 = 11 11 10
+DATA_WIDTH1 = 9 9 18
+TOP = dpram_18x1024_9x2048 dpram_9x2048_x2 dpram_18x1024_x2
+ADDR_DEFINES0 = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR_DEFINES1 = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA_DEFINES0 = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA_DEFINES1 = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR_DEFINES0)) $(word $(1),$(ADDR_DEFINES1)) $(word $(1),$(DATA_DEFINES0)) $(word $(1),$(DATA_DEFINES1)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+#FIXME: $(call simulate_post_synth,3)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/Makefile
@@ -1,10 +1,18 @@
-# Copyright (C) 2019-2022 The SymbiFlow Authors
+# Copyright 2020-2022 F4PGA Authors
 #
-# Use of this source code is governed by a ISC-style
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/ISC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# SPDX-License-Identifier: ISC
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 TESTBENCH = bram18k_tdp_tb.v
 POST_SYNTH = dpram_18x1024_9x2048_post_synth dpram_9x2048_x2_post_synth dpram_18x1024_x2_post_synth   

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/bram18k_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/bram18k_tdp_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,29 +24,29 @@ module TB;
 
 	reg clk_a;
 	reg rce_a_0;
-  reg rce_a_1;
+	reg rce_a_1;
 	reg [`ADDR_WIDTH0-1:0] ra_a_0;
-  reg [`ADDR_WIDTH1-1:0] ra_a_1;
+	reg [`ADDR_WIDTH1-1:0] ra_a_1;
 	wire [`DATA_WIDTH0-1:0] rq_a_0;
 	wire [`DATA_WIDTH1-1:0] rq_a_1;
 	reg wce_a_0;
-  reg wce_a_1;
+	reg wce_a_1;
 	reg [`ADDR_WIDTH0-1:0] wa_a_0;
-  reg [`ADDR_WIDTH1-1:0] wa_a_1;
+	reg [`ADDR_WIDTH1-1:0] wa_a_1;
 	reg [`DATA_WIDTH0-1:0] wd_a_0;
 	reg [`DATA_WIDTH1-1:0] wd_a_1;
 
 	reg clk_b;
 	reg rce_b_0;
-  reg rce_b_1;
+	reg rce_b_1;
 	reg [`ADDR_WIDTH0-1:0] ra_b_0;
-  reg [`ADDR_WIDTH1-1:0] ra_b_1;
+	reg [`ADDR_WIDTH1-1:0] ra_b_1;
 	wire [`DATA_WIDTH0-1:0] rq_b_0;
 	wire [`DATA_WIDTH1-1:0] rq_b_1;
 	reg wce_b_0;
-  reg wce_b_1;
+	reg wce_b_1;
 	reg [`ADDR_WIDTH0-1:0] wa_b_0;
-  reg [`ADDR_WIDTH1-1:0] wa_b_1;
+	reg [`ADDR_WIDTH1-1:0] wa_b_1;
 	reg [`DATA_WIDTH0-1:0] wd_b_0;
 	reg [`DATA_WIDTH1-1:0] wd_b_1;
 
@@ -54,22 +54,22 @@ module TB;
 	initial clk_a = 0;
 	initial clk_b = 0;
 	initial ra_a_0 = 0;
-  initial ra_a_1 = 0;
+	initial ra_a_1 = 0;
 	initial ra_b_0 = 0;
-  initial ra_b_1 = 0;
+	initial ra_b_1 = 0;
 	initial rce_a_0 = 0;
-  initial rce_a_1 = 0;
+	initial rce_a_1 = 0;
 	initial rce_b_0 = 0;
-  initial rce_b_1 = 0;
+	initial rce_b_1 = 0;
 	initial wce_a_0 = 0;
-  initial wce_a_1 = 0;
+	initial wce_a_1 = 0;
 	initial wce_b_0 = 0;
-  initial wce_b_1 = 0;
+	initial wce_b_1 = 0;
 	initial forever #(PERIOD / 2.0) clk_a = ~clk_a;
 	initial begin
 		#(PERIOD / 4.0);
 		forever #(PERIOD / 2.0) clk_b = ~clk_b;
-	end  
+	end	 
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -96,12 +96,12 @@ module TB;
 	reg [`DATA_WIDTH1-1:0] expected_b_1;
 
 	always @(posedge clk_a) begin
-      expected_a_0 <= (a0 | (a0 << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
-      expected_a_1 <= ((a1+1) | ((a1+1) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+			expected_a_0 <= (a0 | (a0 << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
+			expected_a_1 <= ((a1+1) | ((a1+1) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
 	end
 	always @(posedge clk_b) begin
-      expected_b_0 <= ((b0+2) | ((b0+2) << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
-      expected_b_1 <= ((b1+3) | ((b1+3) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+			expected_b_0 <= ((b0+2) | ((b0+2) << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
+			expected_b_1 <= ((b1+3) | ((b1+3) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
 	end
 
 	wire error_a_0 = a0 != 0 ? (rq_a_0 !== expected_a_0) : 0;
@@ -158,10 +158,10 @@ module TB;
 			end
 		end
 		done_a0 = 1'b1;
-    a0 = 0;
-	  // PORTs B0
-    @(posedge clk_b)
-    #2;
+		a0 = 0;
+		// PORTs B0
+		@(posedge clk_b)
+		#2;
 		// Write data
 		for (b0 = (1<<`ADDR_WIDTH0) / 2; b0 < (1<<`ADDR_WIDTH0); b0 = b0 + ADDR_INCR) begin
 			@(negedge clk_b) begin
@@ -189,10 +189,10 @@ module TB;
 			end
 		end
 		done_b0 = 1'b1;
-	  b0 = (1<<`ADDR_WIDTH0) / 2;
-	  // PORTs A1
-    @(posedge clk_a)
-    #2;
+		b0 = (1<<`ADDR_WIDTH0) / 2;
+		// PORTs A1
+		@(posedge clk_a)
+		#2;
 		// Write data
 		for (a1 = 0; a1 < (1<<`ADDR_WIDTH1) / 2; a1 = a1 + ADDR_INCR) begin
 			@(negedge clk_a) begin
@@ -220,10 +220,10 @@ module TB;
 			end
 		end
 		done_a1 = 1'b1;
-    a1 = 0;
-	  // PORTs B1
-    @(posedge clk_b)
-    #2;
+		a1 = 0;
+		// PORTs B1
+		@(posedge clk_b)
+		#2;
 		// Write data
 		for (b1 = (1<<`ADDR_WIDTH1) / 2; b1 < (1<<`ADDR_WIDTH1); b1 = b1 + ADDR_INCR) begin
 			@(negedge clk_b) begin
@@ -251,7 +251,7 @@ module TB;
 			end
 		end
 		done_b1 = 1'b1;
-    b1 = (1<<`ADDR_WIDTH1) / 2;
+		b1 = (1<<`ADDR_WIDTH1) / 2;
 	end
 
 	// Scan for simulation finish
@@ -259,7 +259,7 @@ module TB;
 		if (done_sim)
 			$finish_and_return( (error_a_0_cnt == 0 & error_b_0_cnt == 0 & error_a_1_cnt == 0 & error_b_1_cnt == 0) ? 0 : -1 );
 	end
-  
+	
 	case (`STRINGIFY(`TOP))
 		"dpram_18x1024_9x2048": begin
 			dpram_18x1024_9x2048 #() bram (

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/bram18k_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/bram18k_tdp_tb.v
@@ -1,0 +1,356 @@
+// Copyright (C) 2019-2022 The SymbiFlow Authors
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_a;
+	reg rce_a_0;
+  reg rce_a_1;
+	reg [`ADDR_WIDTH0-1:0] ra_a_0;
+  reg [`ADDR_WIDTH1-1:0] ra_a_1;
+	wire [`DATA_WIDTH0-1:0] rq_a_0;
+	wire [`DATA_WIDTH1-1:0] rq_a_1;
+	reg wce_a_0;
+  reg wce_a_1;
+	reg [`ADDR_WIDTH0-1:0] wa_a_0;
+  reg [`ADDR_WIDTH1-1:0] wa_a_1;
+	reg [`DATA_WIDTH0-1:0] wd_a_0;
+	reg [`DATA_WIDTH1-1:0] wd_a_1;
+
+	reg clk_b;
+	reg rce_b_0;
+  reg rce_b_1;
+	reg [`ADDR_WIDTH0-1:0] ra_b_0;
+  reg [`ADDR_WIDTH1-1:0] ra_b_1;
+	wire [`DATA_WIDTH0-1:0] rq_b_0;
+	wire [`DATA_WIDTH1-1:0] rq_b_1;
+	reg wce_b_0;
+  reg wce_b_1;
+	reg [`ADDR_WIDTH0-1:0] wa_b_0;
+  reg [`ADDR_WIDTH1-1:0] wa_b_1;
+	reg [`DATA_WIDTH0-1:0] wd_b_0;
+	reg [`DATA_WIDTH1-1:0] wd_b_1;
+
+
+	initial clk_a = 0;
+	initial clk_b = 0;
+	initial ra_a_0 = 0;
+  initial ra_a_1 = 0;
+	initial ra_b_0 = 0;
+  initial ra_b_1 = 0;
+	initial rce_a_0 = 0;
+  initial rce_a_1 = 0;
+	initial rce_b_0 = 0;
+  initial rce_b_1 = 0;
+	initial wce_a_0 = 0;
+  initial wce_a_1 = 0;
+	initial wce_b_0 = 0;
+  initial wce_b_1 = 0;
+	initial forever #(PERIOD / 2.0) clk_a = ~clk_a;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_b = ~clk_b;
+	end  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a0;
+	integer b0;
+	integer a1;
+	integer b1;
+
+	reg done_a0;
+	reg done_b0;
+	reg done_a1;
+	reg done_b1;
+	initial done_a0 = 1'b0;
+	initial done_b0 = 1'b0;
+	initial done_a1 = 1'b0;
+	initial done_b1 = 1'b0;
+	wire done_sim = done_a0 & done_b0 & done_a1 & done_b1;
+
+	reg [`DATA_WIDTH0-1:0] expected_a_0;
+	reg [`DATA_WIDTH1-1:0] expected_a_1;
+	reg [`DATA_WIDTH0-1:0] expected_b_0;
+	reg [`DATA_WIDTH1-1:0] expected_b_1;
+
+	always @(posedge clk_a) begin
+      expected_a_0 <= (a0 | (a0 << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
+      expected_a_1 <= ((a1+1) | ((a1+1) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+	always @(posedge clk_b) begin
+      expected_b_0 <= ((b0+2) | ((b0+2) << 20) | 20'h55000) & {`DATA_WIDTH0{1'b1}};
+      expected_b_1 <= ((b1+3) | ((b1+3) << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+
+	wire error_a_0 = a0 != 0 ? (rq_a_0 !== expected_a_0) : 0;
+	wire error_a_1 = a1 != 0 ? (rq_a_1 !== expected_a_1) : 0;
+	wire error_b_0 = b0 != (1<<`ADDR_WIDTH0) / 2 ? (rq_b_0 !== expected_b_0) : 0;
+	wire error_b_1 = b1 != (1<<`ADDR_WIDTH1) / 2 ? (rq_b_1 !== expected_b_1) : 0;
+
+	integer error_a_0_cnt = 0;
+	integer error_a_1_cnt = 0;
+	integer error_b_0_cnt = 0;
+	integer error_b_1_cnt = 0;
+
+	always @ (posedge clk_a)
+	begin
+		if (error_a_0)
+			error_a_0_cnt <= error_a_0_cnt + 1'b1;
+		if (error_a_1)
+			error_a_1_cnt <= error_a_1_cnt + 1'b1;
+	end
+	always @ (posedge clk_b)
+	begin
+		if (error_b_0)
+			error_b_0_cnt <= error_b_0_cnt + 1'b1;
+		if (error_b_1)
+			error_b_1_cnt <= error_b_1_cnt + 1'b1;
+	end
+
+	// PORTs A0
+	initial #(1) begin
+		// Write data
+		for (a0 = 0; a0 < (1<<`ADDR_WIDTH0) / 2; a0 = a0 + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				wa_a_0 = a0;
+				wd_a_0 = a0 | (a0 << 20) | 20'h55000;
+				wce_a_0 = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) wce_a_0 = 0;
+			end
+		end
+		// Read data
+		for (a0 = 0; a0 < (1<<`ADDR_WIDTH0) / 2; a0 = a0 + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				ra_a_0 = a0;
+				rce_a_0 = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) rce_a_0 = 0;
+				if ( rq_a_0 !== expected_a_0) begin
+					$display("%d: PORT A0: FAIL: mismatch act=%x exp=%x at %x", $time, rq_a_0, expected_a_0, a0);
+				end else begin
+					$display("%d: PORT A0: OK: act=%x exp=%x at %x", $time, rq_a_0, expected_a_0, a0);
+				end
+			end
+		end
+		done_a0 = 1'b1;
+    a0 = 0;
+	  // PORTs B0
+    @(posedge clk_b)
+    #2;
+		// Write data
+		for (b0 = (1<<`ADDR_WIDTH0) / 2; b0 < (1<<`ADDR_WIDTH0); b0 = b0 + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				wa_b_0 = b0;
+				wd_b_0 = (b0+2) | ((b0+2) << 20) | 20'h55000;
+				wce_b_0 = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) wce_b_0 = 0;
+			end
+		end
+		// Read data
+		for (b0 = (1<<`ADDR_WIDTH0) / 2; b0 < (1<<`ADDR_WIDTH0); b0 = b0 + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				ra_b_0 = b0;
+				rce_b_0 = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) rce_b_0 = 0;
+				if ( rq_b_0 !== expected_b_0) begin
+					$display("%d: PORT B0: FAIL: mismatch act=%x exp=%x at %x", $time, rq_b_0, expected_b_0, b0);
+				end else begin
+					$display("%d: PORT B0: OK: act=%x exp=%x at %x", $time, rq_b_0, expected_b_0, b0);
+				end
+			end
+		end
+		done_b0 = 1'b1;
+	  b0 = (1<<`ADDR_WIDTH0) / 2;
+	  // PORTs A1
+    @(posedge clk_a)
+    #2;
+		// Write data
+		for (a1 = 0; a1 < (1<<`ADDR_WIDTH1) / 2; a1 = a1 + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				wa_a_1 = a1;
+				wd_a_1 = (a1+1) | ((a1+1) << 20) | 20'h55000;
+				wce_a_1 = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) wce_a_1 = 0;
+			end
+		end
+		// Read data
+		for (a1 = 0; a1 < (1<<`ADDR_WIDTH1) / 2; a1 = a1 + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				ra_a_1 = a1;
+				rce_a_1 = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) rce_a_1 = 0;
+				if ( rq_a_1 !== expected_a_1) begin
+					$display("%d: PORT A1: FAIL: mismatch act=%x exp=%x at %x", $time, rq_a_1, expected_a_1, a1);
+				end else begin
+					$display("%d: PORT A1: OK: act=%x exp=%x at %x", $time, rq_a_1, expected_a_1, a1);
+				end
+			end
+		end
+		done_a1 = 1'b1;
+    a1 = 0;
+	  // PORTs B1
+    @(posedge clk_b)
+    #2;
+		// Write data
+		for (b1 = (1<<`ADDR_WIDTH1) / 2; b1 < (1<<`ADDR_WIDTH1); b1 = b1 + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				wa_b_1 = b1;
+				wd_b_1 = (b1+3) | ((b1+3) << 20) | 20'h55000;
+				wce_b_1 = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) wce_b_1 = 0;
+			end
+		end
+		// Read data
+		for (b1 = (1<<`ADDR_WIDTH1) / 2; b1 < (1<<`ADDR_WIDTH1); b1 = b1 + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				ra_b_1 = b1;
+				rce_b_1 = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) rce_b_1 = 0;
+				if ( rq_b_1 !== expected_b_1) begin
+					$display("%d: PORT B1: FAIL: mismatch act=%x exp=%x at %x", $time, rq_b_1, expected_b_1, b1);
+				end else begin
+					$display("%d: PORT B1: OK: act=%x exp=%x at %x", $time, rq_b_1, expected_b_1, b1);
+				end
+			end
+		end
+		done_b1 = 1'b1;
+    b1 = (1<<`ADDR_WIDTH1) / 2;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk_a, posedge clk_b) begin
+		if (done_sim)
+			$finish_and_return( (error_a_0_cnt == 0 & error_b_0_cnt == 0 & error_a_1_cnt == 0 & error_b_1_cnt == 0) ? 0 : -1 );
+	end
+  
+	case (`STRINGIFY(`TOP))
+		"dpram_18x1024_9x2048": begin
+			dpram_18x1024_9x2048 #() bram (
+				.clk_a_0(clk_a),
+				.REN_a_0(rce_a_0),
+				.RD_ADDR_a_0(ra_a_0),
+				.RDATA_a_0(rq_a_0),
+				.WEN_a_0(wce_a_0),
+				.WR_ADDR_a_0(wa_a_0),
+				.WDATA_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.REN_b_0(rce_b_0),
+				.RD_ADDR_b_0(ra_b_0),
+				.RDATA_b_0(rq_b_0),
+				.WEN_b_0(wce_b_0),
+				.WR_ADDR_b_0(wa_b_0),
+				.WDATA_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.REN_a_1(rce_a_1),
+				.RD_ADDR_a_1(ra_a_1),
+				.RDATA_a_1(rq_a_1),
+				.WEN_a_1(wce_a_1),
+				.WR_ADDR_a_1(wa_a_1),
+				.WDATA_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.REN_b_1(rce_b_1),
+				.RD_ADDR_b_1(ra_b_1),
+				.RDATA_b_1(rq_b_1),
+				.WEN_b_1(wce_b_1),
+				.WR_ADDR_b_1(wa_b_1),
+				.WDATA_b_1(wd_b_1)
+			);
+		end
+		"dpram_9x2048_x2": begin
+			dpram_9x2048_x2 #() bram (
+				.clk_a_0(clk_a),
+				.REN_a_0(rce_a_0),
+				.RD_ADDR_a_0(ra_a_0),
+				.RDATA_a_0(rq_a_0),
+				.WEN_a_0(wce_a_0),
+				.WR_ADDR_a_0(wa_a_0),
+				.WDATA_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.REN_b_0(rce_b_0),
+				.RD_ADDR_b_0(ra_b_0),
+				.RDATA_b_0(rq_b_0),
+				.WEN_b_0(wce_b_0),
+				.WR_ADDR_b_0(wa_b_0),
+				.WDATA_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.REN_a_1(rce_a_1),
+				.RD_ADDR_a_1(ra_a_1),
+				.RDATA_a_1(rq_a_1),
+				.WEN_a_1(wce_a_1),
+				.WR_ADDR_a_1(wa_a_1),
+				.WDATA_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.REN_b_1(rce_b_1),
+				.RD_ADDR_b_1(ra_b_1),
+				.RDATA_b_1(rq_b_1),
+				.WEN_b_1(wce_b_1),
+				.WR_ADDR_b_1(wa_b_1),
+				.WDATA_b_1(wd_b_1)
+			);
+		end
+		"dpram_18x1024_x2": begin
+			dpram_18x1024_x2 #() bram (
+				.clk_a_0(clk_a),
+				.REN_a_0(rce_a_0),
+				.RD_ADDR_a_0(ra_a_0),
+				.RDATA_a_0(rq_a_0),
+				.WEN_a_0(wce_a_0),
+				.WR_ADDR_a_0(wa_a_0),
+				.WDATA_a_0(wd_a_0),
+				.clk_b_0(clk_b),
+				.REN_b_0(rce_b_0),
+				.RD_ADDR_b_0(ra_b_0),
+				.RDATA_b_0(rq_b_0),
+				.WEN_b_0(wce_b_0),
+				.WR_ADDR_b_0(wa_b_0),
+				.WDATA_b_0(wd_b_0),
+
+				.clk_a_1(clk_a),
+				.REN_a_1(rce_a_1),
+				.RD_ADDR_a_1(ra_a_1),
+				.RDATA_a_1(rq_a_1),
+				.WEN_a_1(wce_a_1),
+				.WR_ADDR_a_1(wa_a_1),
+				.WDATA_a_1(wd_a_1),
+				.clk_b_1(clk_b),
+				.REN_b_1(rce_b_1),
+				.RD_ADDR_b_1(ra_b_1),
+				.RDATA_b_1(rq_b_1),
+				.WEN_b_1(wce_b_1),
+				.WR_ADDR_b_1(wa_b_1),
+				.WDATA_b_1(wd_b_1)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/bram18k_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/sim/bram18k_tdp_tb.v
@@ -1,10 +1,18 @@
-// Copyright (C) 2019-2022 The SymbiFlow Authors
+// Copyright 2020-2022 F4PGA Authors
 //
-// Use of this source code is governed by a ISC-style
-// license that can be found in the LICENSE file or at
-// https://opensource.org/licenses/ISC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: ISC
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 `timescale 1ns/1ps
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.tcl
@@ -1,0 +1,38 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram36k_afifo
+
+select af1024x36_1024x36
+select *
+synth_quicklogic -family qlf_k6n10f -top af1024x36_1024x36 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af1024x36_1024x36_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X36_RD_X36_nonsplit
+
+select -clear
+design -load bram36k_afifo
+select af2048x18_2048x18
+select *
+synth_quicklogic -family qlf_k6n10f -top af2048x18_2048x18 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af2048x18_2048x18_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X18_RD_X18_nonsplit
+
+select -clear
+design -load bram36k_afifo
+select af4096x9_4096x9
+select *
+synth_quicklogic -family qlf_k6n10f -top af4096x9_4096x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/af4096x9_4096x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_ASYNC_WR_X9_RD_X9_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.v
@@ -1,0 +1,125 @@
+module af1024x36_1024x36 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 36;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af2048x18_2048x18 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module af4096x9_4096x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0,clock1;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .Push_Clk(clock0),
+                .Pop_Clk(clock1),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module af1024x36_1024x36 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
 
 parameter WR_DATA_WIDTH = 36;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.v
@@ -32,7 +32,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -52,8 +52,7 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af2048x18_2048x18 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -74,7 +73,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -94,8 +93,7 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module af4096x9_4096x9 (DIN,PUSH,POP,clock0,clock1,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -116,7 +114,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -136,6 +134,5 @@ AFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram36k_afifo_tb.v
+POST_SYNTH = af1024x36_1024x36_post_synth af2048x18_2048x18_post_synth af4096x9_4096x9_post_synth
+ADDR_WIDTH0 = 10 11 12
+DATA_WIDTH0 = 36 18 9
+ADDR_WIDTH1 = 10 11 12
+DATA_WIDTH1 = 36 18 9
+TOP = af1024x36_1024x36 af2048x18_2048x18 af4096x9_4096x9
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+# FIXME: $(call simulate_post_synth,5)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/bram36k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/bram36k_afifo_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,32 +23,32 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk0;
-  reg clk1;
-  reg flush;
+	reg clk1;
+	reg flush;
 	reg pop;
 	wire [`DATA_WIDTH1-1:0] dout;
 	reg push;
 	reg [`DATA_WIDTH0-1:0] din;
-  wire almost_full,almost_empty;
-  wire full, empty;
-  wire full_watermark, empty_watermark;
-  wire overrun_error, underrun_error;
+	wire almost_full,almost_empty;
+	wire full, empty;
+	wire full_watermark, empty_watermark;
+	wire overrun_error, underrun_error;
 
-  initial 
-  begin
-    clk0 = 0;
-    clk1 = 0;
-    pop = 0;
-    push = 0;
-    flush = 1;
-    din = 0;
-    #40
-    flush = 0;
-  end
-  
+	initial 
+	begin
+		clk0 = 0;
+		clk1 = 0;
+		pop = 0;
+		push = 0;
+		flush = 1;
+		din = 0;
+		#40
+		flush = 0;
+	end
+	
 	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
-  initial forever #(PERIOD / 2.0) clk1 = ~clk1;
-  
+	initial forever #(PERIOD / 2.0) clk1 = ~clk1;
+	
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -58,12 +58,12 @@ module TB;
 
 	reg done;
 	initial done = 1'b0;
-  
-  reg read_test;
+	
+	reg read_test;
 	initial read_test = 0;
 
 	reg [`DATA_WIDTH1-1:0] expected;
-  initial expected = 0;
+	initial expected = 0;
 
 	always @(posedge clk1) begin
 		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
@@ -80,7 +80,7 @@ module TB;
 
 
 	initial #(50) begin
-    @(posedge clk0)
+		@(posedge clk0)
 		// Write data
 		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
 			@(negedge clk0) begin
@@ -118,59 +118,59 @@ module TB;
 	case (`STRINGIFY(`TOP))
 		"af1024x36_1024x36": begin
 			af1024x36_1024x36 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af2048x18_2048x18": begin
 			af2048x18_2048x18 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"af4096x9_4096x9": begin
 			af4096x9_4096x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk0),
-        .clock1(clk1),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk0),
+				.clock1(clk1),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end		
 	endcase

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/bram36k_afifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/sim/bram36k_afifo_tb.v
@@ -1,0 +1,177 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 30;
+	localparam ADDR_INCR = 1;
+
+	reg clk0;
+  reg clk1;
+  reg flush;
+	reg pop;
+	wire [`DATA_WIDTH1-1:0] dout;
+	reg push;
+	reg [`DATA_WIDTH0-1:0] din;
+  wire almost_full,almost_empty;
+  wire full, empty;
+  wire full_watermark, empty_watermark;
+  wire overrun_error, underrun_error;
+
+  initial 
+  begin
+    clk0 = 0;
+    clk1 = 0;
+    pop = 0;
+    push = 0;
+    flush = 1;
+    din = 0;
+    #40
+    flush = 0;
+  end
+  
+	initial forever #(PERIOD / 3.0) clk0 = ~clk0;
+  initial forever #(PERIOD / 2.0) clk1 = ~clk1;
+  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+  
+  reg read_test;
+	initial read_test = 0;
+
+	reg [`DATA_WIDTH1-1:0] expected;
+  initial expected = 0;
+
+	always @(posedge clk1) begin
+		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+
+	wire error = ((a != 0) && read_test) ? dout !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk1)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1; 
+	end
+
+
+	initial #(50) begin
+    @(posedge clk0)
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
+			@(negedge clk0) begin
+				din = a | (a << 20) | 20'h55000;
+				push = 1;
+			end
+			@(posedge clk0) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk1) begin
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+			@(negedge clk1) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk1) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"af1024x36_1024x36": begin
+			af1024x36_1024x36 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af2048x18_2048x18": begin
+			af2048x18_2048x18 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"af4096x9_4096x9": begin
+			af4096x9_4096x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk0),
+        .clock1(clk1),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end		
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.tcl
@@ -1,0 +1,71 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram36_sdp
+
+select spram_36x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_36x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_36x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X36_RD_X36_nonsplit
+
+select -clear
+design -load bram36_sdp
+select spram_32x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_32x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_32x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X36_RD_X36_nonsplit
+
+select -clear
+design -load bram36_sdp
+select spram_18x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_18x2048 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_18x2048_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X18_nonsplit
+
+select -clear
+design -load bram36_sdp
+select spram_16x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_16x2048 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_16x2048_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X18_nonsplit
+
+select -clear
+design -load bram36_sdp
+select spram_9x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_9x4096 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_9x4096_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X9_nonsplit
+
+select -clear
+design -load bram36_sdp
+select spram_8x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top spram_8x4096 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/spram_8x4096_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X9_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module spram_36x1024 (
     WEN_i,
     REN_i,

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.v
@@ -1,0 +1,281 @@
+module spram_36x1024 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 36;
+parameter BE_WIDTH = 4;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(4'b1111),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_32x1024 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 10;
+parameter RD_ADDR_WIDTH = 10;
+parameter WR_DATA_WIDTH = 32;
+parameter RD_DATA_WIDTH = 32;
+parameter BE_WIDTH = 4;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(4'b1111),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule   
+
+module spram_18x2048 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 11;
+parameter RD_ADDR_WIDTH = 11;
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_16x2048 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 11;
+parameter RD_ADDR_WIDTH = 11;
+parameter WR_DATA_WIDTH = 16;
+parameter RD_DATA_WIDTH = 16;
+parameter BE_WIDTH = 2;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(2'b11),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_9x4096 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 12;
+parameter RD_ADDR_WIDTH = 12;
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 9;
+parameter BE_WIDTH = 1;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(1'b1),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    
+
+module spram_8x4096 (
+    WEN_i,
+    REN_i,
+    clock0,
+    clock1,
+    WR_ADDR_i,
+    RD_ADDR_i,
+    WDATA_i,
+    RDATA_o
+);
+
+parameter WR_ADDR_WIDTH = 12;
+parameter RD_ADDR_WIDTH = 12;
+parameter WR_DATA_WIDTH = 8;
+parameter RD_DATA_WIDTH = 8;
+parameter BE_WIDTH = 1;
+
+input wire WEN_i;
+input wire REN_i;
+input wire clock0;
+input wire clock1;
+input wire [WR_ADDR_WIDTH-1 :0] WR_ADDR_i;
+input wire [RD_ADDR_WIDTH-1 :0] RD_ADDR_i;
+input wire [WR_DATA_WIDTH-1 :0] WDATA_i;
+output wire [RD_DATA_WIDTH-1 :0] RDATA_o;
+
+RAM_36K_BLK #(
+              .WR_ADDR_WIDTH(WR_ADDR_WIDTH),
+              .RD_ADDR_WIDTH(RD_ADDR_WIDTH),
+              .WR_DATA_WIDTH(WR_DATA_WIDTH),
+              .RD_DATA_WIDTH(RD_DATA_WIDTH),
+              .BE_WIDTH(BE_WIDTH)
+              ) spram_x36_inst (
+              
+              .WEN_i(WEN_i),
+              .WR_BE_i(1'b1),
+              .REN_i(REN_i),              
+              .WR_CLK_i(clock0),
+              .RD_CLK_i(clock1),
+              .WR_ADDR_i(WR_ADDR_i),
+              .RD_ADDR_i(RD_ADDR_i),
+              .WDATA_i(WDATA_i),
+              .RDATA_o(RDATA_o)
+              );
+              
+endmodule    

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/Makefile
@@ -35,7 +35,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram36k_sdp_tb.v
+POST_SYNTH = spram_36x1024_post_synth spram_32x1024_post_synth spram_18x2048_post_synth spram_16x2048_post_synth spram_9x4096_post_synth spram_8x4096_post_synth
+ADDR_WIDTH = 10 10 11 11 12 12
+DATA_WIDTH = 36 32 18 16 9 8
+TOP = spram_36x1024 spram_32x1024 spram_18x2048 spram_16x2048 spram_9x4096 spram_8x4096
+ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
+DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR_DEFINES)) $(word $(1),$(DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+# FIXME: $(call simulate_post_synth,5)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)
+	$(call simulate_post_synth,4)
+	$(call clean_post_synth_sim,4)
+	$(call simulate_post_synth,5)
+	$(call clean_post_synth_sim,5)
+	$(call simulate_post_synth,6)
+	$(call clean_post_synth_sim,6)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/bram36k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/bram36k_sdp_tb.v
@@ -1,0 +1,176 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk;
+	reg rce;
+	reg [`ADDR_WIDTH-1:0] ra;
+	wire [`DATA_WIDTH-1:0] rq;
+	reg wce;
+	reg [`ADDR_WIDTH-1:0] wa;
+	reg [`DATA_WIDTH-1:0] wd;
+
+	initial clk = 0;
+	initial ra = 0;
+	initial rce = 0;
+	initial forever #(PERIOD / 2.0) clk = ~clk;
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+
+	reg [`DATA_WIDTH-1:0] expected;
+
+	always @(posedge clk) begin
+		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+
+	wire error = ((a != 0) && read_test) ? rq !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1;
+	end
+
+	reg read_test;
+	initial read_test = 0;
+
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				wa = a;
+				wd = a | (a << 20) | 20'h55000;
+				wce = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) wce = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				ra = a;
+				rce = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) rce = 0;
+				if ( rq !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, rq, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, rq, expected, a);
+				end
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"spram_36x1024": begin
+			spram_36x1024 #() bram (
+				.clock0(clk),
+        .clock1(clk),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_32x1024": begin
+			spram_32x1024 #() bram (
+				.clock0(clk),
+        .clock1(clk),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_18x2048": begin
+			spram_18x2048 #() bram (
+				.clock0(clk),
+        .clock1(clk),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_16x2048": begin
+			spram_16x2048 #() bram (
+				.clock0(clk),
+        .clock1(clk),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_9x4096": begin
+			spram_9x4096 #() bram (
+				.clock0(clk),
+        .clock1(clk),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+		"spram_8x4096": begin
+			spram_8x4096 #() bram (
+				.clock0(clk),
+        .clock1(clk),        
+				.REN_i(rce),
+				.RD_ADDR_i(ra),
+				.RDATA_o(rq),
+				.WEN_i(wce),
+				.WR_ADDR_i(wa),
+				.WDATA_i(wd)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/bram36k_sdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/sim/bram36k_sdp_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -103,7 +103,7 @@ module TB;
 		"spram_36x1024": begin
 			spram_36x1024 #() bram (
 				.clock0(clk),
-        .clock1(clk),        
+				.clock1(clk),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -115,7 +115,7 @@ module TB;
 		"spram_32x1024": begin
 			spram_32x1024 #() bram (
 				.clock0(clk),
-        .clock1(clk),        
+				.clock1(clk),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -127,7 +127,7 @@ module TB;
 		"spram_18x2048": begin
 			spram_18x2048 #() bram (
 				.clock0(clk),
-        .clock1(clk),        
+				.clock1(clk),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -139,7 +139,7 @@ module TB;
 		"spram_16x2048": begin
 			spram_16x2048 #() bram (
 				.clock0(clk),
-        .clock1(clk),        
+				.clock1(clk),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -151,7 +151,7 @@ module TB;
 		"spram_9x4096": begin
 			spram_9x4096 #() bram (
 				.clock0(clk),
-        .clock1(clk),        
+				.clock1(clk),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),
@@ -163,7 +163,7 @@ module TB;
 		"spram_8x4096": begin
 			spram_8x4096 #() bram (
 				.clock0(clk),
-        .clock1(clk),        
+				.clock1(clk),				 
 				.REN_i(rce),
 				.RD_ADDR_i(ra),
 				.RDATA_o(rq),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.tcl
@@ -1,0 +1,38 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram36k_sfifo
+
+select f1024x36_1024x36
+select *
+synth_quicklogic -family qlf_k6n10f -top f1024x36_1024x36 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f1024x36_1024x36_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X36_RD_X36_nonsplit
+
+select -clear
+design -load bram36k_sfifo
+select f2048x18_2048x18
+select *
+synth_quicklogic -family qlf_k6n10f -top f2048x18_2048x18 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f2048x18_2048x18_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X18_RD_X18_nonsplit
+
+select -clear
+design -load bram36k_sfifo
+select f4096x9_4096x9
+select *
+synth_quicklogic -family qlf_k6n10f -top f4096x9_4096x9 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/f4096x9_4096x9_post_synth.v
+select -assert-count 1 t:TDP36K_FIFO_SYNC_WR_X9_RD_X9_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module f1024x36_1024x36 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
 
 parameter WR_DATA_WIDTH = 36;

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.v
@@ -32,7 +32,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -51,8 +51,7 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f2048x18_2048x18 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -73,7 +72,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -92,8 +91,7 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule
 
 module f4096x9_4096x9 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
@@ -114,7 +112,7 @@ output Full_Watermark, Empty_Watermark;
 output Overrun_Error, Underrun_Error;
 
 SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
-        				 ) 
+                  )
   FIFO_INST    (
                 .DIN(DIN),
                 .PUSH(PUSH),
@@ -133,6 +131,5 @@ SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.U
                 .Empty(Empty),
 
                 .DOUT(DOUT)
-         				);
-
+                );
 endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.v
@@ -1,0 +1,122 @@
+module f1024x36_1024x36 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 36;
+parameter RD_DATA_WIDTH = 36;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f2048x18_2048x18 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 18;
+parameter RD_DATA_WIDTH = 18;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule
+
+module f4096x9_4096x9 (DIN,PUSH,POP,clock0,Async_Flush,Almost_Full,Almost_Empty,Full,Empty,Full_Watermark,Empty_Watermark,Overrun_Error,Underrun_Error,DOUT);
+
+parameter WR_DATA_WIDTH = 9;
+parameter RD_DATA_WIDTH = 9;
+parameter UPAE_DBITS = 12'd10;
+parameter UPAF_DBITS = 12'd10;
+
+input clock0;
+input PUSH,POP;
+input [WR_DATA_WIDTH-1:0] DIN;
+input Async_Flush;
+output [RD_DATA_WIDTH-1:0] DOUT;
+output Almost_Full,Almost_Empty;
+output Full, Empty;
+output Full_Watermark, Empty_Watermark;
+output Overrun_Error, Underrun_Error;
+
+SFIFO_36K_BLK  # (.WR_DATA_WIDTH(WR_DATA_WIDTH),.RD_DATA_WIDTH(RD_DATA_WIDTH),.UPAE_DBITS(UPAE_DBITS),.UPAF_DBITS(UPAF_DBITS)
+        				 ) 
+  FIFO_INST    (
+                .DIN(DIN),
+                .PUSH(PUSH),
+                .POP(POP),
+                .CLK(clock0),
+                .Async_Flush(Async_Flush),
+                
+                .Overrun_Error(Overrun_Error),
+                .Full_Watermark(Full_Watermark),
+                .Almost_Full(Almost_Full),
+                .Full(Full),
+                
+                .Underrun_Error(Underrun_Error),
+                .Empty_Watermark(Empty_Watermark),
+                .Almost_Empty(Almost_Empty),
+                .Empty(Empty),
+
+                .DOUT(DOUT)
+         				);
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/Makefile
@@ -39,7 +39,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram36k_sfifo_tb.v
+POST_SYNTH = f1024x36_1024x36_post_synth f2048x18_2048x18_post_synth f4096x9_4096x9_post_synth
+ADDR_WIDTH0 = 10 11 12
+DATA_WIDTH0 = 36 18 9
+ADDR_WIDTH1 = 10 11 12
+DATA_WIDTH1 = 36 18 9
+TOP = f1024x36_1024x36 f2048x18_2048x18 f4096x9_4096x9
+ADDR0_DEFINES = $(foreach awidth0, $(ADDR_WIDTH0),-DADDR_WIDTH0="$(awidth0)")
+ADDR1_DEFINES = $(foreach awidth1, $(ADDR_WIDTH1),-DADDR_WIDTH1="$(awidth1)")
+DATA0_DEFINES = $(foreach dwidth0, $(DATA_WIDTH0),-DDATA_WIDTH0="$(dwidth0)")
+DATA1_DEFINES = $(foreach dwidth1, $(DATA_WIDTH1),-DDATA_WIDTH1="$(dwidth1)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR0_DEFINES)) $(word $(1),$(ADDR1_DEFINES)) $(word $(1),$(DATA0_DEFINES)) $(word $(1),$(DATA1_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+# FIXME: $(call simulate_post_synth,5)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/bram36k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/bram36k_sfifo_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,29 +23,29 @@ module TB;
 	localparam ADDR_INCR = 1;
 
 	reg clk;
-  reg flush;
+	reg flush;
 	reg pop;
 	wire [`DATA_WIDTH1-1:0] dout;
 	reg push;
 	reg [`DATA_WIDTH0-1:0] din;
-  wire almost_full,almost_empty;
-  wire full, empty;
-  wire full_watermark, empty_watermark;
-  wire overrun_error, underrun_error;
+	wire almost_full,almost_empty;
+	wire full, empty;
+	wire full_watermark, empty_watermark;
+	wire overrun_error, underrun_error;
 
-  initial 
-  begin
-    clk = 0;
-    pop = 0;
-    push = 0;
-    flush = 1;
-    din = 0;
-    #40
-    flush = 0;
-  end
-  
+	initial 
+	begin
+		clk = 0;
+		pop = 0;
+		push = 0;
+		flush = 1;
+		din = 0;
+		#40
+		flush = 0;
+	end
+	
 	initial forever #(PERIOD / 3.0) clk = ~clk;
-  
+	
 	initial begin
 		$dumpfile(`STRINGIFY(`VCD));
 		$dumpvars;
@@ -55,12 +55,12 @@ module TB;
 
 	reg done;
 	initial done = 1'b0;
-  
+	
 	reg read_test;
 	initial read_test = 0;
 
 	reg [`DATA_WIDTH1-1:0] expected;
-  initial expected = 0;
+	initial expected = 0;
 
 	always @(posedge clk) begin
 		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
@@ -76,7 +76,7 @@ module TB;
 	end
 
 	initial #(50) begin
-    @(posedge clk)
+		@(posedge clk)
 		// Write data
 		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
 			@(negedge clk) begin
@@ -114,56 +114,56 @@ module TB;
 	case (`STRINGIFY(`TOP))
 		"f1024x36_1024x36": begin
 			f1024x36_1024x36 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f2048x18_2048x18": begin
 			f2048x18_2048x18 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end
 		"f4096x9_4096x9": begin
 			f4096x9_4096x9 #() afifo (
-        .DIN(din),
-        .PUSH(push),
-        .POP(pop),
-        .clock0(clk),
-        .Async_Flush(flush),
-        .Almost_Full(almost_full),
-        .Almost_Empty(almost_empty),
-        .Full(full),
-        .Empty(empty),
-        .Full_Watermark(full_watermark),
-        .Empty_Watermark(empty_watermark),
-        .Overrun_Error(overrun_error),
-        .Underrun_Error(underrun_error),
-        .DOUT(dout)
+				.DIN(din),
+				.PUSH(push),
+				.POP(pop),
+				.clock0(clk),
+				.Async_Flush(flush),
+				.Almost_Full(almost_full),
+				.Almost_Empty(almost_empty),
+				.Full(full),
+				.Empty(empty),
+				.Full_Watermark(full_watermark),
+				.Empty_Watermark(empty_watermark),
+				.Overrun_Error(overrun_error),
+				.Underrun_Error(underrun_error),
+				.DOUT(dout)
 			);
 		end		
 	endcase

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/bram36k_sfifo_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/sim/bram36k_sfifo_tb.v
@@ -1,0 +1,170 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 30;
+	localparam ADDR_INCR = 1;
+
+	reg clk;
+  reg flush;
+	reg pop;
+	wire [`DATA_WIDTH1-1:0] dout;
+	reg push;
+	reg [`DATA_WIDTH0-1:0] din;
+  wire almost_full,almost_empty;
+  wire full, empty;
+  wire full_watermark, empty_watermark;
+  wire overrun_error, underrun_error;
+
+  initial 
+  begin
+    clk = 0;
+    pop = 0;
+    push = 0;
+    flush = 1;
+    din = 0;
+    #40
+    flush = 0;
+  end
+  
+	initial forever #(PERIOD / 3.0) clk = ~clk;
+  
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+
+	reg done;
+	initial done = 1'b0;
+  
+	reg read_test;
+	initial read_test = 0;
+
+	reg [`DATA_WIDTH1-1:0] expected;
+  initial expected = 0;
+
+	always @(posedge clk) begin
+		expected <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH1{1'b1}};
+	end
+
+	wire error = ((a != 0) && read_test) ? dout !== expected : 0;
+
+	integer error_cnt = 0;
+	always @ (posedge clk)
+	begin
+		if (error)
+			error_cnt <= error_cnt + 1'b1; 
+	end
+
+	initial #(50) begin
+    @(posedge clk)
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH0); a = a + ADDR_INCR) begin
+			@(negedge clk) begin
+				din = a | (a << 20) | 20'h55000;
+				push = 1;
+			end
+			@(posedge clk) begin
+				#(PERIOD/10) push = 0;
+			end
+		end
+		// Read data
+		read_test = 1;
+		for (a = 0; a < (1<<`ADDR_WIDTH1); a = a + ADDR_INCR) begin
+			@(posedge clk) begin
+				#(PERIOD/10) pop = 0;
+				if ( dout !== expected) begin
+					$display("%d: FAIL: mismatch act=%x exp=%x at %x", $time, dout, expected, a);
+				end else begin
+					$display("%d: OK: act=%x exp=%x at %x", $time, dout, expected, a);
+				end
+			end
+			@(negedge clk) begin
+				pop = 1;
+			end
+		end
+		done = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk) begin
+		if (done)
+			$finish_and_return( (error_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"f1024x36_1024x36": begin
+			f1024x36_1024x36 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f2048x18_2048x18": begin
+			f2048x18_2048x18 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end
+		"f4096x9_4096x9": begin
+			f4096x9_4096x9 #() afifo (
+        .DIN(din),
+        .PUSH(push),
+        .POP(pop),
+        .clock0(clk),
+        .Async_Flush(flush),
+        .Almost_Full(almost_full),
+        .Almost_Empty(almost_empty),
+        .Full(full),
+        .Empty(empty),
+        .Full_Watermark(full_watermark),
+        .Empty_Watermark(empty_watermark),
+        .Overrun_Error(overrun_error),
+        .Underrun_Error(underrun_error),
+        .DOUT(dout)
+			);
+		end		
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.tcl
@@ -1,0 +1,38 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram36k_tdp
+
+select dpram_36x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top dpram_36x1024 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/dpram_36x1024_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X36_RD_X36_nonsplit
+
+select -clear
+design -load bram36k_tdp
+select dpram_18x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top dpram_18x2048 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/dpram_18x2048_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X18_RD_X18_nonsplit
+
+select -clear
+design -load bram36k_tdp
+select dpram_9x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top dpram_9x4096 -bram_types
+opt_expr -undriven
+opt_clean
+stat
+write_verilog sim/dpram_9x4096_post_synth.v
+select -assert-count 1 t:TDP36K_BRAM_WR_X9_RD_X9_nonsplit

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.v
@@ -1,0 +1,197 @@
+module dpram_36x1024 (
+    clock0,
+    WEN1_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    clock1,
+    WEN2_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 10;
+parameter DATA_WIDTH = 36;
+parameter BE1_WIDTH = 4;
+parameter BE2_WIDTH = 4;
+
+input wire clock0;
+input wire WEN1_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire clock1;
+input wire WEN2_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+DPRAM_36K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH),
+              .DATA_WIDTH(DATA_WIDTH),
+              .BE1_WIDTH(BE1_WIDTH),
+              .BE2_WIDTH(BE2_WIDTH)
+              ) dpram_x36_inst (             
+              .CLK1_i(clock0),
+              .WEN1_i(WEN1_i),
+              .WR1_BE_i(4'b1111),
+              .REN1_i(REN1_i),
+              .WR1_ADDR_i(WR1_ADDR_i),
+              .RD1_ADDR_i(RD1_ADDR_i),
+              .WDATA1_i(WDATA1_i),
+              .RDATA1_o(RDATA1_o),
+              
+              .CLK2_i(clock1),
+              .WEN2_i(WEN2_i),
+              .WR2_BE_i(4'b1111),
+              .REN2_i(REN2_i),
+              .WR2_ADDR_i(WR2_ADDR_i),
+              .RD2_ADDR_i(RD2_ADDR_i),
+              .WDATA2_i(WDATA2_i),
+              .RDATA2_o(RDATA2_o)
+              );
+
+endmodule
+
+module dpram_18x2048 (
+    clock0,
+    WEN1_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    clock1,
+    WEN2_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 11;
+parameter DATA_WIDTH = 18;
+parameter BE1_WIDTH = 2;
+parameter BE2_WIDTH = 2;
+
+input wire clock0;
+input wire WEN1_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire clock1;
+input wire WEN2_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+DPRAM_36K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH),
+              .DATA_WIDTH(DATA_WIDTH),
+              .BE1_WIDTH(BE1_WIDTH),
+              .BE2_WIDTH(BE2_WIDTH)
+              ) dpram_x36_inst (             
+              .CLK1_i(clock0),
+              .WEN1_i(WEN1_i),
+              .WR1_BE_i(2'b11),
+              .REN1_i(REN1_i),
+              .WR1_ADDR_i(WR1_ADDR_i),
+              .RD1_ADDR_i(RD1_ADDR_i),
+              .WDATA1_i(WDATA1_i),
+              .RDATA1_o(RDATA1_o),
+              
+              .CLK2_i(clock1),
+              .WEN2_i(WEN2_i),
+              .WR2_BE_i(2'b11),
+              .REN2_i(REN2_i),
+              .WR2_ADDR_i(WR2_ADDR_i),
+              .RD2_ADDR_i(RD2_ADDR_i),
+              .WDATA2_i(WDATA2_i),
+              .RDATA2_o(RDATA2_o)
+              );
+
+endmodule
+
+module dpram_9x4096 (
+    clock0,
+    WEN1_i,
+    REN1_i,
+    WR1_ADDR_i,
+    RD1_ADDR_i,
+    WDATA1_i,
+    RDATA1_o,
+    
+    clock1,
+    WEN2_i,
+    REN2_i,
+    WR2_ADDR_i,
+    RD2_ADDR_i,
+    WDATA2_i,
+    RDATA2_o
+);
+
+parameter ADDR_WIDTH = 12;
+parameter DATA_WIDTH = 9;
+parameter BE1_WIDTH = 1;
+parameter BE2_WIDTH = 1;
+
+input wire clock0;
+input wire WEN1_i;
+input wire REN1_i;
+input wire [ADDR_WIDTH-1 :0] WR1_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD1_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA1_i;
+output wire [DATA_WIDTH-1 :0] RDATA1_o;
+
+input wire clock1;
+input wire WEN2_i;
+input wire REN2_i;
+input wire [ADDR_WIDTH-1 :0] WR2_ADDR_i;
+input wire [ADDR_WIDTH-1 :0] RD2_ADDR_i;
+input wire [DATA_WIDTH-1 :0] WDATA2_i;
+output wire [DATA_WIDTH-1 :0] RDATA2_o;
+
+DPRAM_36K_BLK #(
+              .ADDR_WIDTH(ADDR_WIDTH),
+              .DATA_WIDTH(DATA_WIDTH),
+              .BE1_WIDTH(BE1_WIDTH),
+              .BE2_WIDTH(BE2_WIDTH)
+              ) dpram_x36_inst (             
+              .CLK1_i(clock0),
+              .WEN1_i(WEN1_i),
+              .WR1_BE_i(1'b1),
+              .REN1_i(REN1_i),
+              .WR1_ADDR_i(WR1_ADDR_i),
+              .RD1_ADDR_i(RD1_ADDR_i),
+              .WDATA1_i(WDATA1_i),
+              .RDATA1_o(RDATA1_o),
+              
+              .CLK2_i(clock1),
+              .WEN2_i(WEN2_i),
+              .WR2_BE_i(1'b1),
+              .REN2_i(REN2_i),
+              .WR2_ADDR_i(WR2_ADDR_i),
+              .RD2_ADDR_i(RD2_ADDR_i),
+              .WDATA2_i(WDATA2_i),
+              .RDATA2_o(RDATA2_o)
+              );
+
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.v
@@ -1,3 +1,19 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module dpram_36x1024 (
     clock0,
     WEN1_i,

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/Makefile
@@ -35,7 +35,6 @@ define clean_post_synth_sim
 	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
 endef
 
-# FIXME: $(call simulate_post_synth,5)
 sim:
 	$(call simulate_post_synth,1)
 	$(call clean_post_synth_sim,1)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2020-2022 F4PGA Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TESTBENCH = bram36k_tdp_tb.v
+POST_SYNTH = dpram_36x1024_post_synth dpram_18x2048_post_synth dpram_9x4096_post_synth
+ADDR_WIDTH = 10 11 12
+DATA_WIDTH = 36 18 9
+TOP = dpram_36x1024 dpram_18x2048 dpram_9x4096
+ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
+DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR_DEFINES)) $(word $(1),$(DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+# FIXME: $(call simulate_post_synth,5)
+sim:
+	$(call simulate_post_synth,1)
+	$(call clean_post_synth_sim,1)
+	$(call simulate_post_synth,2)
+	$(call clean_post_synth_sim,2)
+	$(call simulate_post_synth,3)
+	$(call clean_post_synth_sim,3)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/bram36k_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/bram36k_tdp_tb.v
@@ -1,0 +1,220 @@
+// Copyright 2020-2022 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_a;
+	reg rce_a;
+	reg [`ADDR_WIDTH-1:0] ra_a;
+	wire [`DATA_WIDTH-1:0] rq_a;
+	reg wce_a;
+	reg [`ADDR_WIDTH-1:0] wa_a;
+	reg [`DATA_WIDTH-1:0] wd_a;
+
+	reg clk_b;
+	reg rce_b;
+	reg [`ADDR_WIDTH-1:0] ra_b;
+	wire [`DATA_WIDTH-1:0] rq_b;
+	reg wce_b;
+	reg [`ADDR_WIDTH-1:0] wa_b;
+	reg [`DATA_WIDTH-1:0] wd_b;
+
+
+	initial clk_a = 0;
+	initial clk_b = 0;
+	initial ra_a = 0;
+	initial ra_b = 0;
+	initial rce_a = 0;
+	initial rce_b = 0;
+	initial forever #(PERIOD / 2.0) clk_a = ~clk_a;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_b = ~clk_b;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_a;
+	reg done_b;
+	initial done_a = 1'b0;
+	initial done_b = 1'b0;
+	wire done_sim = done_a & done_b;
+
+	reg [`DATA_WIDTH-1:0] expected_a;
+	reg [`DATA_WIDTH-1:0] expected_b;
+
+	always @(posedge clk_a) begin
+		expected_a <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+	always @(posedge clk_b) begin
+		expected_b <= (b | (b << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+
+	wire error_a = a != 0 ? rq_a !== expected_a : 0;
+	wire error_b = b != (1<<`ADDR_WIDTH) / 2 ? rq_b !== expected_b : 0;
+
+	integer error_a_cnt = 0;
+	integer error_b_cnt = 0;
+
+	always @ (posedge clk_a)
+	begin
+		if (error_a)
+			error_a_cnt <= error_a_cnt + 1'b1;
+	end
+	always @ (posedge clk_b)
+	begin
+		if (error_b)
+			error_b_cnt <= error_b_cnt + 1'b1;
+	end
+	// PORT A
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				wa_a = a;
+				wd_a = a | (a << 20) | 20'h55000;
+				wce_a = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) wce_a = 0;
+			end
+		end
+		// Read data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				ra_a = a;
+				rce_a = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) rce_a = 0;
+				if ( rq_a !== expected_a) begin
+					$display("%d: PORT A: FAIL: mismatch act=%x exp=%x at %x", $time, rq_a, expected_a, a);
+				end else begin
+					$display("%d: PORT A: OK: act=%x exp=%x at %x", $time, rq_a, expected_a, a);
+				end
+			end
+		end
+		done_a = 1'b1;
+	end
+
+	// PORT B
+	initial #(1) begin
+		// Write data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				wa_b = b;
+				wd_b = b | (b << 20) | 20'h55000;
+				wce_b = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) wce_b = 0;
+			end
+		end
+		// Read data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				ra_b = b;
+				rce_b = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) rce_b = 0;
+				if ( rq_b !== expected_b) begin
+					$display("%d: PORT B: FAIL: mismatch act=%x exp=%x at %x", $time, rq_b, expected_b, b);
+				end else begin
+					$display("%d: PORT B: OK: act=%x exp=%x at %x", $time, rq_b, expected_b, b);
+				end
+			end
+		end
+		done_b = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk_a, posedge clk_b) begin
+		if (done_sim)
+			$finish_and_return( (error_a_cnt == 0 & error_b_cnt == 0) ? 0 : -1 );
+	end
+  
+	case (`STRINGIFY(`TOP))
+		"dpram_36x1024": begin
+			dpram_36x1024 #() bram (
+				.clock0(clk_a),
+				.REN1_i(rce_a),
+				.RD1_ADDR_i(ra_a),
+				.RDATA1_o(rq_a),
+				.WEN1_i(wce_a),
+				.WR1_ADDR_i(wa_a),
+				.WDATA1_i(wd_a),
+        
+				.clock1(clk_b),
+				.REN2_i(rce_b),
+				.RD2_ADDR_i(ra_b),
+				.RDATA2_o(rq_b),
+				.WEN2_i(wce_b),
+				.WR2_ADDR_i(wa_b),
+				.WDATA2_i(wd_b)
+			);
+		end
+		"dpram_18x2048": begin
+			dpram_18x2048 #() bram (
+				.clock0(clk_a),
+				.REN1_i(rce_a),
+				.RD1_ADDR_i(ra_a),
+				.RDATA1_o(rq_a),
+				.WEN1_i(wce_a),
+				.WR1_ADDR_i(wa_a),
+				.WDATA1_i(wd_a),
+        
+				.clock1(clk_b),
+				.REN2_i(rce_b),
+				.RD2_ADDR_i(ra_b),
+				.RDATA2_o(rq_b),
+				.WEN2_i(wce_b),
+				.WR2_ADDR_i(wa_b),
+				.WDATA2_i(wd_b)
+			);
+		end
+		"dpram_9x4096": begin
+			dpram_9x4096 #() bram (
+				.clock0(clk_a),
+				.REN1_i(rce_a),
+				.RD1_ADDR_i(ra_a),
+				.RDATA1_o(rq_a),
+				.WEN1_i(wce_a),
+				.WR1_ADDR_i(wa_a),
+				.WDATA1_i(wd_a),
+        
+				.clock1(clk_b),
+				.REN2_i(rce_b),
+				.RD2_ADDR_i(ra_b),
+				.RDATA2_o(rq_b),
+				.WEN2_i(wce_b),
+				.WR2_ADDR_i(wa_b),
+				.WDATA2_i(wd_b)
+			);
+		end
+	endcase
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/bram36k_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/sim/bram36k_tdp_tb.v
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//		 http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -157,7 +157,7 @@ module TB;
 		if (done_sim)
 			$finish_and_return( (error_a_cnt == 0 & error_b_cnt == 0) ? 0 : -1 );
 	end
-  
+	
 	case (`STRINGIFY(`TOP))
 		"dpram_36x1024": begin
 			dpram_36x1024 #() bram (
@@ -168,7 +168,7 @@ module TB;
 				.WEN1_i(wce_a),
 				.WR1_ADDR_i(wa_a),
 				.WDATA1_i(wd_a),
-        
+				
 				.clock1(clk_b),
 				.REN2_i(rce_b),
 				.RD2_ADDR_i(ra_b),
@@ -187,7 +187,7 @@ module TB;
 				.WEN1_i(wce_a),
 				.WR1_ADDR_i(wa_a),
 				.WDATA1_i(wd_a),
-        
+				
 				.clock1(clk_b),
 				.REN2_i(rce_b),
 				.RD2_ADDR_i(ra_b),
@@ -206,7 +206,7 @@ module TB;
 				.WEN1_i(wce_a),
 				.WR1_ADDR_i(wa_a),
 				.WDATA1_i(wd_a),
-        
+				
 				.clock1(clk_b),
 				.REN2_i(rce_b),
 				.RD2_ADDR_i(ra_b),


### PR DESCRIPTION
Modified the following files:
1. synth_quicklogic.cc : added 'chtype' passess for FIFOs (SFIFO and AFIFO)
2. brams_sim,v:
       - addded dpram, spram sfifo & afifo macros
       - added FIFO modes
       - added specify block for rams and fifos
 3. brams_map.v:
       - added dpram, spram sfifo & afifo macros    
4. brams_final_map.v:
        - added dpram, spram sfifo & afifo 18K split macros 