### PR TITLE
systemverilog-plugin: replace default parameter definition in genscope

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3780,14 +3780,10 @@ void UhdmAst::process_gen_scope()
     });
 
     visit_one_to_many(
-      {vpiParamAssign, vpiParameter, vpiNet, vpiArrayNet, vpiVariables, vpiContAssign, vpiProcess, vpiModule, vpiGenScopeArray, vpiTaskFunc}, obj_h,
+      {vpiParameter, vpiParamAssign, vpiNet, vpiArrayNet, vpiVariables, vpiContAssign, vpiProcess, vpiModule, vpiGenScopeArray, vpiTaskFunc}, obj_h,
       [&](AST::AstNode *node) {
           if (node) {
-              if ((node->type == AST::AST_PARAMETER || node->type == AST::AST_LOCALPARAM) && node->children.empty()) {
-                  delete node; // skip parameters without any children
-              } else {
-                  current_node->children.push_back(node);
-              }
+              add_or_replace_child(current_node, node);
           }
       });
 }


### PR DESCRIPTION
Surelog reports both definition of parameter (in ``vpiParameter``) and actual value of paramter (in ``vpiParamAssign``) in ``vpiGenScope``. Previously we were skipping empty definitions of parameters, but we should actually replace this definition with value (if available).

UHDM-integration-test: https://github.com/chipsalliance/UHDM-integration-tests/pull/722
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4730063145/jobs/8393403356