### PR TITLE
systemverilog-plugin: Remove temporary test files.

### DIFF
--- a/systemverilog-plugin/tests/Makefile
+++ b/systemverilog-plugin/tests/Makefile
@@ -35,3 +35,9 @@ defaults_verify = true
 defines_verify = true
 formal_verify = true
 translate_off_verify = true
+
+.PHONY: systemverilog_tests_clean
+systemverilog_tests_clean:
+	@rm -rf $(foreach test,$(TESTS),$(test)/tmp)
+
+clean: systemverilog_tests_clean

--- a/systemverilog-plugin/tests/break_continue/break_continue.tcl
+++ b/systemverilog-plugin/tests/break_continue/break_continue.tcl
@@ -2,12 +2,10 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 # Testing simple round-trip
-read_systemverilog -o $TMP_DIR/break-continue-test $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR $::env(DESIGN_TOP).v
 prep
 write_table [test_output_path $::env(DESIGN_TOP).out]

--- a/systemverilog-plugin/tests/counter/counter.tcl
+++ b/systemverilog-plugin/tests/counter/counter.tcl
@@ -2,11 +2,9 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 # Testing simple round-trip
-read_systemverilog -o $TMP_DIR/counter-test $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR $::env(DESIGN_TOP).v
 write_verilog

--- a/systemverilog-plugin/tests/debug-flag/debug-flag.tcl
+++ b/systemverilog-plugin/tests/debug-flag/debug-flag.tcl
@@ -2,15 +2,13 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 # Testing simple round-trip
-read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -defer $::env(DESIGN_TOP)-pkg.sv
-read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -defer $::env(DESIGN_TOP)-buf.sv
-read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -defer $::env(DESIGN_TOP).v
-read_systemverilog -debug -odir $TMP_DIR/debug-flag-test -link
+read_systemverilog -debug -odir $TMP_DIR -defer $::env(DESIGN_TOP)-pkg.sv
+read_systemverilog -debug -odir $TMP_DIR -defer $::env(DESIGN_TOP)-buf.sv
+read_systemverilog -debug -odir $TMP_DIR -defer $::env(DESIGN_TOP).v
+read_systemverilog -debug -odir $TMP_DIR -link
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/defaults/defaults.tcl
+++ b/systemverilog-plugin/tests/defaults/defaults.tcl
@@ -2,22 +2,20 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 # Define forbidden value
 systemverilog_defaults -add -DPAKALA
 # Stash it
 systemverilog_defaults -push
 systemverilog_defaults -clear
-read_systemverilog -o $TMP_DIR/defaults-test $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR $::env(DESIGN_TOP).v
 # Allow parsing the module again
 delete top
 systemverilog_defaults -pop
 # Skip check for forbidden value
 systemverilog_defaults -add -Pbypass=1
-read_systemverilog -o $TMP_DIR/defaults-test $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR $::env(DESIGN_TOP).v
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/defines/defines.tcl
+++ b/systemverilog-plugin/tests/defines/defines.tcl
@@ -2,14 +2,12 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 systemverilog_defines -DPONA
 systemverilog_defines -DPAKALA
 systemverilog_defines -UPAKALA
-read_systemverilog -o $TMP_DIR/defines-test $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR $::env(DESIGN_TOP).v
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/formal/formal.tcl
+++ b/systemverilog-plugin/tests/formal/formal.tcl
@@ -2,11 +2,9 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
-read_systemverilog -o $TMP_DIR/formal-test -formal $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR -formal $::env(DESIGN_TOP).v
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/report-flag/report-flag.tcl
+++ b/systemverilog-plugin/tests/report-flag/report-flag.tcl
@@ -2,15 +2,13 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 # Testing simple round-trip
-read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -defer $::env(DESIGN_TOP)-pkg.sv
-read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -defer $::env(DESIGN_TOP)-buf.sv
-read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -defer $::env(DESIGN_TOP).v
-read_systemverilog -report $TMP_DIR/report-flag-test -odir $TMP_DIR/report-flag-test -link
+read_systemverilog -report $TMP_DIR -odir $TMP_DIR -defer $::env(DESIGN_TOP)-pkg.sv
+read_systemverilog -report $TMP_DIR -odir $TMP_DIR -defer $::env(DESIGN_TOP)-buf.sv
+read_systemverilog -report $TMP_DIR -odir $TMP_DIR -defer $::env(DESIGN_TOP).v
+read_systemverilog -report $TMP_DIR -odir $TMP_DIR -link
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/separate-compilation/separate-compilation.tcl
+++ b/systemverilog-plugin/tests/separate-compilation/separate-compilation.tcl
@@ -2,15 +2,13 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
 # Testing simple round-trip
-read_systemverilog -odir $TMP_DIR/separate-compilation-test -defer $::env(DESIGN_TOP)-pkg.sv
-read_systemverilog -odir $TMP_DIR/separate-compilation-test -defer $::env(DESIGN_TOP)-buf.sv
-read_systemverilog -odir $TMP_DIR/separate-compilation-test -defer $::env(DESIGN_TOP).v
-read_systemverilog -odir $TMP_DIR/separate-compilation-test -link
+read_systemverilog -odir $TMP_DIR -defer $::env(DESIGN_TOP)-pkg.sv
+read_systemverilog -odir $TMP_DIR -defer $::env(DESIGN_TOP)-buf.sv
+read_systemverilog -odir $TMP_DIR -defer $::env(DESIGN_TOP).v
+read_systemverilog -odir $TMP_DIR -link
 hierarchy
 write_verilog

--- a/systemverilog-plugin/tests/translate_off/translate_off.tcl
+++ b/systemverilog-plugin/tests/translate_off/translate_off.tcl
@@ -2,9 +2,7 @@ yosys -import
 if { [info procs read_uhdm] == {} } { plugin -i systemverilog }
 yosys -import  ;# ingest plugin commands
 
-set TMP_DIR /tmp
-if { [info exists ::env(TMPDIR) ] } {
-  set TMP_DIR $::env(TMPDIR)
-}
+set TMP_DIR ::env(TEST_OUTPUT_PREFIX)/tmp
+file mkdir $TMP_DIR
 
-read_systemverilog -o $TMP_DIR/translate_off-test $::env(DESIGN_TOP).v
+read_systemverilog -o $TMP_DIR $::env(DESIGN_TOP).v


### PR DESCRIPTION
When running tests locally I had an issue where the tests were unexpectedly failing. This has been caused by Surelog temporary files stored in /tmp during previous tests (probably from totally different revisions).
This patch changes temporary directory to a `tmp` subdirectory in the test directory, and extends `clean` target with a command that removes them.

yosys-systemverilog workflow: https://github.com/antmicro/yosys-systemverilog/actions/runs/4981917441