### PR TITLE
systemverilog-plugin: set range before range_valid

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -511,6 +511,8 @@ static void convert_packed_unpacked_range(AST::AstNode *wire_node)
     if (packed_ranges.empty() && unpacked_ranges.empty()) {
         wire_node->attributes.erase(UhdmAst::packed_ranges());
         wire_node->attributes.erase(UhdmAst::unpacked_ranges());
+        wire_node->range_left = 0;
+        wire_node->range_right = 0;
         wire_node->range_valid = true;
         return;
     }


### PR DESCRIPTION
This PR sets ``range_left``/``range_right`` before setting ``range_valid`` to prevent negative ranges in AST.

Fixes: https://github.com/antmicro/yosys-systemverilog/issues/1506
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4342540165