### PR TITLE
Split Github Actions to be per plugin

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -28,6 +28,11 @@ fi
 
 start_section Building
 
+if [ "$PLUGIN_NAME" == "xdc" ] || [ "$PLUGIN_NAME" == "sdc" ]; then 
+    make design_introspection.so -j`nproc`
+	make install_design_introspection -j`nproc`
+fi 
+
 export CXXFLAGS=-Werror
 make UHDM_INSTALL_DIR=`pwd`/env/conda/envs/yosys-plugins/ ${PLUGIN_NAME}.so -j`nproc`
 unset CXXFLAGS

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -19,12 +19,17 @@ set -e
 
 source .github/workflows/common.sh
 
+if [ -z "${PLUGIN_NAME}" ]; then
+	echo "Missing \${PLUGIN_NAME} env value"
+	exit 1
+fi
+
 ##########################################################################
 
 start_section Building
 
 export CXXFLAGS=-Werror
-make UHDM_INSTALL_DIR=`pwd`/env/conda/envs/yosys-plugins/ plugins -j`nproc`
+make UHDM_INSTALL_DIR=`pwd`/env/conda/envs/yosys-plugins/ ${PLUGIN_NAME}.so -j`nproc`
 unset CXXFLAGS
 
 end_section
@@ -32,19 +37,19 @@ end_section
 ##########################################################################
 
 start_section Installing
-make install -j`nproc`
+make install_${PLUGIN_NAME} -j`nproc`
 end_section
 
 ##########################################################################
 
 start_section Testing
-make test -j`nproc`
+make test_${PLUGIN_NAME} -j`nproc`
 end_section
 
 ##########################################################################
 
 start_section Cleanup
-make plugins_clean -j`nproc`
+make clean_${PLUGIN_NAME} -j`nproc`
 end_section
 
 ##########################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,22 @@ jobs:
   Run-tests:
     runs-on: ubuntu-20.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin:
+          - fasm
+          - xdc
+          - params
+          - sdc
+          - ql-iob
+          - design_introspection
+          - integrateinv
+          - ql-qlf
+          - systemverilog
+          - uhdm
+          - dsp-ff
+
     steps:
 
     - uses: actions/checkout@v2
@@ -61,3 +77,4 @@ jobs:
         source .github/workflows/build-and-test.sh
       env:
         OS: ${{ runner.os }}
+        PLUGIN_NAME: ${{ matrix.plugin }}


### PR DESCRIPTION
Right now there is a single Github action, in which we build and test all the plugins sequentially. This PR changes the workflow, so that there is a separate action for each plugin.