### PR TITLE
Undef a macro that clashes with a UHDM class.

### DIFF
--- a/systemverilog-plugin/uhdmastshared.h
+++ b/systemverilog-plugin/uhdmastshared.h
@@ -3,6 +3,10 @@
 
 #include "frontends/ast/ast.h"
 
+// Yosys defines a 'cover' macro in implicitly included kernel/log.h
+// that clashes with cover-class in UHDM
+#undef cover
+
 #include <string>
 #include <uhdm/uhdm.h>
 #include <uhdm/vpi_user.h>


### PR DESCRIPTION
The class `cover` in UHDM will not compile well if the `cover` macro from yosys kernel/log.h is defined. Undef it.