### PR TITLE
Be specific of what includes we need from surelog.

### DIFF
--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -33,8 +33,10 @@
 
 #include <list>
 
-#include "Surelog/ErrorReporting/Report.h"
-#include "Surelog/surelog.h"
+#include "Surelog/API/Surelog.h"
+#include "Surelog/CommandLine/CommandLineParser.h"
+#include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/SourceCompile/SymbolTable.h"
 
 namespace UHDM
 {


### PR DESCRIPTION
The kitchen-sink include file Surelog/surelog.h makes things look simple, but it also hides what we actually want. So apply IWYU principle and only include what we need.

This will help us long-term to tackle
https://github.com/chipsalliance/Surelog/issues/3568