### PR TITLE
systemverilog-plugin: add support for multiple variables declared in anonymous enum var

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2488,11 +2488,11 @@ void UhdmAst::process_enum_typespec()
 
     if (current_node->str.empty()) {
         // anonymous typespec, check if not already created
-        if (shared.anonymous_enums.find(enum_object) != shared.anonymous_enums.end()) {
+        if (const auto enum_iter = shared.anonymous_enums.find(enum_object); enum_iter != shared.anonymous_enums.end()) {
             // we already created typedef for this.
             delete current_node;
-            current_node = new AST::AstNode(AST::AST_WIRETYPE);
-            current_node->str = shared.anonymous_enums[enum_object];
+            current_node = make_node(AST::AST_WIRETYPE);
+            current_node->str = enum_iter->second;
             return;
         }
     }
@@ -2592,9 +2592,9 @@ void UhdmAst::process_enum_typespec()
         auto current_scope = find_ancestor({AST::AST_PACKAGE, AST::AST_MODULE, AST::AST_BLOCK, AST::AST_GENBLOCK});
         uhdmast_assert(current_scope != nullptr);
         move_type_to_new_typedef(current_scope, current_node);
-        current_node = new AST::AstNode(AST::AST_WIRETYPE);
+        current_node = make_node(AST::AST_WIRETYPE);
         current_node->str = typedef_name;
-        shared.anonymous_enums[enum_object] = typedef_name;
+        shared.anonymous_enums[enum_object] = std::move(typedef_name);
     }
 }
 

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2486,6 +2486,17 @@ void UhdmAst::process_enum_typespec()
     const auto *enum_object = (const UHDM::enum_typespec *)handle->object;
     const auto *typespec = enum_object->Base_typespec();
 
+    if (current_node->str.empty()) {
+        // anonymous typespec, check if not already created
+        if (shared.anonymous_enums.find(enum_object) != shared.anonymous_enums.end()) {
+            // we already created typedef for this.
+            delete current_node;
+            current_node = new AST::AstNode(AST::AST_WIRETYPE);
+            current_node->str = shared.anonymous_enums[enum_object];
+            return;
+        }
+    }
+
     if (typespec && typespec->UhdmType() == UHDM::uhdmlogic_typespec) {
         // If it's a logic_typespec, try to reduce expressions inside of it.
         // The `reduceExpr` function needs the whole context of the enum typespec
@@ -2573,6 +2584,17 @@ void UhdmAst::process_enum_typespec()
     });
     if (range) {
         delete range;
+    }
+    if (current_node->str.empty()) {
+        // anonymous typespec
+        std::string typedef_name = "$systemverilog_plugin$anonymous_enum" + std::to_string(shared.next_anonymous_enum_typedef_id());
+        current_node->str = typedef_name;
+        auto current_scope = find_ancestor({AST::AST_PACKAGE, AST::AST_MODULE, AST::AST_BLOCK, AST::AST_GENBLOCK});
+        uhdmast_assert(current_scope != nullptr);
+        move_type_to_new_typedef(current_scope, current_node);
+        current_node = new AST::AstNode(AST::AST_WIRETYPE);
+        current_node->str = typedef_name;
+        shared.anonymous_enums[enum_object] = typedef_name;
     }
 }
 

--- a/systemverilog-plugin/uhdmastshared.h
+++ b/systemverilog-plugin/uhdmastshared.h
@@ -25,6 +25,9 @@ class UhdmAstShared
     // Used for generating unique names for anonymous types used as parameters.
     unsigned anonymous_type_count = 0;
 
+    // Used to generate unique names for anonymous enum typedefs
+    unsigned anonymous_enum_typedef_count = 0;
+
   public:
     ~UhdmAstShared()
     {
@@ -44,6 +47,9 @@ class UhdmAstShared
 
     // Generate the next anonymous type ID (starting with 0).
     unsigned next_anonymous_type_id() { return anonymous_type_count++; }
+
+    // Generate the next anonymous enum typedef ID (starting with 0).
+    unsigned next_anonymous_enum_typedef_id() { return anonymous_enum_typedef_count++; }
 
     // Flag that determines whether debug info should be printed
     bool debug_flag = false;
@@ -81,8 +87,12 @@ class UhdmAstShared
     std::unordered_map<std::string, ::Yosys::AST::AstNode *> param_types;
 
     ::Yosys::AST::AstNode *current_top_node = nullptr;
+
     // Set of non-synthesizable objects to skip in current design;
     std::set<const UHDM::BaseClass *> nonSynthesizableObjects;
+
+    // Map of anonymous enum types to generated typedefs
+    std::unordered_map<const UHDM::enum_typespec *, std::string> anonymous_enums;
 };
 
 } // namespace systemverilog_plugin


### PR DESCRIPTION
This PR adds support for multiple variable declarations in anonymous enum definition.

UHDM-integration-tests: https://github.com/chipsalliance/UHDM-integration-tests/pull/733
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/4936906195