### PR TITLE
Warn about invalidvalue in reduceExpr

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2357,7 +2357,9 @@ static UHDM::expr *reduce_expression(const UHDM::any *expr, const UHDM::any *ins
     bool invalidvalue = false;
     UHDM::ExprEval eval;
     UHDM::expr *resolved_operation = eval.reduceExpr(expr, invalidvalue, inst, pexpr);
-    log_assert(!invalidvalue);
+    if (invalidvalue) {
+        log_file_warning(std::string(expr->VpiFile()), expr->VpiLineNo(), "Could not reduce expression.\n");
+    }
     return resolved_operation;
 }
 


### PR DESCRIPTION
When processing a module in OT, I got this error:
```
ERROR: ERROR: Assert `!invalidvalue' failed in UhdmAst.cc:2360
```

An identifier wasn't delcared properly, so `reduceExpr` failed, and the expected error message would be:
```
rstmgr_pkg.sv:93: ERROR: Identifier `\NumTotalResets' is implicitly declared outside of a module.
```

We wouldn't see the error about undeclared identifier, because `log_assert` stops execution.
`invalidvalue` should always be `false`, so the assert isn't really wrong. However, we should not stop the execution here.
I'm changing this to a warning instead of the assert.

In case when `reduceExpr` fails, the returned object is the same as input, so we don't need to handle the return value separately.

CI run:
https://github.com/antmicro/yosys-systemverilog/actions/runs/4677828014