### PR TITLE
Adding missing tcl.h includes

### DIFF
--- a/design_introspection-plugin/get_cmd.cc
+++ b/design_introspection-plugin/get_cmd.cc
@@ -1,4 +1,5 @@
 #include "get_cmd.h"
+#include <tcl.h>
 
 USING_YOSYS_NAMESPACE
 

--- a/design_introspection-plugin/get_count.cc
+++ b/design_introspection-plugin/get_count.cc
@@ -20,6 +20,7 @@
 #include "get_count.h"
 
 #include "kernel/rtlil.h"
+#include <tcl.h>
 
 USING_YOSYS_NAMESPACE
 

--- a/design_introspection-plugin/selection_to_tcl_list.h
+++ b/design_introspection-plugin/selection_to_tcl_list.h
@@ -19,6 +19,7 @@
 #define _SELECTION_TO_TCL_LIST_H_
 
 #include "kernel/register.h"
+#include <tcl.h>
 
 USING_YOSYS_NAMESPACE
 

--- a/params-plugin/params.cc
+++ b/params-plugin/params.cc
@@ -18,6 +18,7 @@
 #include "kernel/log.h"
 #include "kernel/register.h"
 #include "kernel/rtlil.h"
+#include <tcl.h>
 
 USING_YOSYS_NAMESPACE
 

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <tcl.h>
 
 #include "clocks.h"
 #include "kernel/log.h"


### PR DESCRIPTION
This PR fixes 

```
:5: error: ‘Tcl_Obj’ was not declared in this scope
   50 |     Tcl_Obj *tcl_result;
      |     ^~~~~~~
```

type errors on Ubuntu 24.04. Let me know if are any regression tests I should run or anything, but this fixes the build of ```fasm params sdc design_introspection``` for me. Thanks!