### PR TITLE
systemverilog-plugin: prefer full name in function calls

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1676,13 +1676,12 @@ AST::AstNode *UhdmAst::find_ancestor(const std::unordered_set<AST::AstNodeType> 
 void UhdmAst::process_design()
 {
     current_node = make_ast_node(AST::AST_DESIGN);
-    visit_one_to_many(
-      {UHDM::uhdmallInterfaces, UHDM::uhdmallPackages, UHDM::uhdmtopPackages, UHDM::uhdmallModules, UHDM::uhdmtopModules, vpiTaskFunc}, obj_h,
-      [&](AST::AstNode *node) {
-          if (node) {
-              shared.top_nodes[node->str] = node;
-          }
-      });
+    visit_one_to_many({UHDM::uhdmallInterfaces, UHDM::uhdmtopPackages, UHDM::uhdmallModules, UHDM::uhdmtopModules, vpiTaskFunc}, obj_h,
+                      [&](AST::AstNode *node) {
+                          if (node) {
+                              shared.top_nodes[node->str] = node;
+                          }
+                      });
     visit_one_to_many({vpiParameter, vpiParamAssign}, obj_h, [&](AST::AstNode *node) {});
     visit_one_to_many({vpiTypedef}, obj_h, [&](AST::AstNode *node) {
         if (node)

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -311,6 +311,7 @@ static AST::AstNode *convert_range(AST::AstNode *id, const std::vector<AST::AstN
     // return range from *current* selected range
     // in the end, it results in whole selected range
     id->basic_prep = true;
+    result->dumpAst(NULL, "> ");
     return result;
 }
 
@@ -3824,6 +3825,12 @@ void UhdmAst::process_tf_call(AST::AstNodeType type)
             current_node->children.push_back(node);
         }
     });
+    // Prefer fully qualified name of a function (prefixed with a scope).
+    // This is important when a single function which has been imported from a package
+    // calls another function that is not imported in the calling scope.
+    if (vpiHandle function_h = vpi_handle(vpiFunction, obj_h)) {
+        current_node->str = get_name(function_h, true);
+    }
 }
 
 void UhdmAst::process_immediate_assert()


### PR DESCRIPTION
This PR fixes usage of imported function that uses another, not imported, function.

UHDM-integration-tests: https://github.com/chipsalliance/UHDM-integration-tests/pull/708
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4183705520

