### PR TITLE
systemverilog-plugin: unlock surelog version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,5 +20,5 @@ channels:
   - litex-hub
 dependencies:
   - litex-hub::yosys=0.17_7_g990c9b8e1=20220512_085338_py37
-  - litex-hub::surelog=0.0_5580_g493120558=20230116_180937_py37
+  - litex-hub::surelog
   - litex-hub::iverilog


### PR DESCRIPTION
Fixes: https://github.com/chipsalliance/yosys-f4pga-plugins/issues/429