### PR TITLE
systemverilog-plugin: convert memory when accessing slice

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -439,9 +439,15 @@ static void check_memories(AST::AstNode *module_node)
                 //   mem <= '{default:0};
                 //   mem[7:1] <= mem[6:0];
                 // end
+                // don't convert in case of accessing
+                // memory using address, e.g.
+                // mem[0] <= '{default:0}
+                //
+                // Access to whole memory
                 if (node->children.size() == 0) {
                     force_convert = true;
                 }
+                // Access to slice of memory
                 if (node->children.size() == 1 && node->children[0]->children.size() != 1) {
                     force_convert = true;
                 }

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -428,8 +428,26 @@ static void check_memories(AST::AstNode *module_node)
             }
         }
         if (node->type == AST::AST_IDENTIFIER && memories.count(node->str)) {
-            if (!memories[node->str]->attributes.count(UhdmAst::force_convert()) && node->children.size() == 0) {
-                add_force_convert_attribute(memories[node->str]);
+            if (!memories[node->str]->attributes.count(UhdmAst::force_convert())) {
+                bool force_convert = false;
+                // convert memory to list of registers
+                // in case of access to whole memory
+                // or slice of memory
+                // e.g.
+                // logic [3:0] mem [8:0];
+                // always_ff @ (posedge clk) begin
+                //   mem <= '{default:0};
+                //   mem[7:1] <= mem[6:0];
+                // end
+                if (node->children.size() == 0) {
+                    force_convert = true;
+                }
+                if (node->children.size() == 1 && node->children[0]->children.size() != 1) {
+                    force_convert = true;
+                }
+                if (force_convert) {
+                    add_force_convert_attribute(memories[node->str]);
+                }
             }
         }
     });


### PR DESCRIPTION
Fixes: https://github.com/antmicro/yosys-systemverilog/issues/1505

Convert memories to list of registers if we are accessing slice of memory.

yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4204594665
UHDM-integration test: https://github.com/chipsalliance/UHDM-integration-tests/pull/711