### PR TITLE
Make it easy to change the type used for sizes.

### DIFF
--- a/systemverilog-plugin/third_party/yosys/simplify.cc
+++ b/systemverilog-plugin/third_party/yosys/simplify.cc
@@ -36,6 +36,8 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include "simplify.h"
+
 YOSYS_NAMESPACE_BEGIN
 namespace VERILOG_FRONTEND
 {
@@ -48,8 +50,6 @@ namespace systemverilog_plugin
 
 using namespace ::Yosys;
 using namespace ::Yosys::AST_INTERNAL;
-
-bool simplify(Yosys::AST::AstNode *ast_node, bool const_fold, bool at_zero, bool in_lvalue, int stage, int width_hint, bool sign_hint, bool in_param);
 
 void annotateTypedEnums(Yosys::AST::AstNode *ast_node, Yosys::AST::AstNode *template_node)
 {
@@ -3794,7 +3794,7 @@ replace_fcall_later:;
 	{
 		bool string_op;
 		std::vector<RTLIL::State> tmp_bits;
-		RTLIL::Const (*const_func)(const RTLIL::Const&, const RTLIL::Const&, bool, bool, int);
+		RTLIL::Const (*const_func)(const RTLIL::Const&, const RTLIL::Const&, bool, bool, ys_size_type);
 		RTLIL::Const dummy_arg;
 
 		switch (ast_node->type)

--- a/systemverilog-plugin/third_party/yosys/simplify.h
+++ b/systemverilog-plugin/third_party/yosys/simplify.h
@@ -2,5 +2,6 @@
 
 namespace systemverilog_plugin
 {
+    using ys_size_type = int;  // Makes it easy to change if changed upstream.
     bool simplify(Yosys::AST::AstNode *ast_node, bool const_fold, bool at_zero, bool in_lvalue, int stage, int width_hint, bool sign_hint, bool in_param);
 }


### PR DESCRIPTION
I am working on a patch that changes yosys types that deal with sizes to be a ys_size_type typedef (needed to get ready for bigger designs).

This change here is a no-op, but it makes it possible to change things at a single place once we're ready.