### PR TITLE
Rename synth_quicklogic to synth_quicklogic_f4pga to not conflict with yosys builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The plugin adds the following command:
 
 The plugin adds the following command:
 
-* synth_quicklogic
+* synth_quicklogic_f4pga
 * ql_dsp
 
 Detailed help on the supported command(s) can be obtained by running `help <command_name>` in Yosys.

--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -108,6 +108,6 @@ $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-read.h: ql-bram-asymmetric-wider-read.
 	python3 $(PMGEN_PY) -o $@ -p ql_bram_asymmetric_wider_read ql-bram-asymmetric-wider-read.pmg
 
 install_modules: $(VERILOG_MODULES)
-	$(foreach f,$^,install -D $(f) $(YOSYS_DATA_DIR)/quicklogic/$(f);)
+	$(foreach f,$^,install -D $(f) $(YOSYS_DATA_DIR)/quicklogic_f4pga/$(f);)
 
 install: install_modules

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -28,7 +28,7 @@ PRIVATE_NAMESPACE_BEGIN
 #define STR(val) XSTR(val)
 
 #ifndef PASS_NAME
-#define PASS_NAME synth_quicklogic
+#define PASS_NAME synth_quicklogic_f4pga
 #endif
 
 struct SynthQuickLogicPass : public ScriptPass {
@@ -241,7 +241,7 @@ struct SynthQuickLogicPass : public ScriptPass {
     void script() override
     {
         if (check_label("begin")) {
-            std::string family_path = " +/quicklogic/" + family;
+            std::string family_path = " +/quicklogic_f4pga/" + family;
             std::string readVelArgs;
 
             // Read simulation library
@@ -254,7 +254,7 @@ struct SynthQuickLogicPass : public ScriptPass {
             // Use -nomem2reg here to prevent Yosys from complaining about
             // some block ram cell models. After all the only part of the cells
             // library required here is cell port definitions plus specify blocks.
-            run("read_verilog -lib -specify -nomem2reg +/quicklogic/common/cells_sim.v" + readVelArgs);
+            run("read_verilog -lib -specify -nomem2reg +/quicklogic_f4pga/common/cells_sim.v" + readVelArgs);
             run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
         }
 
@@ -291,7 +291,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                 if (help_mode || !nodsp) {
                     run("memory_dff");
                     run("wreduce t:$mul");
-                    run("techmap -map +/mul2dsp.v -map +/quicklogic/" + family +
+                    run("techmap -map +/mul2dsp.v -map +/quicklogic_f4pga/" + family +
                           "/dsp_map.v -D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=16 "
                           "-D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2 -D DSP_Y_MINWIDTH=11 "
                           "-D DSP_NAME=$__MUL16X16",
@@ -324,13 +324,13 @@ struct SynthQuickLogicPass : public ScriptPass {
                     run("ql_dsp_macc" + use_dsp_cfg_params, "(for qlf_k6n10f if not -no_dsp)");
                     run("techmap -map +/mul2dsp.v [...]", "  (for qlf_k6n10f if not -no_dsp)");
                     run("chtype -set $mul t:$__soft_mul", "  (for qlf_k6n10f if not -no_dsp)");
-                    run("techmap -map +/quicklogic/" + family + "/dsp_map.v", "(for qlf_k6n10f if not -no_dsp)");
+                    run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_map.v", "(for qlf_k6n10f if not -no_dsp)");
                     if (use_dsp_cfg_params.empty())
-                        run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0", "(for qlf_k6n10f if not -no_dsp)");
+                        run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0", "(for qlf_k6n10f if not -no_dsp)");
                     else
-                        run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1", "(for qlf_k6n10f if not -no_dsp)");
+                        run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1", "(for qlf_k6n10f if not -no_dsp)");
                     run("ql_dsp_simd                   ", "(for qlf_k6n10f if not -no_dsp)");
-                    run("techmap -map +/quicklogic/" + family + "/dsp_final_map.v", "(for qlf_k6n10f if not -no_dsp)");
+                    run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_final_map.v", "(for qlf_k6n10f if not -no_dsp)");
                     run("ql_dsp_io_regs");
                 } else if (!nodsp) {
 
@@ -346,11 +346,11 @@ struct SynthQuickLogicPass : public ScriptPass {
                         run("chtype -set $mul t:$__soft_mul");
                     }
                     if (use_dsp_cfg_params.empty())
-                        run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0");
+                        run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0");
                     else
-                        run("techmap -map +/quicklogic/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1");
+                        run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1");
                     run("ql_dsp_simd");
-                    run("techmap -map +/quicklogic/" + family + "/dsp_final_map.v");
+                    run("techmap -map +/quicklogic_f4pga/" + family + "/dsp_final_map.v");
                     run("ql_dsp_io_regs");
                 }
             }
@@ -370,14 +370,14 @@ struct SynthQuickLogicPass : public ScriptPass {
         }
 
         if (check_label("map_bram", "(skip if -no_bram)") && (family == "qlf_k6n10" || family == "qlf_k6n10f" || family == "pp3") && inferBram) {
-            run("memory_bram -rules +/quicklogic/" + family + "/brams.txt");
+            run("memory_bram -rules +/quicklogic_f4pga/" + family + "/brams.txt");
             if (family == "pp3") {
                 run("pp3_braminit");
             }
             run("ql_bram_split                   ", "(for qlf_k6n10f if not -no_bram)");
-            run("techmap -autoproc -map +/quicklogic/" + family + "/brams_map.v");
+            run("techmap -autoproc -map +/quicklogic_f4pga/" + family + "/brams_map.v");
             if (family == "qlf_k6n10f") {
-                run("techmap -map +/quicklogic/" + family + "/brams_final_map.v");
+                run("techmap -map +/quicklogic_f4pga/" + family + "/brams_final_map.v");
             }
 
             // Data width to specialized cell type width map
@@ -439,7 +439,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         if (check_label("map_gates")) {
             if (inferAdder && (family == "qlf_k4n8" || family == "qlf_k6n10" || family == "qlf_k6n10f")) {
-                run("techmap -map +/techmap.v -map +/quicklogic/" + family + "/arith_map.v");
+                run("techmap -map +/techmap.v -map +/quicklogic_f4pga/" + family + "/arith_map.v");
             } else {
                 run("techmap");
             }
@@ -476,9 +476,9 @@ struct SynthQuickLogicPass : public ScriptPass {
                 run("dfflegalize" + legalizeArgs);
             } else if (family == "pp3") {
                 run("dfflegalize -cell $_DFFSRE_PPPP_ 0 -cell $_DLATCH_?_ x");
-                run("techmap -map +/quicklogic/" + family + "/cells_map.v");
+                run("techmap -map +/quicklogic_f4pga/" + family + "/cells_map.v");
             }
-            std::string techMapArgs = " -map +/techmap.v -map +/quicklogic/" + family + "/ffs_map.v";
+            std::string techMapArgs = " -map +/techmap.v -map +/quicklogic_f4pga/" + family + "/ffs_map.v";
             if (!noffmap) {
                 run("techmap " + techMapArgs);
             }
@@ -497,14 +497,14 @@ struct SynthQuickLogicPass : public ScriptPass {
                 } else if (family == "qlf_k4n8") {
                     run("abc -lut 4 ");
                 } else if (family == "pp3") {
-                    run("techmap -map +/quicklogic/" + family + "/latches_map.v");
+                    run("techmap -map +/quicklogic_f4pga/" + family + "/latches_map.v");
                     if (abc9) {
-                        run("read_verilog -lib -specify -icells +/quicklogic/" + family + "/abc9_model.v");
-                        run("techmap -map +/quicklogic/" + family + "/abc9_map.v");
+                        run("read_verilog -lib -specify -icells +/quicklogic_f4pga/" + family + "/abc9_model.v");
+                        run("techmap -map +/quicklogic_f4pga/" + family + "/abc9_map.v");
                         run("abc9 -maxlut 4 -dff");
-                        run("techmap -map +/quicklogic/" + family + "/abc9_unmap.v");
+                        run("techmap -map +/quicklogic_f4pga/" + family + "/abc9_unmap.v");
                     } else {
-                        std::string lutDefs = "+/quicklogic/" + family + "/lutdefs.txt";
+                        std::string lutDefs = "+/quicklogic_f4pga/" + family + "/lutdefs.txt";
                         rewrite_filename(lutDefs);
 
                         std::string abcArgs = "+read_lut," + lutDefs +
@@ -523,7 +523,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 
         if (check_label("map_cells") && (family == "qlf_k6n10" || family == "pp3")) {
             std::string techMapArgs;
-            techMapArgs = "-map +/quicklogic/" + family + "/lut_map.v";
+            techMapArgs = "-map +/quicklogic_f4pga/" + family + "/lut_map.v";
             run("techmap " + techMapArgs);
             run("clean");
         }

--- a/ql-qlf-plugin/tests/consts/consts.tcl
+++ b/ql-qlf-plugin/tests/consts/consts.tcl
@@ -4,7 +4,7 @@ yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 
-synth_quicklogic -top my_top -family pp3
+synth_quicklogic_f4pga -top my_top -family pp3
 stat
 yosys cd my_top
 select -assert-count 1 t:my_lut

--- a/ql-qlf-plugin/tests/dffs/dffs.tcl
+++ b/ql-qlf-plugin/tests/dffs/dffs.tcl
@@ -11,8 +11,8 @@ design -save read
 # DFF
 hierarchy -top my_dff
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8 -top my_dff
-synth_quicklogic -family qlf_k4n8 -top my_dff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k4n8/cells_sim.v synth_quicklogic_f4pga -family qlf_k4n8 -top my_dff
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dff
 design -load postopt
 yosys cd my_dff
 stat
@@ -20,7 +20,7 @@ select -assert-count 1 t:dffsr
 
 # DFFR (posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffr_p
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffr_p
 yosys cd my_dffr_p
 stat
 select -assert-count 1 t:dffsr
@@ -28,7 +28,7 @@ select -assert-count 1 t:\$lut
 
 # DFFR (posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffr_p_2
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffr_p_2
 yosys cd my_dffr_p_2
 stat
 select -assert-count 2 t:dffsr
@@ -36,14 +36,14 @@ select -assert-count 1 t:\$lut
 
 # DFFR (negedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffr_n
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffr_n
 yosys cd my_dffr_n
 stat
 select -assert-count 1 t:dffsr
 
 # DFFS (posedge SET)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffs_p
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffs_p
 yosys cd my_dffs_p
 stat
 select -assert-count 1 t:dffsr
@@ -51,14 +51,14 @@ select -assert-count 1 t:\$lut
 
 # DFFS (negedge SET)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffs_n
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffs_n
 yosys cd my_dffs_n
 stat
 select -assert-count 1 t:dffsr
 
 # DFFN
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffn
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffn
 yosys cd my_dffn
 stat
 select -assert-count 1 t:dffnsr
@@ -66,7 +66,7 @@ select -assert-count 1 t:dffnsr
 
 # DFFNR (negedge CLK posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffnr_p
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffnr_p
 yosys cd my_dffnr_p
 stat
 select -assert-count 1 t:dffnsr
@@ -74,14 +74,14 @@ select -assert-count 1 t:\$lut
 
 # DFFNR (negedge CLK negedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffnr_n
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffnr_n
 yosys cd my_dffnr_n
 stat
 select -assert-count 1 t:dffnsr
 
 # DFFNS (negedge CLK posedge SET)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffns_p
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffns_p
 yosys cd my_dffns_p
 stat
 select -assert-count 1 t:dffnsr
@@ -89,14 +89,14 @@ select -assert-count 1 t:\$lut
 
 # DFFS (negedge CLK negedge SET)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffns_n
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffns_n
 yosys cd my_dffns_n
 stat
 select -assert-count 1 t:dffnsr
 
 # DFFSR (posedge CLK posedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_ppp
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_ppp
 yosys cd my_dffsr_ppp
 stat
 select -assert-count 1 t:dffsr
@@ -104,7 +104,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (posedge CLK negedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_pnp
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_pnp
 yosys cd my_dffsr_pnp
 stat
 select -assert-count 1 t:dffsr
@@ -112,7 +112,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (posedge CLK posedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_ppn
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_ppn
 yosys cd my_dffsr_ppn
 stat
 select -assert-count 1 t:dffsr
@@ -120,7 +120,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSR (posedge CLK negedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_pnn
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_pnn
 yosys cd my_dffsr_pnn
 stat
 select -assert-count 1 t:dffsr
@@ -128,7 +128,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSR (negedge CLK posedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_npp
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_npp
 yosys cd my_dffsr_npp
 stat
 select -assert-count 1 t:dffnsr
@@ -136,7 +136,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (negedge CLK negedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_nnp
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_nnp
 yosys cd my_dffsr_nnp
 stat
 select -assert-count 1 t:dffnsr
@@ -144,7 +144,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (negedge CLK posedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_npn
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_npn
 yosys cd my_dffsr_npn
 stat
 select -assert-count 1 t:dffnsr
@@ -152,7 +152,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSR (negedge CLK negedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k4n8 -top my_dffsr_nnn
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_dffsr_nnn
 yosys cd my_dffsr_nnn
 stat
 select -assert-count 1 t:dffnsr
@@ -169,7 +169,7 @@ design -save read
 # DFF
 hierarchy -top my_dff
 yosys proc
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10 -top my_dff
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10 -top my_dff
 design -load postopt
 yosys cd my_dff
 stat
@@ -177,21 +177,21 @@ select -assert-count 1 t:dff
 
 # DFFR (posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffr_p
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffr_p
 yosys cd my_dffr_p
 stat
 select -assert-count 1 t:dffr
 
 # DFFR (posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffr_p_2
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffr_p_2
 yosys cd my_dffr_p_2
 stat
 select -assert-count 2 t:dffr
 
 # DFFR (negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffr_n
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffr_n
 yosys cd my_dffr_n
 stat
 select -assert-count 1 t:dffr
@@ -199,14 +199,14 @@ select -assert-count 1 t:\$lut
 
 #DFFRE (posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffre_p
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffre_p
 yosys cd my_dffre_p
 stat
 select -assert-count 1 t:dffre
 
 #DFFRE (negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffre_n
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffre_n
 yosys cd my_dffre_n
 stat
 select -assert-count 1 t:dffre
@@ -214,14 +214,14 @@ select -assert-count 1 t:\$lut
 
 # DFFS (posedge SET)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffs_p
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffs_p
 yosys cd my_dffs_p
 stat
 select -assert-count 1 t:dffs
 
 # DFFS (negedge SET)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffs_n
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffs_n
 yosys cd my_dffs_n
 stat
 select -assert-count 1 t:dffs
@@ -229,21 +229,21 @@ select -assert-count 1 t:\$lut
 
 # DFFSE (posedge SET)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffse_p
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffse_p
 yosys cd my_dffse_p
 stat
 select -assert-count 1 t:dffse
 
 # DFFSE (negedge SET)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffse_n
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffse_n
 yosys cd my_dffse_n
 stat
 select -assert-count 1 t:dffse
 
 # DFFN
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffn
 yosys cd my_dffn
 stat
 select -assert-count 1 t:dff
@@ -251,7 +251,7 @@ select -assert-count 1 t:\$lut
 
 # DFFNR (negedge CLK posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffnr_p
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffnr_p
 yosys cd my_dffnr_p
 stat
 select -assert-count 1 t:dffr
@@ -259,7 +259,7 @@ select -assert-count 1 t:\$lut
 
 # DFFNR (negedge CLK negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffnr_n
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffnr_n
 yosys cd my_dffnr_n
 stat
 select -assert-count 1 t:dffr
@@ -267,7 +267,7 @@ select -assert-count 2 t:\$lut
 
 # DFFNS (negedge CLK posedge SET)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffns_p
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffns_p
 yosys cd my_dffns_p
 stat
 select -assert-count 1 t:dffs
@@ -275,7 +275,7 @@ select -assert-count 1 t:\$lut
 
 # DFFS (negedge CLK negedge SET)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffns_n
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffns_n
 yosys cd my_dffns_n
 stat
 select -assert-count 1 t:dffs
@@ -283,7 +283,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (posedge CLK posedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_ppp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_ppp
 yosys cd my_dffsr_ppp
 stat
 select -assert-count 1 t:dffsr
@@ -291,7 +291,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSR (posedge CLK negedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_pnp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_pnp
 yosys cd my_dffsr_pnp
 stat
 select -assert-count 1 t:dffsr
@@ -299,7 +299,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSR (posedge CLK posedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_ppn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_ppn
 yosys cd my_dffsr_ppn
 stat
 select -assert-count 1 t:dffsr
@@ -307,7 +307,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (posedge CLK negedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_pnn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_pnn
 yosys cd my_dffsr_pnn
 stat
 select -assert-count 1 t:dffsr
@@ -315,7 +315,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (negedge CLK posedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_npp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_npp
 yosys cd my_dffsr_npp
 stat
 select -assert-count 1 t:dffsr
@@ -323,7 +323,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (negedge CLK negedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_nnp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_nnp
 yosys cd my_dffsr_nnp
 stat
 select -assert-count 1 t:dffsr
@@ -331,7 +331,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSR (negedge CLK posedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_npn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_npn
 yosys cd my_dffsr_npn
 stat
 select -assert-count 1 t:dffsr
@@ -339,7 +339,7 @@ select -assert-count 3 t:\$lut
 
 # DFFSR (negedge CLK negedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsr_nnn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsr_nnn
 yosys cd my_dffsr_nnn
 stat
 select -assert-count 1 t:dffsr
@@ -347,7 +347,7 @@ select -assert-count 3 t:\$lut
 
 # DFFSRE (posedge CLK posedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_ppp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_ppp
 yosys cd my_dffsre_ppp
 stat
 select -assert-count 1 t:dffsre
@@ -355,7 +355,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSRE (posedge CLK negedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_pnp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_pnp
 yosys cd my_dffsre_pnp
 stat
 select -assert-count 1 t:dffsre
@@ -363,7 +363,7 @@ select -assert-count 1 t:\$lut
 
 # DFFSRE (posedge CLK posedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_ppn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_ppn
 yosys cd my_dffsre_ppn
 stat
 select -assert-count 1 t:dffsre
@@ -371,7 +371,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSRE (posedge CLK negedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_pnn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_pnn
 yosys cd my_dffsre_pnn
 stat
 select -assert-count 1 t:dffsre
@@ -379,7 +379,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSRE (negedge CLK posedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_npp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_npp
 yosys cd my_dffsre_npp
 stat
 select -assert-count 1 t:dffsre
@@ -387,7 +387,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSRE (negedge CLK negedge SET posedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_nnp
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_nnp
 yosys cd my_dffsre_nnp
 stat
 select -assert-count 1 t:dffsre
@@ -395,7 +395,7 @@ select -assert-count 2 t:\$lut
 
 # DFFSRE (negedge CLK posedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_npn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_npn
 yosys cd my_dffsre_npn
 stat
 select -assert-count 1 t:dffsre
@@ -403,7 +403,7 @@ select -assert-count 3 t:\$lut
 
 # DFFSRE (negedge CLK negedge SET negedge RST)
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_dffsre_nnn
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_dffsre_nnn
 yosys cd my_dffsre_nnn
 stat
 select -assert-count 1 t:dffsre
@@ -420,7 +420,7 @@ design -save read
 # DFF
 hierarchy -top my_dff
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dff
 design -load postopt
 yosys cd my_dff
 stat
@@ -430,7 +430,7 @@ select -assert-count 1 t:sdffsre
 design -load read
 hierarchy -top my_dffn
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffn
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffn
 design -load postopt
 yosys cd my_dffn
 stat
@@ -441,7 +441,7 @@ select -assert-count 1 t:sdffnsre
 design -load read
 hierarchy -top my_dffr_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffr_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffr_n
 design -load postopt
 yosys cd my_dffr_n
 stat
@@ -451,7 +451,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffr_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffr_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffr_p
 design -load postopt
 yosys cd my_dffr_p
 stat
@@ -462,7 +462,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_dffre_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffre_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffre_n
 design -load postopt
 yosys cd my_dffre_n
 stat
@@ -472,7 +472,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffre_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffre_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffre_p
 design -load postopt
 yosys cd my_dffre_p
 stat
@@ -484,7 +484,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_dffs_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffs_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffs_n
 design -load postopt
 yosys cd my_dffs_n
 stat
@@ -494,7 +494,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffs_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffs_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffs_p
 design -load postopt
 yosys cd my_dffs_p
 stat
@@ -505,7 +505,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_dffse_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffse_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffse_n
 design -load postopt
 yosys cd my_dffse_n
 stat
@@ -515,7 +515,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffse_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffse_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffse_p
 design -load postopt
 yosys cd my_dffse_p
 stat
@@ -527,7 +527,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_sdffr_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffr_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffr_n
 design -load postopt
 yosys cd my_sdffr_n
 stat
@@ -537,7 +537,7 @@ select -assert-count 1 t:sdffsre
 design -load read
 hierarchy -top my_sdffr_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffr_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffr_p
 design -load postopt
 yosys cd my_sdffr_p
 stat
@@ -548,7 +548,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_sdffs_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffs_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffs_n
 design -load postopt
 yosys cd my_sdffs_n
 stat
@@ -558,7 +558,7 @@ select -assert-count 1 t:sdffsre
 design -load read
 hierarchy -top my_sdffs_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffs_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffs_p
 design -load postopt
 yosys cd my_sdffs_p
 stat
@@ -570,7 +570,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_sdffnr_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffnr_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffnr_n
 design -load postopt
 yosys cd my_sdffnr_n
 stat
@@ -580,7 +580,7 @@ select -assert-count 1 t:sdffnsre
 design -load read
 hierarchy -top my_sdffnr_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffnr_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffnr_p
 design -load postopt
 yosys cd my_sdffnr_p
 stat
@@ -591,7 +591,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_sdffns_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffns_n
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffns_n
 design -load postopt
 yosys cd my_sdffns_n
 stat
@@ -601,7 +601,7 @@ select -assert-count 1 t:sdffnsre
 design -load read
 hierarchy -top my_sdffns_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_sdffns_p
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_sdffns_p
 design -load postopt
 yosys cd my_sdffns_p
 stat
@@ -613,7 +613,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_latch
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latch
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latch
 design -load postopt
 yosys cd my_latch
 stat
@@ -623,7 +623,7 @@ select -assert-count 1 t:latchsre
 design -load read
 hierarchy -top my_latchn
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchn
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchn
 design -load postopt
 yosys cd my_latchn
 stat
@@ -634,7 +634,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchr_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchr_n
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchr_n
 #design -load postopt
 #yosys cd my_latchr_n
 #stat
@@ -644,7 +644,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchr_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchr_p
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchr_p
 #design -load postopt
 #yosys cd my_latchr_p
 #stat
@@ -655,7 +655,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchs_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchs_n
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchs_n
 #design -load postopt
 #yosys cd my_latchs_n
 #stat
@@ -665,7 +665,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchs_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchs_p
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchs_p
 #design -load postopt
 #yosys cd my_latchs_p
 #stat
@@ -677,7 +677,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchnr_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchnr_n
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchnr_n
 #design -load postopt
 #yosys cd my_latchnr_n
 #stat
@@ -687,7 +687,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchnr_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchnr_p
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchnr_p
 #design -load postopt
 #yosys cd my_latchnr_p
 #stat
@@ -698,7 +698,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchns_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchns_n
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchns_n
 #design -load postopt
 #yosys cd my_latchns_n
 #stat
@@ -708,7 +708,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchns_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchns_p
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchns_p
 #design -load postopt
 #yosys cd my_latchns_p
 #stat
@@ -727,7 +727,7 @@ design -save read
 # DFF
 hierarchy -top my_dff
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dff -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dff -nosdff
 design -load postopt
 yosys cd my_dff
 stat
@@ -737,7 +737,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffn
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffn -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffn -nosdff
 design -load postopt
 yosys cd my_dffn
 stat
@@ -748,7 +748,7 @@ select -assert-count 1 t:dffnsre
 design -load read
 hierarchy -top my_dffr_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffr_n -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffr_n -nosdff
 design -load postopt
 yosys cd my_dffr_n
 stat
@@ -758,7 +758,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffr_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffr_p -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffr_p -nosdff
 design -load postopt
 yosys cd my_dffr_p
 stat
@@ -769,7 +769,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_dffre_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffre_n -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffre_n -nosdff
 design -load postopt
 yosys cd my_dffre_n
 stat
@@ -779,7 +779,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffre_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffre_p -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffre_p -nosdff
 design -load postopt
 yosys cd my_dffre_p
 stat
@@ -791,7 +791,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_dffs_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffs_n -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffs_n -nosdff
 design -load postopt
 yosys cd my_dffs_n
 stat
@@ -801,7 +801,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffs_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffs_p -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffs_p -nosdff
 design -load postopt
 yosys cd my_dffs_p
 stat
@@ -812,7 +812,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_dffse_n
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffse_n -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffse_n -nosdff
 design -load postopt
 yosys cd my_dffse_n
 stat
@@ -822,7 +822,7 @@ select -assert-count 1 t:dffsre
 design -load read
 hierarchy -top my_dffse_p
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_dffse_p -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_dffse_p -nosdff
 design -load postopt
 yosys cd my_dffse_p
 stat
@@ -834,7 +834,7 @@ select -assert-count 1 t:\$lut
 design -load read
 hierarchy -top my_latch
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latch -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latch -nosdff
 design -load postopt
 yosys cd my_latch
 stat
@@ -844,7 +844,7 @@ select -assert-count 1 t:latchsre
 design -load read
 hierarchy -top my_latchn
 yosys proc
-equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchn -nosdff
+equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchn -nosdff
 design -load postopt
 yosys cd my_latchn
 stat
@@ -855,7 +855,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchr_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchr_n -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchr_n -nosdff
 #design -load postopt
 #yosys cd my_latchr_n
 #stat
@@ -865,7 +865,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchr_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchr_p -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchr_p -nosdff
 #design -load postopt
 #yosys cd my_latchr_p
 #stat
@@ -876,7 +876,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchs_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchs_n -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchs_n -nosdff
 #design -load postopt
 #yosys cd my_latchs_n
 #stat
@@ -886,7 +886,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchs_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchs_p -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchs_p -nosdff
 #design -load postopt
 #yosys cd my_latchs_p
 #stat
@@ -898,7 +898,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchnr_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchnr_n -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchnr_n -nosdff
 #design -load postopt
 #yosys cd my_latchnr_n
 #stat
@@ -908,7 +908,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchnr_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchnr_p -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchnr_p -nosdff
 #design -load postopt
 #yosys cd my_latchnr_p
 #stat
@@ -919,7 +919,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchns_n
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchns_n -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchns_n -nosdff
 #design -load postopt
 #yosys cd my_latchns_n
 #stat
@@ -929,7 +929,7 @@ select -assert-count 1 t:latchnsre
 #design -load read
 #hierarchy -top my_latchns_p
 #yosys proc
-#equiv_opt -assert -async2sync -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f -top my_latchns_p -nosdff
+#equiv_opt -assert -async2sync -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f -top my_latchns_p -nosdff
 #design -load postopt
 #yosys cd my_latchns_p
 #stat
@@ -950,7 +950,7 @@ design -save read
 # DFF
 hierarchy -top my_dff
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_dff
+equiv_opt -async2sync -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3 -top my_dff
 design -load postopt
 yosys cd my_dff
 stat
@@ -965,7 +965,7 @@ select -assert-count 1 t:logic_1
 design -load read
 hierarchy -top my_dffe
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_dffe
+equiv_opt -async2sync -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3 -top my_dffe
 design -load postopt
 yosys cd my_dffe
 stat
@@ -979,7 +979,7 @@ select -assert-count 1 t:logic_0
 design -load read
 hierarchy -top my_dffr_p
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_dffr_p
+equiv_opt -async2sync -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3 -top my_dffr_p
 design -load postopt
 yosys cd my_dffr_p
 stat
@@ -996,7 +996,7 @@ select -assert-none t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad %% t:*
 design -load read
 hierarchy -top my_dffr_n
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_dffr_n
+equiv_opt -async2sync -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3 -top my_dffr_n
 design -load postopt
 yosys cd my_dffr_n
 stat
@@ -1014,7 +1014,7 @@ select -assert-none t:LUT1 t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad
 design -load read
 hierarchy -top my_sdffs_p
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_sdffs_p
+equiv_opt -async2sync -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3 -top my_sdffs_p
 design -load postopt
 yosys cd my_sdffs_p
 stat
@@ -1032,7 +1032,7 @@ select -assert-none t:LUT2 t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad
 design -load read
 hierarchy -top my_sdffns_p
 yosys proc
-equiv_opt -async2sync -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3 -top my_sdffns_p
+equiv_opt -async2sync -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3 -top my_sdffns_p
 design -load postopt
 yosys cd my_sdffns_p
 stat

--- a/ql-qlf-plugin/tests/fsm/fsm.tcl
+++ b/ql-qlf-plugin/tests/fsm/fsm.tcl
@@ -9,7 +9,7 @@ hierarchy -top fsm
 yosys proc
 flatten
 
-equiv_opt -run :prove -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -run :prove -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 async2sync
 miter -equiv -make_assert -flatten gold gate miter
 sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip 1 miter

--- a/ql-qlf-plugin/tests/full_adder/full_adder.tcl
+++ b/ql-qlf-plugin/tests/full_adder/full_adder.tcl
@@ -6,7 +6,7 @@ yosys -import  ;# ingest plugin commands
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top full_adder
 yosys proc
-equiv_opt -assert -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k4n8/cells_sim.v synth_quicklogic_f4pga -family qlf_k4n8
 
 design -reset
 
@@ -14,21 +14,21 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top subtractor
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k4n8/cells_sim.v synth_quicklogic_f4pga -family qlf_k4n8
 design -reset
 
 # Equivalence check for comparator synthesis
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top comparator
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k4n8/cells_sim.v synth_quicklogic_f4pga -family qlf_k4n8
 design -reset
 
 # Equivalence check for adder synthesis for qlf-k6n10
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top full_adder
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10
 design -load postopt
 yosys cd full_adder
 stat
@@ -40,7 +40,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top subtractor
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10
 design -load postopt
 yosys cd subtractor
 stat
@@ -52,7 +52,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top comparator
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10
 design -load postopt
 yosys cd comparator
 stat
@@ -64,7 +64,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top full_adder
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f
 design -load postopt
 yosys cd full_adder
 stat
@@ -76,7 +76,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top subtractor
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f
 design -load postopt
 yosys cd subtractor
 stat
@@ -88,7 +88,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top comparator
 yosys proc
-equiv_opt -assert  -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f
+equiv_opt -assert  -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10f
 design -load postopt
 yosys cd comparator
 stat
@@ -100,7 +100,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top full_adder
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd full_adder
 
@@ -119,7 +119,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top subtractor
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd subtractor
 
@@ -137,7 +137,7 @@ design -reset
 read_verilog -icells -DWIDTH=4 $::env(DESIGN_TOP).v
 hierarchy -check -top comparator
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd comparator
 

--- a/ql-qlf-plugin/tests/iob_no_flatten/iob_no_flatten.tcl
+++ b/ql-qlf-plugin/tests/iob_no_flatten/iob_no_flatten.tcl
@@ -4,7 +4,7 @@ yosys -import  ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
 
-synth_quicklogic -family qlf_k4n8 -top my_top
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_top
 yosys stat
 yosys cd my_top
 select -assert-count 2 t:dffsr
@@ -13,7 +13,7 @@ design -reset
 
 read_verilog $::env(DESIGN_TOP).v
 
-synth_quicklogic -family qlf_k6n10 -top my_top
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_top
 yosys stat
 yosys cd my_top
 select -assert-count 2 t:dff

--- a/ql-qlf-plugin/tests/iob_no_flatten/iob_no_flatten.ys
+++ b/ql-qlf-plugin/tests/iob_no_flatten/iob_no_flatten.ys
@@ -1,7 +1,7 @@
 plugin -i ql-qlf
 read_verilog ./iob_no_flatten.v
 
-synth_quicklogic -family qlf_k4n8 -top my_top
+synth_quicklogic_f4pga -family qlf_k4n8 -top my_top
 stat
 cd my_top
 select -assert-count 2 t:$_DFF_P_

--- a/ql-qlf-plugin/tests/latches/latches.tcl
+++ b/ql-qlf-plugin/tests/latches/latches.tcl
@@ -8,14 +8,14 @@ design -save read
 # Tests for qlf_k6n10 family
 # LATCHP
 design -load read
-synth_quicklogic -family qlf_k6n10 -top latchp
+synth_quicklogic_f4pga -family qlf_k6n10 -top latchp
 yosys cd latchp
 stat
 select -assert-count 1 t:latchsre
 
 # LATCHN
 design -load read
-synth_quicklogic -family qlf_k6n10 -top latchn
+synth_quicklogic_f4pga -family qlf_k6n10 -top latchn
 yosys cd latchn
 stat
 select -assert-count 1 t:\$lut
@@ -23,7 +23,7 @@ select -assert-count 1 t:latchsre
 
 # LATCHSRE
 design -load read
-synth_quicklogic -family qlf_k6n10 -top my_latchsre
+synth_quicklogic_f4pga -family qlf_k6n10 -top my_latchsre
 yosys cd my_latchsre
 stat
 select -assert-count 2 t:\$lut
@@ -31,16 +31,16 @@ select -assert-count 1 t:latchsre
 
 ## Tests for qlf_k4n8 family
 ## Currently disabled cause latch aren't supported
-## in synth_quicklogic for that family
+## in synth_quicklogic_f4pga for that family
 ## LATCHP
-#synth_quicklogic -family qlf_k4n8 -top latchp
+#synth_quicklogic_f4pga -family qlf_k4n8 -top latchp
 #yosys cd latchp
 #stat
 #select -assert-count 1 t:\$_DLATCH_P_
 #
 ## LATCHP no init
 #design -load read
-#synth_quicklogic -family qlf_k4n8 -top latchp_noinit
+#synth_quicklogic_f4pga -family qlf_k4n8 -top latchp_noinit
 #yosys cd latchp_noinit
 #stat
 #select -assert-count 1 t:\$_DLATCH_P_
@@ -52,7 +52,7 @@ design -load read
 hierarchy -top latchp_noinit
 yosys proc
 # Can't run any sort of equivalence check because latches are blown to LUTs
-synth_quicklogic -family pp3 -top latchp_noinit
+synth_quicklogic_f4pga -family pp3 -top latchp_noinit
 yosys cd latchp_noinit
 select -assert-count 1 t:LUT3
 select -assert-count 3 t:inpad
@@ -65,7 +65,7 @@ design -load read
 hierarchy -top latchn
 yosys proc
 # Can't run any sort of equivalence check because latches are blown to LUTs
-synth_quicklogic -family pp3 -top latchn
+synth_quicklogic_f4pga -family pp3 -top latchn
 yosys cd latchn
 select -assert-count 1 t:LUT3
 select -assert-count 3 t:inpad
@@ -78,7 +78,7 @@ design -load read
 hierarchy -top my_latchsre
 yosys proc
 # Can't run any sort of equivalence check because latches are blown to LUTs
-synth_quicklogic -family pp3 -top my_latchsre
+synth_quicklogic_f4pga -family pp3 -top my_latchsre
 yosys cd my_latchsre
 select -assert-count 1 t:LUT2
 select -assert-count 1 t:LUT4

--- a/ql-qlf-plugin/tests/logic/logic.tcl
+++ b/ql-qlf-plugin/tests/logic/logic.tcl
@@ -6,7 +6,7 @@ yosys -import  ;# ingest plugin commands
 read_verilog $::env(DESIGN_TOP).v
 hierarchy -top top
 yosys proc
-equiv_opt -assert -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k4n8/cells_sim.v synth_quicklogic_f4pga -family qlf_k4n8
 design -load postopt
 yosys cd top
 
@@ -19,7 +19,7 @@ design -reset
 read_verilog $::env(DESIGN_TOP).v
 hierarchy -top top
 yosys proc
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10
 design -load postopt
 yosys cd top
 
@@ -32,7 +32,7 @@ design -reset
 read_verilog $::env(DESIGN_TOP).v
 hierarchy -top top
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd top
 

--- a/ql-qlf-plugin/tests/logic/logic.ys
+++ b/ql-qlf-plugin/tests/logic/logic.ys
@@ -2,7 +2,7 @@ plugin -i ql-qlf
 read_verilog ./logic.v
 hierarchy -top top
 proc
-equiv_opt -assert -map +/quicklogic/qlf_k4n8/cells_sim.v synth_quicklogic -family qlf_k4n8
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k4n8/cells_sim.v synth_quicklogic_f4pga -family qlf_k4n8
 design -load postopt
 cd top
 

--- a/ql-qlf-plugin/tests/mac_unit/mac_unit.tcl
+++ b/ql-qlf-plugin/tests/mac_unit/mac_unit.tcl
@@ -8,7 +8,7 @@ design -save read
 
 #Infer QL_DSP
 hierarchy -top $TOP
-synth_quicklogic -family qlf_k6n10 -top $TOP
+synth_quicklogic_f4pga -family qlf_k6n10 -top $TOP
 yosys cd $TOP
 stat
 select -assert-count 1 t:QL_DSP
@@ -16,7 +16,7 @@ select -assert-count 1 t:QL_DSP
 #Test no_dsp arg
 design -load read
 hierarchy -top $TOP
-synth_quicklogic -family qlf_k6n10 -top $TOP -no_dsp
+synth_quicklogic_f4pga -family qlf_k6n10 -top $TOP -no_dsp
 yosys cd $TOP
 stat
 select -assert-count 0 t:QL_DSP

--- a/ql-qlf-plugin/tests/multiplier/multiplier.tcl
+++ b/ql-qlf-plugin/tests/multiplier/multiplier.tcl
@@ -8,7 +8,7 @@ design -save read
 
 #Infer QL_DSP
 hierarchy -top $TOP
-synth_quicklogic -family qlf_k6n10 -top $TOP
+synth_quicklogic_f4pga -family qlf_k6n10 -top $TOP
 yosys cd $TOP
 stat
 select -assert-count 1 t:QL_DSP
@@ -16,7 +16,7 @@ select -assert-count 1 t:QL_DSP
 #Test no_dsp arg
 design -load read
 hierarchy -top $TOP
-synth_quicklogic -family qlf_k6n10 -top $TOP -no_dsp
+synth_quicklogic_f4pga -family qlf_k6n10 -top $TOP -no_dsp
 yosys cd $TOP
 stat
 select -assert-count 0 t:QL_DSP

--- a/ql-qlf-plugin/tests/mux/mux.tcl
+++ b/ql-qlf-plugin/tests/mux/mux.tcl
@@ -7,7 +7,7 @@ design -save read
 
 hierarchy -top mux2
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd mux2
 select -assert-count 1 t:LUT3
@@ -19,7 +19,7 @@ select -assert-none t:LUT3 t:inpad t:outpad %% t:* %D
 design -load read
 hierarchy -top mux4
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd mux4
 select -assert-count 3 t:LUT3
@@ -31,7 +31,7 @@ select -assert-none t:LUT3 t:inpad t:outpad %% t:* %D
 design -load read
 hierarchy -top mux8
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd mux8
 select -assert-count 1 t:LUT1
@@ -45,7 +45,7 @@ select -assert-none t:LUT1 t:LUT3 t:mux4x0 t:inpad t:outpad %% t:* %D
 design -load read
 hierarchy -top mux16
 yosys proc
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd mux16
 select -assert-count 1 t:LUT3

--- a/ql-qlf-plugin/tests/pp3_bram/pp3_bram.tcl
+++ b/ql-qlf-plugin/tests/pp3_bram/pp3_bram.tcl
@@ -6,7 +6,7 @@ read_verilog $::env(DESIGN_TOP).v
 design -save read
 
 design -load read
-synth_quicklogic -family pp3 -top top_bram_9_16
+synth_quicklogic_f4pga -family pp3 -top top_bram_9_16
 yosys cd top_bram_9_16
 stat
 select -assert-count 1 t:ckpad
@@ -15,7 +15,7 @@ select -assert-count 16 t:outpad
 select -assert-count 1 t:ram8k_2x1_cell_macro
 
 design -load read
-synth_quicklogic -family pp3 -top top_bram_9_32
+synth_quicklogic_f4pga -family pp3 -top top_bram_9_32
 yosys cd top_bram_9_32
 stat
 select -assert-count 1 t:ckpad
@@ -24,7 +24,7 @@ select -assert-count 32 t:outpad
 select -assert-count 1 t:ram8k_2x1_cell_macro
 
 design -load read
-synth_quicklogic -family pp3 -top top_bram_10_16
+synth_quicklogic_f4pga -family pp3 -top top_bram_10_16
 yosys cd top_bram_10_16
 stat
 select -assert-count 1 t:ckpad
@@ -34,7 +34,7 @@ select -assert-count 1 t:ram8k_2x1_cell_macro
 
 # BRAM initialization from file using pp3_braminig pass test
 design -load read
-synth_quicklogic -family pp3 -top top_bram_init
+synth_quicklogic_f4pga -family pp3 -top top_bram_init
 yosys cd top_bram_init
 stat
 select -assert-count 1 t:ckpad

--- a/ql-qlf-plugin/tests/qlf_k6n10_bram/bram.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10_bram/bram.tcl
@@ -6,22 +6,22 @@ read_verilog $::env(DESIGN_TOP).v
 hierarchy -top BRAM_32x512
 yosys proc
 yosys memory
-equiv_opt -assert -map +/quicklogic/qlf_k6n10_cells_sim.v synth_quicklogic -family qlf_k6n10 -top BRAM_32x512
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10_cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_32x512
 
 design -load read
-synth_quicklogic -family qlf_k6n10 -top BRAM_16x1024
+synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_16x1024
 yosys cd BRAM_16x1024
 stat
 select -assert-count 1 t:DP_RAM16K
 
 design -load read
-synth_quicklogic -family qlf_k6n10 -top BRAM_8x2048
+synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_8x2048
 yosys cd BRAM_16x1024
 stat
 select -assert-count 1 t:DP_RAM16K
 
 design -load read
-synth_quicklogic -family qlf_k6n10 -top BRAM_4x4096
+synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_4x4096
 yosys cd BRAM_16x1024
 stat
 select -assert-count 1 t:DP_RAM16K

--- a/ql-qlf-plugin/tests/qlf_k6n10_bram/bram.ys
+++ b/ql-qlf-plugin/tests/qlf_k6n10_bram/bram.ys
@@ -8,7 +8,7 @@ design -save read
 hierarchy -top BRAM_32x512
 proc
 memory
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10 -top BRAM_32x512
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_32x512
 design -load postopt
 cd BRAM_32x512
 stat
@@ -19,7 +19,7 @@ select -assert-count 1 t:DP_RAM16K
 hierarchy -top BRAM_32x512
 proc
 memory
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10 -top BRAM_16x1024
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_16x1024
 design -load postopt
 cd BRAM_16x1024
 stat
@@ -30,7 +30,7 @@ select -assert-count 1 t:DP_RAM16K
 hierarchy -top BRAM_8x2048
 proc
 memory
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10 -top BRAM_8x2048
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_8x2048
 design -load postopt
 cd BRAM_8x2048
 stat
@@ -41,7 +41,7 @@ select -assert-count 1 t:DP_RAM16K
 hierarchy -top BRAM_4x4096
 proc
 memory
-equiv_opt -assert -map +/quicklogic/qlf_k6n10/cells_sim.v synth_quicklogic -family qlf_k6n10 -top BRAM_4x4096
+equiv_opt -assert -map +/quicklogic_f4pga/qlf_k6n10/cells_sim.v synth_quicklogic_f4pga -family qlf_k6n10 -top BRAM_4x4096
 design -load postopt
 cd BRAM_4x4096
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram18k_sdp/asymmetric_bram18k_sdp.tcl
@@ -8,7 +8,7 @@ design -save asymmetric_bram18k_sdp
 
 select spram_9x2048_18x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_9x2048_18x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_9x2048_18x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load asymmetric_bram18k_sdp
 select spram_18x1024_9x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_18x1024_9x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_18x1024_9x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_afifo/asymmetric_bram36k_afifo.tcl
@@ -8,7 +8,7 @@ design -save asymmetric_bram36k_afifo
 
 select af4096x9_1024x36
 select *
-synth_quicklogic -family qlf_k6n10f -top af4096x9_1024x36 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af4096x9_1024x36 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load asymmetric_bram36k_afifo
 select af2048x18_1024x36
 select *
-synth_quicklogic -family qlf_k6n10f -top af2048x18_1024x36 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af2048x18_1024x36 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load asymmetric_bram36k_afifo
 select af2048x18_4098x9
 select *
-synth_quicklogic -family qlf_k6n10f -top af2048x18_4098x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af2048x18_4098x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load asymmetric_bram36k_afifo
 select af1024x36_4098x9
 select *
-synth_quicklogic -family qlf_k6n10f -top af1024x36_4098x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af1024x36_4098x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sdp/asymmetric_bram36k_sdp.tcl
@@ -8,7 +8,7 @@ design -save asymmetric_bram36k_sdp
 
 select spram_9x4096_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_9x4096_36x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_9x4096_36x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load asymmetric_bram36k_sdp
 select spram_18x2048_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_18x2048_36x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_18x2048_36x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load asymmetric_bram36k_sdp
 select spram_18x2048_9x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_18x2048_9x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_18x2048_9x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load asymmetric_bram36k_sdp
 select spram_36x1024_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_36x1024_18x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_36x1024_18x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/asymmetric_bram36k_sfifo/asymmetric_bram36k_sfifo.tcl
@@ -8,7 +8,7 @@ design -save asymmetric_bram36k_sfifo
 
 select f4096x9_1024x36
 select *
-synth_quicklogic -family qlf_k6n10f -top f4096x9_1024x36 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f4096x9_1024x36 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load asymmetric_bram36k_sfifo
 select f2048x18_1024x36
 select *
-synth_quicklogic -family qlf_k6n10f -top f2048x18_1024x36 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f2048x18_1024x36 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load asymmetric_bram36k_sfifo
 select f2048x18_4098x9
 select *
-synth_quicklogic -family qlf_k6n10f -top f2048x18_4098x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f2048x18_4098x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load asymmetric_bram36k_sfifo
 select f1024x36_2048x18
 select *
-synth_quicklogic -family qlf_k6n10f -top f1024x36_2048x18 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f1024x36_2048x18 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_afifo/bram18k_afifo.tcl
@@ -8,7 +8,7 @@ design -save bram18k_afifo
 
 select af1024x18_1024x18
 select *
-synth_quicklogic -family qlf_k6n10f -top af1024x18_1024x18 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af1024x18_1024x18 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram18k_afifo
 select af1024x16_1024x16
 select *
-synth_quicklogic -family qlf_k6n10f -top af1024x16_1024x16 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af1024x16_1024x16 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram18k_afifo
 select af2048x9_2048x9
 select *
-synth_quicklogic -family qlf_k6n10f -top af2048x9_2048x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af2048x9_2048x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram18k_afifo
 select af2048x8_2048x8
 select *
-synth_quicklogic -family qlf_k6n10f -top af2048x8_2048x8 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af2048x8_2048x8 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sdp/bram18k_sdp.tcl
@@ -8,7 +8,7 @@ design -save bram18k_sdp
 
 select spram_18x1024_2x
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_18x1024_2x -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_18x1024_2x -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram18k_sdp
 select spram_9x2048_x2
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_9x2048_x2 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_9x2048_x2 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram18k_sdp
 select spram_9x2048_18x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_9x2048_18x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_9x2048_18x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_sfifo/bram18k_sfifo.tcl
@@ -8,7 +8,7 @@ design -save bram18k_sfifo
 
 select f1024x18_1024x18
 select *
-synth_quicklogic -family qlf_k6n10f -top f1024x18_1024x18 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f1024x18_1024x18 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram18k_sfifo
 select f1024x16_1024x16
 select *
-synth_quicklogic -family qlf_k6n10f -top f1024x16_1024x16 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f1024x16_1024x16 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram18k_sfifo
 select f2048x9_2048x9
 select *
-synth_quicklogic -family qlf_k6n10f -top f2048x9_2048x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f2048x9_2048x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram18k_sfifo
 select f2048x8_2048x8
 select *
-synth_quicklogic -family qlf_k6n10f -top f2048x8_2048x8 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f2048x8_2048x8 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram18k_tdp/bram18k_tdp.tcl
@@ -8,7 +8,7 @@ design -save bram18k_tdp
 
 select dpram_18x1024_x2
 select *
-synth_quicklogic -family qlf_k6n10f -top dpram_18x1024_x2 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top dpram_18x1024_x2 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram18k_tdp
 select dpram_9x2048_x2
 select *
-synth_quicklogic -family qlf_k6n10f -top dpram_9x2048_x2 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top dpram_9x2048_x2 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram18k_tdp
 select dpram_18x1024_9x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top dpram_18x1024_9x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top dpram_18x1024_9x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_afifo/bram36k_afifo.tcl
@@ -8,7 +8,7 @@ design -save bram36k_afifo
 
 select af1024x36_1024x36
 select *
-synth_quicklogic -family qlf_k6n10f -top af1024x36_1024x36 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af1024x36_1024x36 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram36k_afifo
 select af2048x18_2048x18
 select *
-synth_quicklogic -family qlf_k6n10f -top af2048x18_2048x18 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af2048x18_2048x18 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram36k_afifo
 select af4096x9_4096x9
 select *
-synth_quicklogic -family qlf_k6n10f -top af4096x9_4096x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top af4096x9_4096x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sdp/bram36k_sdp.tcl
@@ -8,7 +8,7 @@ design -save bram36_sdp
 
 select spram_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_36x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_36x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram36_sdp
 select spram_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_32x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_32x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram36_sdp
 select spram_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_18x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_18x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram36_sdp
 select spram_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_16x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_16x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -52,7 +52,7 @@ select -clear
 design -load bram36_sdp
 select spram_9x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_9x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_9x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -63,7 +63,7 @@ select -clear
 design -load bram36_sdp
 select spram_8x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_8x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_8x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_sfifo/bram36k_sfifo.tcl
@@ -8,7 +8,7 @@ design -save bram36k_sfifo
 
 select f1024x36_1024x36
 select *
-synth_quicklogic -family qlf_k6n10f -top f1024x36_1024x36 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f1024x36_1024x36 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram36k_sfifo
 select f2048x18_2048x18
 select *
-synth_quicklogic -family qlf_k6n10f -top f2048x18_2048x18 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f2048x18_2048x18 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram36k_sfifo
 select f4096x9_4096x9
 select *
-synth_quicklogic -family qlf_k6n10f -top f4096x9_4096x9 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top f4096x9_4096x9 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram36k_tdp/bram36k_tdp.tcl
@@ -8,7 +8,7 @@ design -save bram36k_tdp
 
 select dpram_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top dpram_36x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top dpram_36x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram36k_tdp
 select dpram_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top dpram_18x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top dpram_18x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram36k_tdp
 select dpram_9x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top dpram_9x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top dpram_9x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_read/bram_asymmetric_wider_read.tcl
@@ -8,7 +8,7 @@ design -save bram_tdp
 
 select spram_16x2048_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_16x2048_32x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_16x2048_32x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -20,7 +20,7 @@ select -clear
 design -load bram_tdp
 select spram_8x4096_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_8x4096_16x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_8x4096_16x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -32,7 +32,7 @@ select -clear
 design -load bram_tdp
 select spram_8x2048_16x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_8x2048_16x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_8x2048_16x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -44,7 +44,7 @@ select -clear
 design -load bram_tdp
 select spram_8x4096_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_8x4096_32x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_8x4096_32x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_asymmetric_wider_write/bram_asymmetric_wider_write.tcl
@@ -8,7 +8,7 @@ design -save bram_tdp
 
 select spram_16x1024_8x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_16x1024_8x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_16x1024_8x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -20,7 +20,7 @@ select -clear
 design -load bram_tdp
 select spram_16x2048_8x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_16x2048_8x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_16x2048_8x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -32,7 +32,7 @@ select -clear
 design -load bram_tdp
 select spram_32x1024_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_32x1024_16x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_32x1024_16x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -44,7 +44,7 @@ select -clear
 design -load bram_tdp
 select spram_32x1024_8x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top spram_32x1024_8x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top spram_32x1024_8x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/bram_sdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp/bram_sdp.tcl
@@ -8,7 +8,7 @@ design -save bram_sdp
 
 select BRAM_SDP_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_36x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_36x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_32x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_32x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_18x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_18x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_16x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_16x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -52,7 +52,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_9x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_9x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_9x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -63,7 +63,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_8x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_8x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_8x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -74,7 +74,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_4x8192
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_4x8192 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_4x8192 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -85,7 +85,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_2x16384
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_2x16384 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_2x16384 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -96,7 +96,7 @@ select -clear
 design -load bram_sdp
 select BRAM_SDP_1x32768
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_1x32768 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_1x32768 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/bram_sdp_split.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_sdp_split/bram_sdp_split.tcl
@@ -8,7 +8,7 @@ design -save bram_sdp_split
 
 select BRAM_SDP_SPLIT_2x18x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x18x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x18x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram_sdp_split
 select BRAM_SDP_SPLIT_2x16x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x16x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x16x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram_sdp_split
 select BRAM_SDP_SPLIT_2x9x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x9x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x9x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram_sdp_split
 select BRAM_SDP_SPLIT_2x8x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x8x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x8x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -52,7 +52,7 @@ select -clear
 design -load bram_sdp_split
 select BRAM_SDP_SPLIT_2x4x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x4x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x4x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -63,7 +63,7 @@ select -clear
 design -load bram_sdp_split
 select BRAM_SDP_SPLIT_2x2x8192
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x2x8192 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x2x8192 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -74,7 +74,7 @@ select -clear
 design -load bram_sdp_split
 select BRAM_SDP_SPLIT_2x1x16384
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x1x16384 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_SDP_SPLIT_2x1x16384 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
@@ -8,7 +8,7 @@ design -save bram_tdp
 
 select BRAM_TDP_36x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_36x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_36x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_32x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_32x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_32x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_18x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_18x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_18x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_16x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_16x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_16x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -52,7 +52,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_9x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_9x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_9x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -63,7 +63,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_8x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_8x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_8x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -74,7 +74,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_4x8192
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_4x8192 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_4x8192 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -85,7 +85,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_2x16384
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_2x16384 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_2x16384 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -96,7 +96,7 @@ select -clear
 design -load bram_tdp
 select BRAM_TDP_1x32768
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_1x32768 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_1x32768 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/bram_tdp_split.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp_split/bram_tdp_split.tcl
@@ -8,7 +8,7 @@ design -save bram_tdp_split
 
 select BRAM_TDP_SPLIT_2x18x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x18x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x18x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load bram_tdp_split
 select BRAM_TDP_SPLIT_2x16x1024
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x16x1024 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x16x1024 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load bram_tdp_split
 select BRAM_TDP_SPLIT_2x9x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x9x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x9x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -41,7 +41,7 @@ select -clear
 design -load bram_tdp_split
 select BRAM_TDP_SPLIT_2x8x2048
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x8x2048 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x8x2048 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -52,7 +52,7 @@ select -clear
 design -load bram_tdp_split
 select BRAM_TDP_SPLIT_2x4x4096
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x4x4096 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x4x4096 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -63,7 +63,7 @@ select -clear
 design -load bram_tdp_split
 select BRAM_TDP_SPLIT_2x2x8192
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x2x8192 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x2x8192 -bram_types
 opt_expr -undriven
 opt_clean
 stat
@@ -74,7 +74,7 @@ select -clear
 design -load bram_tdp_split
 select BRAM_TDP_SPLIT_2x1x16384
 select *
-synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x1x16384 -bram_types
+synth_quicklogic_f4pga -family qlf_k6n10f -top BRAM_TDP_SPLIT_2x1x16384 -bram_types
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_macc/dsp_macc.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_macc/dsp_macc.tcl
@@ -7,10 +7,10 @@ proc check_equiv {top use_cfg_params} {
     design -save preopt
 
     if {${use_cfg_params} == 1} {
-        synth_quicklogic -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
     } else {
         stat
-        synth_quicklogic -family qlf_k6n10f -top ${top}
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top}
     }
 
     design -stash postopt
@@ -18,8 +18,8 @@ proc check_equiv {top use_cfg_params} {
     design -copy-from preopt  -as gold A:top
     design -copy-from postopt -as gate A:top
 
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/cells_sim.v
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/dsp_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/dsp_sim.v
     yosys proc
     opt_expr
     opt_clean -purge

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_madd/dsp_madd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_madd/dsp_madd.tcl
@@ -7,10 +7,10 @@ proc check_equiv {top use_cfg_params} {
     design -save preopt
 
     if {${use_cfg_params} == 1} {
-        synth_quicklogic -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
     } else {
         stat
-        synth_quicklogic -family qlf_k6n10f -top ${top}
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top}
     }
 
     design -stash postopt
@@ -18,8 +18,8 @@ proc check_equiv {top use_cfg_params} {
     design -copy-from preopt  -as gold A:top
     design -copy-from postopt -as gate A:top
 
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/cells_sim.v
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/dsp_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/dsp_sim.v
     yosys proc
     opt_expr
     opt_clean -purge

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
@@ -7,10 +7,10 @@ proc check_equiv {top use_cfg_params} {
     design -save preopt
 
     if {${use_cfg_params} == 1} {
-        synth_quicklogic -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
     } else {
         stat
-        synth_quicklogic -family qlf_k6n10f -top ${top}
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top}
     }
 
     design -stash postopt
@@ -18,8 +18,8 @@ proc check_equiv {top use_cfg_params} {
     design -copy-from preopt  -as gold A:top
     design -copy-from postopt -as gate A:top
 
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/cells_sim.v
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/dsp_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/dsp_sim.v
     yosys proc
     opt_expr
     opt_clean -purge

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult_post_synth_sim/dsp_mult_post_synth_sim.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult_post_synth_sim/dsp_mult_post_synth_sim.tcl
@@ -8,7 +8,7 @@ design -save dsp_mult_post_synth_sim
 
 select dsp_mult
 select *
-synth_quicklogic -family qlf_k6n10f -top dsp_mult
+synth_quicklogic_f4pga -family qlf_k6n10f -top dsp_mult
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load dsp_mult_post_synth_sim
 select dsp_mult
 select *
-synth_quicklogic -family qlf_k6n10f -top dsp_mult -use_dsp_cfg_params
+synth_quicklogic_f4pga -family qlf_k6n10f -top dsp_mult -use_dsp_cfg_params
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
@@ -7,10 +7,10 @@ proc check_equiv {top use_cfg_params} {
     design -save preopt
 
     if {${use_cfg_params} == 1} {
-        synth_quicklogic -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top} -use_dsp_cfg_params
     } else {
         stat
-        synth_quicklogic -family qlf_k6n10f -top ${top}
+        synth_quicklogic_f4pga -family qlf_k6n10f -top ${top}
     }
 
     design -stash postopt
@@ -18,8 +18,8 @@ proc check_equiv {top use_cfg_params} {
     design -copy-from preopt  -as gold A:top
     design -copy-from postopt -as gate A:top
 
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/cells_sim.v
-    techmap -wb -autoproc -map +/quicklogic/qlf_k6n10f/dsp_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/cells_sim.v
+    techmap -wb -autoproc -map +/quicklogic_f4pga/qlf_k6n10f/dsp_sim.v
     yosys proc
     opt_expr
     opt_clean

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd_post_synth_sim/dsp_simd_post_synth_sim.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd_post_synth_sim/dsp_simd_post_synth_sim.tcl
@@ -8,7 +8,7 @@ design -save dsp_simd
 
 select simd_mult
 select *
-synth_quicklogic -family qlf_k6n10f -top simd_mult
+synth_quicklogic_f4pga -family qlf_k6n10f -top simd_mult
 opt_expr -undriven
 opt_clean
 stat
@@ -19,7 +19,7 @@ select -clear
 design -load dsp_simd
 select simd_mult_explicit_ports
 select *
-synth_quicklogic -family qlf_k6n10f -top simd_mult_explicit_ports
+synth_quicklogic_f4pga -family qlf_k6n10f -top simd_mult_explicit_ports
 opt_expr -undriven
 opt_clean
 stat
@@ -30,7 +30,7 @@ select -clear
 design -load dsp_simd
 select simd_mult_explicit_params
 select *
-synth_quicklogic -family qlf_k6n10f -top simd_mult_explicit_params -use_dsp_cfg_params
+synth_quicklogic_f4pga -family qlf_k6n10f -top simd_mult_explicit_params -use_dsp_cfg_params
 opt_expr -undriven
 opt_clean
 stat

--- a/ql-qlf-plugin/tests/shreg/shreg.tcl
+++ b/ql-qlf-plugin/tests/shreg/shreg.tcl
@@ -3,14 +3,14 @@ if { [info procs quicklogic_eqn] == {} } { plugin -i ql-qlf }
 yosys -import ;# ingest plugin commands
 
 read_verilog $::env(DESIGN_TOP).v
-synth_quicklogic -family qlf_k4n8 -top top
+synth_quicklogic_f4pga -family qlf_k4n8 -top top
 stat
 select -assert-count 8 t:sh_dff
 
 design -reset
 
 read_verilog $::env(DESIGN_TOP).v
-synth_quicklogic -family qlf_k6n10f -top top
+synth_quicklogic_f4pga -family qlf_k6n10f -top top
 stat
 select -assert-count 8 t:sh_dff
 

--- a/ql-qlf-plugin/tests/tribuf/tribuf.tcl
+++ b/ql-qlf-plugin/tests/tribuf/tribuf.tcl
@@ -9,7 +9,7 @@ yosys proc
 tribuf
 flatten
 synth
-equiv_opt -assert -map +/quicklogic/pp3/cells_sim.v -map +/simcells.v synth_quicklogic -family pp3
+equiv_opt -assert -map +/quicklogic_f4pga/pp3/cells_sim.v -map +/simcells.v synth_quicklogic_f4pga -family pp3
 design -load postopt
 yosys cd tristate
 select -assert-count 2 t:inpad


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/yosys-f4pga-plugins/issues/496
Separated from https://github.com/chipsalliance/yosys-f4pga-plugins/pull/485

CI passing on my fork:
<img width="431" alt="Screenshot 2023-09-04 at 12 58 36" src="https://github.com/chipsalliance/yosys-f4pga-plugins/assets/3105306/b363e0d3-2620-436d-8ca0-8a8889562b62">
