### PR TITLE
sdc-plugin: Add missing includes.

### DIFF
--- a/sdc-plugin/buffers.cc
+++ b/sdc-plugin/buffers.cc
@@ -18,6 +18,9 @@
 #include "buffers.h"
 #include <cassert>
 #include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
 
 const std::vector<std::string> Pll::inputs = {"CLKIN1", "CLKIN2"};
 const std::vector<std::string> Pll::outputs = {"CLKOUT0", "CLKOUT1", "CLKOUT2", "CLKOUT3", "CLKOUT4", "CLKOUT5"};


### PR DESCRIPTION
This file does compile (by accident) in most environments, but it did stop to compile in mine. I'm using latest yosys, so maybe that's the reason.
Anyway, the file uses things from the added includes, so the includes should be there.