### PR TITLE
systemverilog-plugin: move handle of list op to process_case_item

### DIFF
--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -175,6 +175,7 @@ class UhdmAst
     static const ::Yosys::IdString &force_convert();
     static const ::Yosys::IdString &is_imported();
     static const ::Yosys::IdString &is_simplified_wire();
+    static const ::Yosys::IdString &low_high_bound();
 };
 
 } // namespace systemverilog_plugin


### PR DESCRIPTION
Hot-fix for: https://github.com/chipsalliance/yosys-f4pga-plugins/pull/450

Ref: https://github.com/antmicro/yosys-systemverilog/issues/1448

yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4125754497/jobs/7126745238

It moves list op in set membership operator from ``process_list_op`` to ``process_case_item``.

Because ``process_list_op`` adds nodes directly to ancestor previous approach breaks processes with multiple conditions.
Ultimately I think we should refactor ``process_list_op`` to return nodes to caller instead of adding it directly as it causes a lot of confusion.

I've also added assert to ``vpiOperand`` visit in ``process_case_item`` to make sure we don't add any nodes in this visitor.

Fixing this showed that opentitan also uses identifiers as list op arguments, so I've added support for this (it was in TODO in previous PR).
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>