### PR TITLE
Systemverilog plugin: Use pkg-config to determine dependencies.

### DIFF
--- a/Makefile_plugin.common
+++ b/Makefile_plugin.common
@@ -101,14 +101,14 @@ OBJECTS := $(_ALL_OBJECTS)
 
 # Shared library
 
-_SO_LIB := $(BUILD_DIR)/$(NAME).so
-_ALL_BUILD_SUBDIRS += $(abspath $(dir $(_SO_LIB)))
+SO_LIB := $(BUILD_DIR)/$(NAME).so
+_ALL_BUILD_SUBDIRS += $(abspath $(dir $(SO_LIB)))
 
-$(_SO_LIB): $(_ALL_OBJECTS) $(_MAKEFILES) | $(abspath $(dir $(_SO_LIB)))
+$(SO_LIB): $(_ALL_OBJECTS) $(_MAKEFILES) | $(abspath $(dir $(SO_LIB)))
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $(_ALL_OBJECTS) $(LDLIBS)
 
 .PHONY: $(NAME).so
-$(NAME).so: $(_SO_LIB)
+$(NAME).so: $(SO_LIB)
 
 # Tests
 
@@ -125,8 +125,8 @@ endif
 
 # Installation
 
-$(YOSYS_PLUGINS_DIR)/$(NAME).so: $(_SO_LIB) | $(YOSYS_PLUGINS_DIR)
-	install -D $(_SO_LIB) $@
+$(YOSYS_PLUGINS_DIR)/$(NAME).so: $(SO_LIB) | $(YOSYS_PLUGINS_DIR)
+	install -D $(SO_LIB) $@
 
 .PHONY: install_plugin
 install_plugin: $(YOSYS_PLUGINS_DIR)/$(NAME).so
@@ -151,4 +151,3 @@ PMGEN_PY := $(TOP_DIR)/pmgen.py
 
 $(PMGEN_PY):
 	@$(MAKE) -C $(TOP_DIR) pmgen.py
-

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -49,4 +49,6 @@ CXXFLAGS += -std=c++17 -Wall -W -Wextra \
             -Wno-unused-parameter \
             $(shell $(PKG_CONFIG_INVOKE) --cflags Surelog)
 
-LDFLAGS += $(shell $(PKG_CONFIG_INVOKE) --libs Surelog)
+LDFLAGS += $(shell $(PKG_CONFIG_INVOKE) --libs-only-L Surelog)
+
+LDLIBS += $(shell $(PKG_CONFIG_INVOKE) --libs-only-l --libs-only-other Surelog)

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -42,7 +42,7 @@ include ../Makefile_plugin.common
 $(BUILD_DIR)/.$(NAME)-deps-test:
 	$(PKG_CONFIG_INVOKE) --cflags Surelog
 
-${_SO_LIB}: | $(BUILD_DIR)/.$(NAME)-deps-test
+${SO_LIB}: | $(BUILD_DIR)/.$(NAME)-deps-test
 
 CXXFLAGS += -std=c++17 -Wall -W -Wextra \
             -Wno-deprecated-declarations \

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -27,31 +27,26 @@ SOURCES = UhdmAst.cc \
 # Directory to search for Surelog and UHDM libraries
 UHDM_INSTALL_DIR ?= /usr/local
 
+# Tell pkg-config to look in the provided install path first.
+# PKG_CONFIG_PATH and PKG_CONFIG_PATH_FOR_TARGET are search paths it looks in
+# so set the environment variables and prefix with our local install first
+PKG_CONFIG_INVOKE = \
+   PKG_CONFIG_PATH=$(UHDM_INSTALL_DIR)/lib/pkgconfig:${PKG_CONFIG_PATH} \
+   PKG_CONFIG_PATH_FOR_TARGET=$(UHDM_INSTALL_DIR)/lib/pkgconfig:${PKG_CONFIG_PATH_FOR_TARGET} \
+   pkg-config
+
 include ../Makefile_plugin.common
+
+# A litmus-test: make compilation fail if pkg-config fails
+.SECONDARY: $(BUILD_DIR)/.$(NAME)-deps-test
+$(BUILD_DIR)/.$(NAME)-deps-test:
+	$(PKG_CONFIG_INVOKE) --cflags Surelog
+
+${_SO_LIB}: | $(BUILD_DIR)/.$(NAME)-deps-test
 
 CXXFLAGS += -std=c++17 -Wall -W -Wextra \
             -Wno-deprecated-declarations \
             -Wno-unused-parameter \
-            -I${UHDM_INSTALL_DIR}/include \
-            -I${UHDM_INSTALL_DIR}/include/Surelog
+            $(shell $(PKG_CONFIG_INVOKE) --cflags Surelog)
 
-LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm \
-           -L${UHDM_INSTALL_DIR}/lib/surelog \
-           -L${UHDM_INSTALL_DIR}/lib \
-           -L${UHDM_INSTALL_DIR}/lib64/uhdm \
-           -L${UHDM_INSTALL_DIR}/lib64/surelog \
-           -L${UHDM_INSTALL_DIR}/lib64
-
-LDLIBS += -Wl,--whole-archive \
-          -luhdm \
-          -Wl,--no-whole-archive \
-          -lsurelog \
-          -lantlr4-runtime \
-          -lflatbuffers \
-          -lcapnp \
-          -lkj \
-          -ldl \
-          -lutil \
-          -lm \
-          -lrt \
-          -lpthread
+LDFLAGS += $(shell $(PKG_CONFIG_INVOKE) --libs Surelog)

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -46,7 +46,7 @@ ${SO_LIB}: | $(BUILD_DIR)/.$(NAME)-deps-test
 
 CXXFLAGS += -std=c++17 -Wall -W -Wextra \
             -Wno-deprecated-declarations \
-            -Wno-unused-parameter \
+            -Wno-unused-parameter
             $(shell $(PKG_CONFIG_INVOKE) --cflags Surelog)
 
 LDFLAGS += $(shell $(PKG_CONFIG_INVOKE) --libs-only-L Surelog)

--- a/systemverilog-plugin/Makefile
+++ b/systemverilog-plugin/Makefile
@@ -46,7 +46,7 @@ ${SO_LIB}: | $(BUILD_DIR)/.$(NAME)-deps-test
 
 CXXFLAGS += -std=c++17 -Wall -W -Wextra \
             -Wno-deprecated-declarations \
-            -Wno-unused-parameter
+            -Wno-unused-parameter \
             $(shell $(PKG_CONFIG_INVOKE) --cflags Surelog)
 
 LDFLAGS += $(shell $(PKG_CONFIG_INVOKE) --libs-only-L Surelog)


### PR DESCRIPTION
UHDM and Surelog now both provide pkg-config configuration so using that moves the repsonsibility finding the correct include paths and libs to the right place.

Fixes #472