### PR TITLE
duplicated ranges

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -309,52 +309,58 @@ static void add_multirange_wire(AST::AstNode *node, std::vector<AST::AstNode *> 
     }
 }
 
-static size_t add_multirange_attribute(AST::AstNode *wire_node, const std::vector<AST::AstNode *> ranges)
+// Sets the `wire_node->multirange_dimensions` attribute and returns the total sizes of packed and unpacked ranges.
+static std::pair<size_t, size_t> set_multirange_dimensions(AST::AstNode *wire_node, const std::vector<AST::AstNode *> packed_ranges,
+                                                           const std::vector<AST::AstNode *> unpacked_ranges)
 {
     // node->multirange_dimensions stores dimensions' offsets and widths.
     // It shall have even number of elements.
     // For a range of [A:B] it should be appended with {min(A,B)} and {max(A,B)-min(A,B)+1}
     // For a range of [A] it should be appended with {0} and {A}
 
-    size_t size = 1;
-    for (size_t i = 0; i < ranges.size(); i++) {
-        log_assert(AST_INTERNAL::current_ast_mod);
-        simplify_sv(ranges[i], wire_node);
-        // If it's a range of [A], make it [A:A].
-        if (ranges[i]->children.size() == 1) {
-            ranges[i]->children.push_back(ranges[i]->children[0]->clone());
-        }
-        while (simplify(ranges[i], true, false, false, 1, -1, false, false)) {
-        }
-        // this workaround case, where yosys doesn't follow id2ast and simplifies it to resolve constant
-        if (ranges[i]->children[0]->id2ast) {
-            simplify_sv(ranges[i]->children[0]->id2ast, ranges[i]->children[0]);
-            while (simplify(ranges[i]->children[0]->id2ast, true, false, false, 1, -1, false, false)) {
+    auto calc_range_size = [wire_node](const std::vector<AST::AstNode *> &ranges) -> size_t {
+        size_t size = 1;
+        for (size_t i = 0; i < ranges.size(); i++) {
+            log_assert(AST_INTERNAL::current_ast_mod);
+            simplify_sv(ranges[i], wire_node);
+            // If it's a range of [A], make it [A:A].
+            if (ranges[i]->children.size() == 1) {
+                ranges[i]->children.push_back(ranges[i]->children[0]->clone());
             }
-        }
-        if (ranges[i]->children[1]->id2ast) {
-            simplify_sv(ranges[i]->children[1]->id2ast, ranges[i]->children[1]);
-            while (simplify(ranges[i]->children[1]->id2ast, true, false, false, 1, -1, false, false)) {
+            while (simplify(ranges[i], true, false, false, 1, -1, false, false)) {
             }
-        }
-        simplify_sv(ranges[i], wire_node);
-        while (simplify(ranges[i], true, false, false, 1, -1, false, false)) {
-        }
-        log_assert(ranges[i]->children[0]->type == AST::AST_CONSTANT);
-        log_assert(ranges[i]->children[1]->type == AST::AST_CONSTANT);
+            // this workaround case, where yosys doesn't follow id2ast and simplifies it to resolve constant
+            if (ranges[i]->children[0]->id2ast) {
+                simplify_sv(ranges[i]->children[0]->id2ast, ranges[i]->children[0]);
+                while (simplify(ranges[i]->children[0]->id2ast, true, false, false, 1, -1, false, false)) {
+                }
+            }
+            if (ranges[i]->children[1]->id2ast) {
+                simplify_sv(ranges[i]->children[1]->id2ast, ranges[i]->children[1]);
+                while (simplify(ranges[i]->children[1]->id2ast, true, false, false, 1, -1, false, false)) {
+                }
+            }
+            simplify_sv(ranges[i], wire_node);
+            while (simplify(ranges[i], true, false, false, 1, -1, false, false)) {
+            }
+            log_assert(ranges[i]->children[0]->type == AST::AST_CONSTANT);
+            log_assert(ranges[i]->children[1]->type == AST::AST_CONSTANT);
 
-        const auto low = min(ranges[i]->children[0]->integer, ranges[i]->children[1]->integer);
-        const auto high = max(ranges[i]->children[0]->integer, ranges[i]->children[1]->integer);
-        const auto elem_size = high - low + 1;
+            const auto low = min(ranges[i]->children[0]->integer, ranges[i]->children[1]->integer);
+            const auto high = max(ranges[i]->children[0]->integer, ranges[i]->children[1]->integer);
+            const auto elem_size = high - low + 1;
 
-        wire_node->multirange_dimensions.push_back(low);
-        wire_node->multirange_dimensions.push_back(elem_size);
-        wire_node->multirange_swapped.push_back(ranges[i]->range_swapped);
-        size *= elem_size;
-    }
+            wire_node->multirange_dimensions.push_back(low);
+            wire_node->multirange_dimensions.push_back(elem_size);
+            wire_node->multirange_swapped.push_back(ranges[i]->range_swapped);
+            size *= elem_size;
+        }
+        return size;
+    };
+    size_t packed_size = calc_range_size(packed_ranges);
+    size_t unpacked_size = calc_range_size(unpacked_ranges);
     log_assert(wire_node->multirange_dimensions.size() % 2 == 0);
-
-    return size;
+    return {packed_size, unpacked_size};
 }
 
 static AST::AstNode *convert_range(AST::AstNode *id, int packed_ranges_size, int unpacked_ranges_size, int i)
@@ -670,8 +676,7 @@ static void convert_packed_unpacked_range(AST::AstNode *wire_node)
     if (convert_node) {
         // if not already converted
         if (wire_node->multirange_dimensions.empty()) {
-            const size_t packed_size = add_multirange_attribute(wire_node, packed_ranges);
-            const size_t unpacked_size = add_multirange_attribute(wire_node, unpacked_ranges);
+            const auto [packed_size, unpacked_size] = set_multirange_dimensions(wire_node, packed_ranges, unpacked_ranges);
             if (packed_ranges.size() == 1 && unpacked_ranges.empty()) {
                 ranges.push_back(packed_ranges[0]->clone());
             } else if (unpacked_ranges.size() == 1 && packed_ranges.empty()) {

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4768,8 +4768,6 @@ void UhdmAst::process_port()
 void UhdmAst::process_net()
 {
     current_node = make_ast_node(AST::AST_WIRE);
-    std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
-    std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
     auto net_type = vpi_get(vpiNetType, obj_h);
     current_node->is_reg = net_type == vpiReg;
     current_node->is_output = net_type == vpiOutput;
@@ -4782,14 +4780,13 @@ void UhdmAst::process_net()
             // wiretype needs to be 1st node
             current_node->children.insert(current_node->children.begin(), wiretype_node);
             current_node->is_custom_type = true;
+        } else {
+            // Ranges from the typespec are copied to the current node as attributes.
+            // So that multiranges can be replaced with a single range as a node later.
+            copy_packed_unpacked_attribute(node, current_node);
         }
         delete node;
     });
-    if (vpiHandle typespec_h = vpi_handle(vpiTypespec, obj_h)) {
-        visit_one_to_many({vpiRange}, typespec_h, [&](AST::AstNode *node) { packed_ranges.push_back(node); });
-        vpi_release_handle(typespec_h);
-    }
-    add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
 }
 
 void UhdmAst::process_parameter()

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -319,10 +319,11 @@ static size_t add_multirange_attribute(AST::AstNode *wire_node, const std::vecto
     size_t size = 1;
     for (size_t i = 0; i < ranges.size(); i++) {
         log_assert(AST_INTERNAL::current_ast_mod);
+        simplify_sv(ranges[i], wire_node);
+        // If it's a range of [A], make it [A:A].
         if (ranges[i]->children.size() == 1) {
             ranges[i]->children.push_back(ranges[i]->children[0]->clone());
         }
-        simplify_sv(ranges[i], wire_node);
         while (simplify(ranges[i], true, false, false, 1, -1, false, false)) {
         }
         // this workaround case, where yosys doesn't follow id2ast and simplifies it to resolve constant

--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4774,7 +4774,9 @@ void UhdmAst::process_net()
     current_node->is_logic = !current_node->is_reg;
     current_node->is_signed = vpi_get(vpiSigned, obj_h);
     visit_one_to_one({vpiTypespec}, obj_h, [&](AST::AstNode *node) {
-        if (node && !node->str.empty()) {
+        if (!node)
+            return;
+        if (!node->str.empty()) {
             auto wiretype_node = new AST::AstNode(AST::AST_WIRETYPE);
             wiretype_node->str = node->str;
             // wiretype needs to be 1st node


### PR DESCRIPTION
1. This refactors `add_multirange_attribute` function.
* The purpose of the function is to put data about multiranges in `node->multirange_dimensions` vector, and as it doesn't do anything related to `node->attributes`, the name could be considered misleading. I'm renaming it to `set_multirange_dimensions` and will be happy to consider other options, too.
* There was a node duplicated and then both nodes were simplified. Now it's duplicated after simplification.
* Ideally, the function should be called only once for each node. The function will now use both `packed_ranges` and `unpacked_ranges` in a single call, so that it's easier to forbid multiple calls of the function later on. 
2. The `process_net` function has a bug which causes ranges to be duplicated. With the current solution, the same range is added to a node here: https://github.com/chipsalliance/yosys-f4pga-plugins/blob/main/systemverilog-plugin/UhdmAst.cc#L501 and here: https://github.com/chipsalliance/yosys-f4pga-plugins/blob/main/systemverilog-plugin/UhdmAst.cc#L542
The solution is that during the part when `process_*` functions are executed, we should store information about the ranges in attributes, and later on in the simplification process replace the attributes with children nodes.

Input:
```
typedef logic [3:0][7:0] my_struct_packed_t;
module single_range_dot_access (
    input  my_struct_packed_t x,
    output my_struct_packed_t y
);
   assign y[2][1] = x[0][0];
endmodule : single_range_dot_access
```


Result without the changes:
```
    module single_range_dot_access(x, y);
      (* wiretype = "\my_struct_packed_t" *)
      input [1023:0] x;
      (* wiretype = "\my_struct_packed_t" *)
      output [1023:0] y;
      assign y[319:288] = x[31:0];
      /** AST_TYPEDEF **/
    endmodule
```

Result with the changes and Surelog `654c4fe230` and `7689edf1`:
```
module single_range_dot_access(x, y);
  (* wiretype = "\my_struct_packed_t" *)
  input [31:0] x;
  (* wiretype = "\my_struct_packed_t" *)
  output [31:0] y;
  assign y[9:9] = x[0:0];
  /** AST_TYPEDEF **/
endmodule
```

The size of the input/output wires is fixed.
With the current Surelog (`bf13c83`) it doesn't appear to break anything, and also fixes one FV test.

CI with the changes:
https://github.com/antmicro/yosys-systemverilog/actions/runs/5309555386
https://github.com/antmicro/yosys-systemverilog/actions/runs/5290316276