### PR TITLE
systemverilog: Fix signed wire handling

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1397,7 +1397,7 @@ static void add_or_replace_child(AST::AstNode *parent, AST::AstNode *child)
                 if (child->type == AST::AST_MEMORY)
                     child->type = AST::AST_WIRE;
             }
-            child->is_signed = (*it)->is_signed;
+            child->is_signed = child->is_signed || (*it)->is_signed;
             if (!(*it)->children.empty() && child->children.empty()) {
                 // This is a bit ugly, but if the child we're replacing has children and
                 // our node doesn't, we copy its children to not lose any information
@@ -3968,7 +3968,7 @@ void UhdmAst::process_port()
                     current_node->children = std::move(node->children);
                 }
             }
-            current_node->is_signed = node->is_signed;
+            current_node->is_signed = current_node->is_signed || node->is_signed;
             delete node;
         }
     });


### PR DESCRIPTION
These changes prevent from overwriting _is_signed_ property from _vpiNet_ node by the value from _typespec_ or when node is replaced during further processing.
It fixes one of the problems spotted in the issue https://github.com/antmicro/yosys-systemverilog/issues/938, where wires were not marked as signed.

The test added for this plugin update: https://github.com/chipsalliance/UHDM-integration-tests/pull/701
The test workflow for this PR: https://github.com/antmicro/yosys-systemverilog/pull/1273