### PR TITLE
systemverilog-plugin: fix size of struct used as I/O wire

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -412,6 +412,7 @@ static void resolve_wiretype(AST::AstNode *wire_node)
     wiretype_ast = AST_INTERNAL::current_scope[wiretype_node->str];
     // we need to setup current top ast as this simplify
     // needs to have access to all already defined ids
+    simplify_sv(wiretype_ast, nullptr);
     while (simplify(wire_node, true, false, false, 1, -1, false, false)) {
     }
     log_assert(!wiretype_ast->children.empty());

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4292,7 +4292,7 @@ void UhdmAst::process_port()
                 }
                 delete node;
             });
-            visit_one_to_many({vpiRange}, actual_h, [&](AST::AstNode *node) { current_node->children.push_back(node); });
+            visit_one_to_many({vpiRange}, actual_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
             shared.report.mark_handled(actual_h);
             break;
         case vpiPackedArrayNet:
@@ -4300,7 +4300,7 @@ void UhdmAst::process_port()
             shared.report.mark_handled(actual_h);
             break;
         case vpiArrayVar:
-            visit_one_to_many({vpiRange}, actual_h, [&](AST::AstNode *node) { current_node->children.push_back(node); });
+            visit_one_to_many({vpiRange}, actual_h, [&](AST::AstNode *node) { unpacked_ranges.push_back(node); });
             shared.report.mark_handled(actual_h);
             break;
         case vpiEnumNet:

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4336,7 +4336,7 @@ void UhdmAst::process_port()
     }
     visit_one_to_one({vpiTypedef}, obj_h, [&](AST::AstNode *node) {
         if (node) {
-            if (current_node->children.empty() || (!current_node->children.empty() && current_node->children[0]->type != AST::AST_WIRETYPE)) {
+            if (current_node->children.empty() || current_node->children[0]->type != AST::AST_WIRETYPE) {
                 if (!node->str.empty()) {
                     auto wiretype_node = new AST::AstNode(AST::AST_WIRETYPE);
                     wiretype_node->str = node->str;

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -1199,7 +1199,9 @@ static void simplify_sv(AST::AstNode *current_node, AST::AstNode *parent_node)
         break;
     case AST::AST_STRUCT_ITEM:
         AST_INTERNAL::current_scope[current_node->str] = current_node;
-        convert_packed_unpacked_range(current_node);
+        if (current_node->attributes.count(UhdmAst::packed_ranges()) || current_node->attributes.count(UhdmAst::unpacked_ranges())) {
+            convert_packed_unpacked_range(current_node);
+        }
         while (simplify(current_node, true, false, false, 1, -1, false, false)) {
         };
         break;

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4330,7 +4330,7 @@ void UhdmAst::process_port()
     }
     visit_one_to_one({vpiTypedef}, obj_h, [&](AST::AstNode *node) {
         if (node) {
-            if (!current_node->children.empty() && current_node->children[0]->type != AST::AST_WIRETYPE) {
+            if (current_node->children.empty() || (!current_node->children.empty() && current_node->children[0]->type != AST::AST_WIRETYPE)) {
                 if (!node->str.empty()) {
                     auto wiretype_node = new AST::AstNode(AST::AST_WIRETYPE);
                     wiretype_node->str = node->str;


### PR DESCRIPTION
This PR contains multiple small fixes that combined fixes size of struct that is used as I/O in module.


UHDM-integration-tests: https://github.com/chipsalliance/UHDM-integration-tests/pull/720
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4618618727