### PR TITLE
Fix hier path processing

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4288,8 +4288,7 @@ void UhdmAst::process_hier_path()
                 top_node = current_node;
                 delete node;
             } else {
-                if (node->str.empty()) {
-                    log_assert(!node->children.empty());
+                if (!node->children.empty() && node->children[0]->type == AST::AST_RANGE && (node->str == "\\" || node->str.empty())) {
                     top_node->children.push_back(node->children[0]);
                     node->children.erase(node->children.begin());
                     delete node;


### PR DESCRIPTION
Recently, the naming of objects in `hier_path` has changed in Surelog.
See https://github.com/chipsalliance/Surelog/issues/3691.
Here's a CI run with bumped Surelog (`7689edf`), where `MemberSelectOf2DStructPackedArray` and other tests fail:
https://github.com/antmicro/yosys-systemverilog/actions/runs/5197447471

These changes fix the tests, see the CI with newer Surelog and the changes:
https://github.com/antmicro/yosys-systemverilog/actions/runs/5199424709

And also with the current Surelog submodule, the changes don't break anything, CI:
https://github.com/antmicro/yosys-systemverilog/actions/runs/5199420625