### PR TITLE
systemverilog-plugin: split line and column in uhdmast_assert_log

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -729,7 +729,7 @@ void UhdmAst::uhdmast_assert_log(const char *expr_str, const char *func, const c
         int svcolumn = vpi_get(vpiColumnNo, obj_h);
         std::string obj_type_name = UHDM::VpiTypeName(obj_h);
         const char *obj_name = vpi_get_str(vpiName, obj_h);
-        std::cerr << svfile << ':' << svline << svcolumn << ": note: When processing object of type '" << obj_type_name << '\'';
+        std::cerr << svfile << ':' << svline << ':' << svcolumn << ": note: When processing object of type '" << obj_type_name << '\'';
         if (obj_name && obj_name[0] != '\0') {
             std::cerr << " named '" << obj_name << '\'';
         }


### PR DESCRIPTION
This PR splits line and column in reported error:
currently:
```
top.sv:1215: note: When processing object of type 'operation'.
```
after this PR:
```
top.sv:12:15: note: When processing object of type 'operation'.
```