### PR TITLE
Process vpiArrayTypespec the same way as vpiPackedArrayTypespec

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -2396,6 +2396,7 @@ void UhdmAst::process_typespec_member()
         break;
     }
     case vpiPackedArrayTypespec:
+    case vpiArrayTypespec:
         visit_one_to_one({vpiTypespec}, obj_h, [&](AST::AstNode *node) {
             if (node && node->type == AST::AST_STRUCT) {
                 auto str = current_node->str;


### PR DESCRIPTION
Previously the was no case for `vpiArrayTypespec` in `process_typespec_member`.

CI run here: https://github.com/antmicro/yosys-systemverilog/actions/runs/4958803078