### PR TITLE
systemverilog: Keep enums compatible with UHDM changes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,5 +20,5 @@ channels:
   - litex-hub
 dependencies:
   - litex-hub::yosys=0.17_7_g990c9b8e1=20220512_085338_py37
-  - litex-hub::surelog=0.0_5519_g900fb2499=20221223_060448_py37
+  - litex-hub::surelog=0.0_5564_g312b6efa2=20230110_140709_py37
   - litex-hub::iverilog

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1695,8 +1695,8 @@ void UhdmAst::process_module()
                                            [](auto node) { return node->type == AST::AST_INITIAL || node->type == AST::AST_ALWAYS; });
             auto children_after_process = std::vector<AST::AstNode *>(process_it, current_node->children.end());
             current_node->children.erase(process_it, current_node->children.end());
-            visit_one_to_many({vpiModule, vpiInterface, vpiParameter, vpiParamAssign, vpiPort, vpiNet, vpiArrayNet, vpiTaskFunc, vpiGenScopeArray,
-                               vpiContAssign, vpiVariables},
+            visit_one_to_many({vpiModuleInst, vpiInterfaceInst, vpiParameter, vpiParamAssign, vpiPort, vpiNet, vpiArrayNet, vpiTaskFunc,
+                               vpiGenScopeArray, vpiContAssign, vpiVariables},
                               obj_h, [&](AST::AstNode *node) {
                                   if (node) {
                                       add_or_replace_child(current_node, node);
@@ -1726,8 +1726,8 @@ void UhdmAst::process_module()
                     move_type_to_new_typedef(current_node, node);
                 }
             });
-            visit_one_to_many({vpiModule, vpiInterface, vpiTaskFunc, vpiParameter, vpiParamAssign, vpiPort, vpiNet, vpiArrayNet, vpiGenScopeArray,
-                               vpiProcess, vpiClockingBlock, vpiAssertion},
+            visit_one_to_many({vpiModuleInst, vpiInterfaceInst, vpiTaskFunc, vpiParameter, vpiParamAssign, vpiPort, vpiNet, vpiArrayNet,
+                               vpiGenScopeArray, vpiProcess, vpiClockingBlock, vpiAssertion},
                               obj_h, [&](AST::AstNode *node) {
                                   if (node) {
                                       if (node->type == AST::AST_ASSIGN && node->children.size() < 2)
@@ -1852,7 +1852,7 @@ void UhdmAst::process_module()
                 add_or_replace_child(module_node, node);
             }
         });
-        visit_one_to_many({vpiInterface, vpiModule, vpiPort, vpiGenScopeArray, vpiContAssign}, obj_h, [&](AST::AstNode *node) {
+        visit_one_to_many({vpiInterfaceInst, vpiModuleInst, vpiPort, vpiGenScopeArray, vpiContAssign}, obj_h, [&](AST::AstNode *node) {
             if (node) {
                 add_or_replace_child(module_node, node);
             }
@@ -3396,8 +3396,8 @@ void UhdmAst::process_gen_scope()
     });
 
     visit_one_to_many(
-      {vpiParamAssign, vpiParameter, vpiNet, vpiArrayNet, vpiVariables, vpiContAssign, vpiProcess, vpiModule, vpiGenScopeArray, vpiTaskFunc}, obj_h,
-      [&](AST::AstNode *node) {
+      {vpiParamAssign, vpiParameter, vpiNet, vpiArrayNet, vpiVariables, vpiContAssign, vpiProcess, vpiModuleInst, vpiGenScopeArray, vpiTaskFunc},
+      obj_h, [&](AST::AstNode *node) {
           if (node) {
               if ((node->type == AST::AST_PARAMETER || node->type == AST::AST_LOCALPARAM) && node->children.empty()) {
                   delete node; // skip parameters without any children
@@ -3893,7 +3893,7 @@ void UhdmAst::process_port()
         auto actual_type = vpi_get(vpiType, actual_h);
         switch (actual_type) {
         case vpiModport: {
-            vpiHandle iface_h = vpi_handle(vpiInterface, actual_h);
+            vpiHandle iface_h = vpi_handle(vpiInterfaceInst, actual_h);
             if (iface_h) {
                 std::string cellName, ifaceName;
                 if (auto s = vpi_get_str(vpiName, actual_h)) {
@@ -3915,7 +3915,7 @@ void UhdmAst::process_port()
             }
             break;
         }
-        case vpiInterface: {
+        case vpiInterfaceInst: {
             auto typeNode = new AST::AstNode(AST::AST_INTERFACEPORTTYPE);
             if (auto s = vpi_get_str(vpiDefName, actual_h)) {
                 typeNode->str = s;
@@ -4274,7 +4274,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case vpiPort:
         process_port();
         break;
-    case vpiModule:
+    case vpiModuleInst:
         process_module();
         break;
     case vpiStructTypespec:
@@ -4347,7 +4347,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case vpiPackage:
         process_package();
         break;
-    case vpiInterface:
+    case vpiInterfaceInst:
         process_interface();
         break;
     case vpiModport:


### PR DESCRIPTION
This is a follow-up to #436 and #438.

PR ensures compatibility with Surelog and UHDM after enum renames in https://github.com/chipsalliance/UHDM/commit/ae0a2dc4236bc1e2e389de3ccad2d99add07a3f4.