### PR TITLE
Do not duplicate ranges when bit selection operator is used

### DIFF
--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -174,6 +174,7 @@ class UhdmAst
     // set this attribute to force conversion of multirange wire to single range. It is useful to force-convert some memories.
     static const ::Yosys::IdString &force_convert();
     static const ::Yosys::IdString &is_imported();
+    static const ::Yosys::IdString &is_simplified_wire();
 };
 
 } // namespace systemverilog_plugin


### PR DESCRIPTION
Related to https://github.com/antmicro/yosys-systemverilog/issues/1223

https://github.com/YosysHQ/yosys/blob/52d8ddee0ccde0afccbc703d673e46457f63672b/tests/asicworld/code_hdl_models_arbiter.v#L106-L107
This usage of the bit selection operator leads to calling `simplify` on the same wire multiple times.
In general we need to be able to repeat calls to `simplify` on wires but in this case calling it again results in creating redundant `AST_RANGE` nodes.

We've agreed that removing the `simplify` call is not the right solution, so I'm adding an attribute to acknowledge that a wire was already simplified.

I'm running tests here: https://github.com/antmicro/yosys-systemverilog/actions/runs/3891658163
With additional changes in the passlist for tests: https://github.com/antmicro/yosys-systemverilog/commits/wsip/passlist