### PR TITLE
Canonicalize paths used in tests.

### DIFF
--- a/clockgating-plugin/tests/regfile/regfile.tcl
+++ b/clockgating-plugin/tests/regfile/regfile.tcl
@@ -1,18 +1,20 @@
 yosys -import
-if { [info procs getparam] == {} } { plugin -i params }
+if { [info procs reg_clock_gating] == {} } { plugin -i clockgating }
 yosys -import  ;# ingest plugin commands
 
+set LIBDIR [file dirname $::env(DESIGN_TOP)]/lib
+
 read_verilog $::env(DESIGN_TOP).v
-read_liberty -lib -ignore_miss_dir -setattr blackbox ./lib/sky130_fd_sc_hd.lib 
-read_verilog ./lib/sky130_hd_clkg_blackbox.v
+read_liberty -lib -ignore_miss_dir -setattr blackbox $LIBDIR/sky130_fd_sc_hd.lib
+read_verilog $LIBDIR/sky130_hd_clkg_blackbox.v
 hierarchy -check -auto-top
 
 
-reg_clock_gating ./lib/sky130_hd_ff_map.v
+reg_clock_gating $LIBDIR/sky130_hd_ff_map.v
 opt_clean -purge
 synth -top top
-dfflibmap -liberty ./lib/sky130_fd_sc_hd.lib 
-abc -D 1250 -liberty ./lib/sky130_fd_sc_hd.lib 
+dfflibmap -liberty $LIBDIR/sky130_fd_sc_hd.lib
+abc -D 1250 -liberty $LIBDIR/sky130_fd_sc_hd.lib
 splitnets
 opt_clean -purge
 hilomap -hicell sky130_fd_sc_hd__conb_1 HI -locell sky130_fd_sc_hd__conb_1 LO
@@ -21,7 +23,6 @@ opt_clean -purge
 insbuf -buf sky130_fd_sc_hd__buf_2 A X
 dffinit
 flatten
-opt;; 
+opt;;
 #check
-write_verilog -noattr -noexpr -nohex -nodec -defparam clockgated_regfile.v
-            
+write_verilog -noattr -noexpr -nohex -nodec -defparam [test_output_path "clockgated_regfile.v"]

--- a/systemverilog-plugin/tests/break_continue/break_continue.tcl
+++ b/systemverilog-plugin/tests/break_continue/break_continue.tcl
@@ -10,4 +10,4 @@ if { [info exists ::env(TMPDIR) ] } {
 # Testing simple round-trip
 read_systemverilog -o $TMP_DIR/break-continue-test $::env(DESIGN_TOP).v
 prep
-write_table $::env(DESIGN_TOP).out
+write_table [test_output_path $::env(DESIGN_TOP).out]

--- a/systemverilog-plugin/tests/defaults/defaults.tcl
+++ b/systemverilog-plugin/tests/defaults/defaults.tcl
@@ -12,12 +12,12 @@ systemverilog_defaults -add -DPAKALA
 # Stash it
 systemverilog_defaults -push
 systemverilog_defaults -clear
-read_systemverilog $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR/defaults-test $::env(DESIGN_TOP).v
 # Allow parsing the module again
 delete top
 systemverilog_defaults -pop
 # Skip check for forbidden value
 systemverilog_defaults -add -Pbypass=1
-read_systemverilog $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR/defaults-test $::env(DESIGN_TOP).v
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/defines/defines.tcl
+++ b/systemverilog-plugin/tests/defines/defines.tcl
@@ -10,6 +10,6 @@ if { [info exists ::env(TMPDIR) ] } {
 systemverilog_defines -DPONA
 systemverilog_defines -DPAKALA
 systemverilog_defines -UPAKALA
-read_systemverilog $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR/defines-test $::env(DESIGN_TOP).v
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/formal/formal.tcl
+++ b/systemverilog-plugin/tests/formal/formal.tcl
@@ -7,6 +7,6 @@ if { [info exists ::env(TMPDIR) ] } {
   set TMP_DIR $::env(TMPDIR)
 }
 
-read_systemverilog -formal $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR/formal-test -formal $::env(DESIGN_TOP).v
 hierarchy
 write_verilog

--- a/test-utils/test-utils.tcl
+++ b/test-utils/test-utils.tcl
@@ -3,5 +3,6 @@
 # Return path where the test output file "filename"
 # is to be written.
 proc test_output_path { filename } {
+    file mkdir [file dirname "$::env(TEST_OUTPUT_PREFIX)${filename}"]
     return "$::env(TEST_OUTPUT_PREFIX)${filename}"
 }


### PR DESCRIPTION
Making sure the inputs are typically relative to env(DESIGN_TOP) and the outputs are written to what [test_output_path] returns. That way, we can build things in a read-only environment with only a temporary location writable.