### PR TITLE
Do not visit unnecessary nodes in uhdmallModules

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1726,15 +1726,13 @@ void UhdmAst::process_module()
                     move_type_to_new_typedef(current_node, node);
                 }
             });
-            visit_one_to_many({vpiModule, vpiInterface, vpiTaskFunc, vpiParameter, vpiParamAssign, vpiPort, vpiNet, vpiArrayNet, vpiGenScopeArray,
-                               vpiProcess, vpiClockingBlock, vpiAssertion},
-                              obj_h, [&](AST::AstNode *node) {
-                                  if (node) {
-                                      if (node->type == AST::AST_ASSIGN && node->children.size() < 2)
-                                          return;
-                                      add_or_replace_child(current_node, node);
-                                  }
-                              });
+            visit_one_to_many({vpiModule, vpiParameter, vpiParamAssign, vpiNet, vpiArrayNet, vpiProcess}, obj_h, [&](AST::AstNode *node) {
+                if (node) {
+                    if (node->type == AST::AST_ASSIGN && node->children.size() < 2)
+                        return;
+                    add_or_replace_child(current_node, node);
+                }
+            });
         }
     } else {
         // Not a top module, create instance

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1850,7 +1850,7 @@ void UhdmAst::process_module()
                 add_or_replace_child(module_node, node);
             }
         });
-        visit_one_to_many({vpiInterface, vpiModule, vpiPort, vpiGenScopeArray, vpiContAssign}, obj_h, [&](AST::AstNode *node) {
+        visit_one_to_many({vpiInterface, vpiModule, vpiPort, vpiGenScopeArray, vpiContAssign, vpiTaskFunc}, obj_h, [&](AST::AstNode *node) {
             if (node) {
                 add_or_replace_child(module_node, node);
             }


### PR DESCRIPTION
These modifications remove nodes from being visited in _uhdmallModules_, that don't change the proper performance of the plugin when skipped.

The workflow with these modifications is tested in this PR: https://github.com/antmicro/yosys-systemverilog/pull/1357.