### PR TITLE
systemverilog: Fix multiple function return statements

### DIFF
--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -175,6 +175,9 @@ class UhdmAst
     static const ::Yosys::IdString &force_convert();
     static const ::Yosys::IdString &is_imported();
     static const ::Yosys::IdString &is_simplified_wire();
+    static const ::Yosys::IdString &node_subtype();
+
+    static constexpr int return_stmt_subtype = 1;
 };
 
 } // namespace systemverilog_plugin


### PR DESCRIPTION
Currently all return statements are included in AST tree which results in incorrect multiple assign with different values like:
```verilog
module top(o);
  output o;
  /** AST_FUNCTION **/
  assign o = 1'b 0;
  assign o = 1'b 1;
endmodule
```
This PR fixes https://github.com/antmicro/yosys-systemverilog/issues/1243.