### PR TITLE
handle vpiTypeParameter

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4533,6 +4533,13 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case vpiClockingBlock:
         process_unsupported_stmt(object);
         break;
+    case vpiTypeParameter:
+        // Instances in an `uhdmTopModules` tree already have all parameter references
+        // substituted with the parameter type/value by Surelog,
+        // so the plugin doesn't need to process the parameter itself.
+        // Other parameter types are handled by the plugin
+        // mainly because they were implemented before Surelog did the substitution.
+        break;
     case vpiProgram:
     default:
         report_error("%.*s:%d: Encountered unhandled object '%.*s' of type '%s'\n", (int)object->VpiFile().length(), object->VpiFile().data(),


### PR DESCRIPTION
See https://github.com/lowRISC/opentitan/blob/748b19f8aa4bcd9b7c077d37b5f042dd23e07b23/hw/ip/prim/rtl/prim_sparse_fsm_flop.sv#L7

```
module prim_sparse_fsm_flop #(
  parameter int               Width      = 1,
  parameter type              StateEnumT = logic [Width-1:0],
```

The parameter is used like this:
```
  input  StateEnumT state_i,
  output StateEnumT state_o
```

The type parameter is not handled by the switch in the `process_object` function.
Parameters in general are replaced with proper values by Surelog, so I expect that we can just skip processing the node in the plugin.

The result I'm getting by using `read_systemverilog -debug` is:
With `Width = 1`:
```
      input [0:0] state_i;
      output [0:0] state_o;
```

With `Width = 8`:
```
      input [7:0] state_i;
      output [7:0] state_o;
```

So, from what I see, Surelog handles it properly.

See CI run here:https://github.com/antmicro/yosys-systemverilog/actions/runs/3998128456