### PR TITLE
Take name from the AST_DOT node in pattern assignment

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -3586,13 +3586,22 @@ void UhdmAst::process_assignment_pattern_op()
         std::map<size_t, AST::AstNode *> ordered_children;
         visit_one_to_many({vpiOperand}, obj_h, [&](AST::AstNode *node) {
             if (node->type == AST::AST_ASSIGN || node->type == AST::AST_ASSIGN_EQ || node->type == AST::AST_ASSIGN_LE) {
-                // Find at what position in the concat should we place this node
-                auto key = node->children[0]->str;
-                key = key.substr(key.find('.') + 1);
+                // Get the name of the parameter or it's child, to which the pattern is assigned.
+                std::string key;
+                if (!node->children.empty() && !node->children[0]->children.empty() &&
+                    node->children[0]->children[0]->type == static_cast<AST::AstNodeType>(AST::Extended::AST_DOT)) {
+                    key = node->children[0]->children[0]->str;
+                } else if (!node->children.empty()) {
+                    key = node->children[0]->str;
+                } else {
+                    log_file_error(node->filename, node->location.first_line, "Couldn't find `key` in assignment pattern.\n");
+                }
                 auto param_type = shared.param_types[param_node->str];
                 if (!param_type) {
                     log_error("Couldn't find parameter type for node: %s\n", param_node->str.c_str());
                 }
+                // Place the child node holding the value assigned in the pattern, in the right order,
+                // so the overall value of the param_node is correct.
                 size_t pos =
                   std::find_if(param_type->children.begin(), param_type->children.end(), [key](AST::AstNode *child) { return child->str == key; }) -
                   param_type->children.begin();


### PR DESCRIPTION
As reported in issue https://github.com/chipsalliance/yosys-f4pga-plugins/issues/482, in cases were typedef struct parameter is used, only the value of the first struct field was added to the whole parameter value, and the rest was ignored - it was caused by the fact that the string of the struct fields were skipped when adding the values of struct, so all of them had the same name, hence they were treated as one field.

Test _yosys-systemverilog_ CI run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4743420278
Test for the plugin: https://github.com/chipsalliance/UHDM-integration-tests/pull/723