### PR TITLE
systemverilog-plugin: Enable non-synthesizable code removal in Surelog.

### DIFF
--- a/systemverilog-plugin/tests/Makefile
+++ b/systemverilog-plugin/tests/Makefile
@@ -21,7 +21,8 @@ TESTS = counter \
 		report-flag \
 		defines \
 		defaults \
-		formal
+		formal \
+		translate_off
 
 include $(shell pwd)/../../Makefile_test.common
 
@@ -33,3 +34,4 @@ report-flag_verify = true
 defaults_verify = true
 defines_verify = true
 formal_verify = true
+translate_off_verify = true

--- a/systemverilog-plugin/tests/translate_off/translate_off.tcl
+++ b/systemverilog-plugin/tests/translate_off/translate_off.tcl
@@ -1,0 +1,10 @@
+yosys -import
+if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
+yosys -import  ;# ingest plugin commands
+
+set TMP_DIR /tmp
+if { [info exists ::env(TMPDIR) ] } {
+  set TMP_DIR $::env(TMPDIR)
+}
+
+read_systemverilog -o $TMP_DIR/translate_off-test $::env(DESIGN_TOP).v

--- a/systemverilog-plugin/tests/translate_off/translate_off.v
+++ b/systemverilog-plugin/tests/translate_off/translate_off.v
@@ -1,0 +1,22 @@
+// Copyright 2020-2023 F4PGA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module top(input i, output o);
+    // synopsys translate_off
+    initial $stop("Code between translate_off...translate_on should be ignored.");
+    // synopsys translate_on
+    assign o = i;
+endmodule

--- a/systemverilog-plugin/uhdmsurelogastfrontend.cc
+++ b/systemverilog-plugin/uhdmsurelogastfrontend.cc
@@ -172,6 +172,7 @@ struct UhdmSurelogAstFrontend : public UhdmCommonFrontend {
         clp->setParse(true);
         clp->fullSVMode(true);
         clp->setCacheAllowed(true);
+        clp->setReportNonSynthesizable(true);
         if (this->shared.defer) {
             clp->setCompile(false);
             clp->setElaborate(false);


### PR DESCRIPTION
Always activate `-synth` option in Surelog, which makes it ignore code between `// synopsys translate_off` and `// synopsys translate_on` (and a few other similar comments).

yosys-systemverilog: https://github.com/antmicro/yosys-systemverilog/actions/runs/4959300348