### PR TITLE
ql-qlf: always write blif files with .param statements

### DIFF
--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -532,11 +532,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         if (check_label("blif")) {
             if (!blif_file.empty()) {
-                if (inferAdder) {
-                    run(stringf("write_blif -param %s", help_mode ? "<file-name>" : blif_file.c_str()));
-                } else {
-                    run(stringf("write_blif %s", help_mode ? "<file-name>" : blif_file.c_str()));
-                }
+                run(stringf("write_blif -param %s", help_mode ? "<file-name>" : blif_file.c_str()));
             }
         }
 


### PR DESCRIPTION
This PR fixes issue https://github.com/chipsalliance/yosys-f4pga-plugins/issues/422.
I tested synthesis of [full adder](https://github.com/chipsalliance/yosys-f4pga-plugins/blob/main/ql-qlf-plugin/tests/full_adder/full_adder.v#L17-L26) module for `qlf_k4n8` family in 4 different variants (with and without inferring adders and writing params in blif files) and there was no significant differences between results so we can can just always write blif with params.

Signed-off-by: Pawel Czarnecki <pczarnecki@antmicro.com>