### PR TITLE
Add version to Makefile; use that to automatically tag the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,35 @@ jobs:
       env:
         OS: ${{ runner.os }}
         PLUGIN_NAME: ${{ matrix.plugin }}
+
+  release-tagging:
+    name: Version Tagging
+    runs-on: ubuntu-20.04
+    if: ${{github.event_name == 'push' && github.ref == 'refs/heads/main'}}
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+       fetch-depth: 0
+       token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Tag with Makefile version if not already.
+      run: |
+        git config --local user.name "Development Bot"
+        git config --local user.email f4pga-dev@chipsalliance.org"
+
+        # We want to tag whenever the version in the Makefile changes.
+        # So extract the hash of when the current version was entered.
+        read TAG_HASH TAG_VERSION <<<$(git annotate -l Makefile | sed 's/\(^[0-9A-Fa-f]\+\).*PLUGIN_VERSION\s\+=\s\+\([0-9]\+\.[0-9]\+\).*/\1 \2/p;d')
+
+        echo "F4PGA Yosys Plugin Version v${TAG_VERSION} at hash ${TAG_HASH}"
+
+        # If this is the first time we see this tag: apply.
+        if [ -z "$(git tag -l "v${TAG_VERSION}")" ]; then
+          git tag -a "v${TAG_VERSION}" ${TAG_HASH} -m "Update to v${TAG_VERSION}"
+          git push origin "v${TAG_VERSION}"
+        else
+          echo "Tag already applied"
+        fi

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Version number of Plugins. For simplicity, based on date when we choose to
+# release. We can get more sophisticated later (but then need bump Major >= 2).
+# Version number has a Major and Minor version number, git-tags are free to
+# append a patchlevel (which is number of commits since last X.Y update).
+#
+# The CI will automatically tag the release with v${PLLUGIN_VERSION}
+#
+# TODO: pass as -D to gcc so that modules can provide e.g. --version flags.
+PLUGIN_VERSION = 1.20230419
+
 PLUGIN_LIST := fasm xdc params sdc ql-iob design_introspection integrateinv ql-qlf systemverilog uhdm dsp-ff
 PLUGINS := $(foreach plugin,$(PLUGIN_LIST),$(plugin).so)
 PLUGINS_INSTALL := $(foreach plugin,$(PLUGIN_LIST),install_$(plugin))


### PR DESCRIPTION
This is a suggestion to provide a version number to the project, and use that to also tag with the same version in git.

Context:
https://github.com/chipsalliance/yosys-f4pga-plugins/issues/489