### PR TITLE
systemverilog-plugin: fix assignments on declaration

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2636,9 +2636,26 @@ void UhdmAst::process_assignment(const UHDM::BaseClass *object)
 
     visit_one_to_one({vpiLhs, vpiRhs}, obj_h, [&](AST::AstNode *node) {
         if (node) {
-            if (node->type == AST::AST_PARAMETER || node->type == AST::AST_LOCALPARAM) {
+            // fix node types for some assignments
+            // yosys requires that declaration of variable
+            // and assignment are separated
+            switch (node->type) {
+            case AST::AST_WIRE:
+                // wires can be declarated inside initialization block of for block
+                if (AST::AstNode *for_block = find_ancestor({AST::AST_BLOCK})) {
+                    if (for_block->str.find("$fordecl_block") != std::string::npos)
+                        break;
+                }
+                [[fallthrough]];
+            case AST::AST_PARAMETER:
+            case AST::AST_LOCALPARAM:
                 node->type = AST::AST_IDENTIFIER;
-            }
+                delete_attribute(node, UhdmAst::packed_ranges());
+                delete_attribute(node, UhdmAst::unpacked_ranges());
+                break;
+            default:
+                break;
+            };
             current_node->children.push_back(node);
         }
     });
@@ -3790,17 +3807,6 @@ void UhdmAst::process_function()
     visit_one_to_many({vpiVariables}, obj_h, [&](AST::AstNode *node) { current_node->children.push_back(node); });
     visit_one_to_one({vpiStmt}, obj_h, [&](AST::AstNode *node) {
         if (node) {
-            // Fix for assignments on declaration, e.g.:
-            // logic [63:0] key_out = key_in;
-            // key_out is already declared as vpiVariables, but it is also declared inside vpiStmt
-            const std::unordered_set<AST::AstNodeType> assign_types = {AST::AST_ASSIGN, AST::AST_ASSIGN_EQ, AST::AST_ASSIGN_LE};
-            for (auto c : node->children) {
-                if (assign_types.find(c->type) != assign_types.end() && c->children[0]->type == AST::AST_WIRE) {
-                    c->children[0]->type = AST::AST_IDENTIFIER;
-                    delete_attribute(c->children[0], UhdmAst::packed_ranges());
-                    delete_attribute(c->children[0], UhdmAst::unpacked_ranges());
-                }
-            }
             current_node->children.push_back(node);
         }
     });

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2650,6 +2650,7 @@ void UhdmAst::process_assignment(const UHDM::BaseClass *object)
             case AST::AST_PARAMETER:
             case AST::AST_LOCALPARAM:
                 node->type = AST::AST_IDENTIFIER;
+                delete_children(node);
                 delete_attribute(node, UhdmAst::packed_ranges());
                 delete_attribute(node, UhdmAst::unpacked_ranges());
                 break;


### PR DESCRIPTION
This PR fixes assignments on declaration in more generic way. Assignments on declaration in genfor blocks are handled separately, so they are left intact.

UHDM-integration-tests: https://github.com/chipsalliance/UHDM-integration-tests/pull/719
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4531860494