### PR TITLE
Allows Union Types in Parameter Fields

### DIFF
--- a/systemverilog-plugin/UhdmAst.cc
+++ b/systemverilog-plugin/UhdmAst.cc
@@ -4835,6 +4835,7 @@ void UhdmAst::process_parameter()
             shared.report.mark_handled(typespec_h);
             break;
         }
+        case vpiUnionTypespec:
         case vpiStructTypespec: {
             visit_one_to_one({vpiTypespec}, obj_h, [&](AST::AstNode *node) {
                 if (node && !node->str.empty()) {


### PR DESCRIPTION
If a union type was referenced as a parameter this would fail.