### PR TITLE
Add 'final' to unsupported statements 

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4259,10 +4259,11 @@ void UhdmAst::process_primterm()
     visit_one_to_one({vpiExpr}, obj_h, [&](AST::AstNode *node) { current_node->children.push_back(node); });
 }
 
-void UhdmAst::process_unsupported_stmt(const UHDM::BaseClass *object)
+void UhdmAst::process_unsupported_stmt(const UHDM::BaseClass *object, bool is_error)
 {
-    log_error("%.*s:%d: Currently not supported object of type '%s'\n", (int)object->VpiFile().length(), object->VpiFile().data(),
-              object->VpiLineNo(), UHDM::VpiTypeName(obj_h).c_str());
+    const auto log_func = is_error ? log_error : log_warning;
+    std::string prefix = object->VpiLineNo() ? (std::string(object->VpiFile()) + ":" + std::to_string(object->VpiLineNo()) + ": ") : "";
+    log_func("%sCurrently not supported object of type '%s'\n", prefix.c_str(), UHDM::VpiTypeName(obj_h).c_str());
 }
 
 AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
@@ -4383,6 +4384,9 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         break;
     case vpiInitial:
         process_initial();
+        break;
+    case vpiFinal:
+        process_unsupported_stmt(object, false);
         break;
     case vpiNamedBegin:
         process_begin(true);

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -151,7 +151,7 @@ class UhdmAst
     void process_gate();
     void process_primterm();
     void simplify_parameter(::Yosys::AST::AstNode *parameter, ::Yosys::AST::AstNode *module_node = nullptr);
-    void process_unsupported_stmt(const UHDM::BaseClass *object);
+    void process_unsupported_stmt(const UHDM::BaseClass *object, bool is_error = true);
 
     UhdmAst(UhdmAst *p, UhdmAstShared &s, const std::string &i) : parent(p), shared(s), indent(i)
     {


### PR DESCRIPTION
`final` is unsupported by Yosys and it causes a crash with an error:
```
ERROR: :0: Encountered unhandled object '' of type 'final_stmt' 
```
From now on, there will be a warning printed since this is not a statement that should break synthesis and it is used for simulation purposes only.

FYI @mglb @wsipak @mandrys 