### PR TITLE
systemverilog-plugin: fix anonymous enum when declared in submodules

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -69,6 +69,8 @@ static IdString is_type_parameter;
 /*static*/ const IdString &UhdmAst::is_simplified_wire() { return attr_id::is_simplified_wire; }
 /*static*/ const IdString &UhdmAst::low_high_bound() { return attr_id::low_high_bound; }
 
+#define MAKE_INTERNAL_ID(X) IdString("$systemverilog_plugin$" #X)
+
 void attr_id_init()
 {
     // Initialize only once
@@ -80,14 +82,14 @@ void attr_id_init()
 
     // Register IdStrings. Can't be done statically, as the IdString class uses resources created during Yosys initialization which happens after
     // static initialization of the plugin when everything is statically linked.
-    attr_id::partial = IdString("$systemverilog_plugin$partial");
-    attr_id::packed_ranges = IdString("$systemverilog_plugin$packed_ranges");
-    attr_id::unpacked_ranges = IdString("$systemverilog_plugin$unpacked_ranges");
-    attr_id::force_convert = IdString("$systemverilog_plugin$force_convert");
-    attr_id::is_imported = IdString("$systemverilog_plugin$is_imported");
-    attr_id::is_simplified_wire = IdString("$systemverilog_plugin$is_simplified_wire");
-    attr_id::low_high_bound = IdString("$systemverilog_plugin$low_high_bound");
-    attr_id::is_type_parameter = IdString("$systemverilog_plugin$is_type_parameter");
+    attr_id::partial = MAKE_INTERNAL_ID(partial);
+    attr_id::packed_ranges = MAKE_INTERNAL_ID(packed_ranges);
+    attr_id::unpacked_ranges = MAKE_INTERNAL_ID(unpacked_ranges);
+    attr_id::force_convert = MAKE_INTERNAL_ID(force_convert);
+    attr_id::is_imported = MAKE_INTERNAL_ID(is_imported);
+    attr_id::is_simplified_wire = MAKE_INTERNAL_ID(is_simplified_wire);
+    attr_id::low_high_bound = MAKE_INTERNAL_ID(low_high_bound);
+    attr_id::is_type_parameter = MAKE_INTERNAL_ID(is_type_parameter);
 }
 
 void attr_id_cleanup()

--- a/systemverilog-plugin/UhdmAst.h
+++ b/systemverilog-plugin/UhdmAst.h
@@ -201,6 +201,7 @@ class UhdmAst
     static const ::Yosys::IdString &is_imported();
     static const ::Yosys::IdString &is_simplified_wire();
     static const ::Yosys::IdString &low_high_bound();
+    static const ::Yosys::IdString &is_elaborated_module();
 };
 
 // Utility for building AstNode trees.


### PR DESCRIPTION
This PR fixes anonymous enums when they are declared in submodule and this submodule is used multiple times with the same parameters.

UHDM-integration-test: https://github.com/chipsalliance/UHDM-integration-tests/pull/739
yosys-systemverilog run: https://github.com/antmicro/yosys-systemverilog/actions/runs/5130641235

All unexpected failures in yosys-systemverilog run:
```
yosys:asicworld/code_hdl_models_GrayCounter.v
yosys:simple/always03.v
yosys:simple/sincos.v
yosys:asicworld/code_verilog_tutorial_fsm_full.v
yosys:simple/operators.v
```
are due to additional IdString and different optimizations applied to netlist. I've checked that AST for this tests are identical as before this PR.