### PR TITLE
systemverilog-plugin: Fix IdString initialization

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -42,41 +42,44 @@ enum AstNodeTypeExtended {
 }
 } // namespace AST
 
-/*static*/ const IdString &UhdmAst::partial()
+namespace attr_id
 {
-    static const IdString id("\\partial");
-    return id;
-}
-/*static*/ const IdString &UhdmAst::packed_ranges()
-{
-    static const IdString id("\\packed_ranges");
-    return id;
-}
-/*static*/ const IdString &UhdmAst::unpacked_ranges()
-{
-    static const IdString id("\\unpacked_ranges");
-    return id;
-}
-/*static*/ const IdString &UhdmAst::force_convert()
-{
-    static const IdString id("\\force_convert");
-    return id;
-}
-/*static*/ const IdString &UhdmAst::is_imported()
-{
-    static const IdString id("\\is_imported");
-    return id;
-}
-/*static*/ const IdString &UhdmAst::is_simplified_wire()
-{
-    static const IdString id("\\is_simplified_wire");
-    return id;
-}
+static IdString partial;
+static IdString packed_ranges;
+static IdString unpacked_ranges;
+static IdString force_convert;
+static IdString is_imported;
+static IdString is_simplified_wire;
+static IdString low_high_bound;
+}; // namespace attr_id
 
-/*static*/ const IdString &UhdmAst::low_high_bound()
+/*static*/ const IdString &UhdmAst::partial() { return attr_id::partial; }
+/*static*/ const IdString &UhdmAst::packed_ranges() { return attr_id::packed_ranges; }
+/*static*/ const IdString &UhdmAst::unpacked_ranges() { return attr_id::unpacked_ranges; }
+/*static*/ const IdString &UhdmAst::force_convert() { return attr_id::force_convert; }
+/*static*/ const IdString &UhdmAst::is_imported() { return attr_id::is_imported; }
+/*static*/ const IdString &UhdmAst::is_simplified_wire() { return attr_id::is_simplified_wire; }
+/*static*/ const IdString &UhdmAst::low_high_bound() { return attr_id::low_high_bound; }
+
+void UhdmAst::static_init()
 {
-    static const IdString id("\\low_high_bound");
-    return id;
+    // Initialize only once
+    static bool already_initialized = false;
+    if (already_initialized)
+        return;
+    already_initialized = true;
+
+    // Actual initialization
+
+    // Register IdStrings. Can't be done statically, as the IdString class uses resources created during Yosys initialization which happens after
+    // static initialization of the plugin when everything is statically linked.
+    attr_id::partial = IdString("$systemverilog_plugin$partial");
+    attr_id::packed_ranges = IdString("$systemverilog_plugin$packed_ranges");
+    attr_id::unpacked_ranges = IdString("$systemverilog_plugin$unpacked_ranges");
+    attr_id::force_convert = IdString("$systemverilog_plugin$force_convert");
+    attr_id::is_imported = IdString("$systemverilog_plugin$is_imported");
+    attr_id::is_simplified_wire = IdString("$systemverilog_plugin$is_simplified_wire");
+    attr_id::low_high_bound = IdString("$systemverilog_plugin$low_high_bound");
 }
 
 static void sanitize_symbol_name(std::string &name)
@@ -4721,6 +4724,16 @@ AST::AstNode *UhdmAst::visit_designs(const std::vector<vpiHandle> &designs)
             current_node->children.push_back(child);
         }
     }
+
+    // Release static copies of private IdStrings. Those should be last instances in use.
+    attr_id::low_high_bound = IdString();
+    attr_id::is_simplified_wire = IdString();
+    attr_id::is_imported = IdString();
+    attr_id::force_convert = IdString();
+    attr_id::unpacked_ranges = IdString();
+    attr_id::packed_ranges = IdString();
+    attr_id::partial = IdString();
+
     return current_node;
 }
 

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -168,11 +168,6 @@ class UhdmAst
     // Visits all VPI design objects and returns created ASTs
     ::Yosys::AST::AstNode *visit_designs(const std::vector<vpiHandle> &designs);
 
-    // Does initialization of the class global data.
-    // Must be called before the first use of the class.
-    // Can be called multiple times; only the first call performs actual initialization.
-    static void static_init();
-
     static const ::Yosys::IdString &partial();
     static const ::Yosys::IdString &packed_ranges();
     static const ::Yosys::IdString &unpacked_ranges();

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -168,6 +168,11 @@ class UhdmAst
     // Visits all VPI design objects and returns created ASTs
     ::Yosys::AST::AstNode *visit_designs(const std::vector<vpiHandle> &designs);
 
+    // Does initialization of the class global data.
+    // Must be called before the first use of the class.
+    // Can be called multiple times; only the first call performs actual initialization.
+    static void static_init();
+
     static const ::Yosys::IdString &partial();
     static const ::Yosys::IdString &packed_ranges();
     static const ::Yosys::IdString &unpacked_ranges();

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -118,6 +118,7 @@ class Compiler
 struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
     UhdmSurelogAstFrontend(std::string name, std::string short_help) : UhdmCommonFrontend(name, short_help) {}
     UhdmSurelogAstFrontend() : UhdmCommonFrontend("verilog_with_uhdm", "generate/read UHDM file") {}
+
     void help() override
     {
         //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -128,6 +129,9 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         log("\n");
         this->print_read_options();
     }
+
+    virtual void on_register() override { UhdmAst::static_init(); }
+
     AST::AstNode *parse(std::string filename) override
     {
         std::vector<const char *> cstrings;

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -130,8 +130,6 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         this->print_read_options();
     }
 
-    virtual void on_register() override { UhdmAst::static_init(); }
-
     AST::AstNode *parse(std::string filename) override
     {
         std::vector<const char *> cstrings;


### PR DESCRIPTION
Changes:
- The private IdStrings renamed to start with `$`, as this is convention used in Yosys (see: [verific frontend][verific], [ID() macro][def_id]).
- IdStrings are initialized all at once on plugin registration and removed after the design is parsed. This is required because, for some reason, Yosys can generate slightly different output depending on how much extra IdStrings are there.

This is an initial change. Expected follow up changes:
- Remove all private attributes from final AstNode tree.
- Remove existing memory leaks of AstNode objects. Otherwise IdStrings will never unregister, as they use reference counting.
- Remove `UhdmAst::XXX()` methods and use `attr_id::XXX` directly.

[verific]: https://github.com/YosysHQ/yosys/blob/f35bdaa5278b408e94ac8c97a06c3f7f0fe1773a/frontends/verific/verific.cc#L196
[def_id]: https://github.com/YosysHQ/yosys/blob/f35bdaa5278b408e94ac8c97a06c3f7f0fe1773a/kernel/yosys.h#L344