### PR TITLE
Fix typo in verision tagging CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Tag with Makefile version if not already.
       run: |
         git config --local user.name "Development Bot"
-        git config --local user.email f4pga-dev@chipsalliance.org"
+        git config --local user.email "f4pga-dev@chipsalliance.org"
 
         # We want to tag whenever the version in the Makefile changes.
         # So extract the hash of when the current version was entered.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 # The CI will automatically tag the release with v${PLLUGIN_VERSION}
 #
 # TODO: pass as -D to gcc so that modules can provide e.g. --version flags.
-PLUGIN_VERSION = 1.20230419
+PLUGIN_VERSION = 1.20230425
 
 PLUGIN_LIST := fasm xdc params sdc ql-iob design_introspection integrateinv ql-qlf systemverilog uhdm dsp-ff
 PLUGINS := $(foreach plugin,$(PLUGIN_LIST),$(plugin).so)


### PR DESCRIPTION
While at it, bump the version to today as the old PR was a few days old.