### PR TITLE
Upgrade GitHub actions with deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: Install
       run: |
@@ -85,7 +85,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
        fetch-depth: 0
        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -25,7 +25,7 @@ jobs:
   Checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: SymbiFlow/actions/checks@main
       with:


### PR DESCRIPTION
extracted from https://github.com/chipsalliance/yosys-f4pga-plugins/pull/485

CI passing on my fork:
<img width="629" alt="Screenshot 2023-09-04 at 13 10 50" src="https://github.com/chipsalliance/yosys-f4pga-plugins/assets/3105306/79dd06cc-a29d-4870-934d-a8bd5b7333fb">
